### PR TITLE
Fix stale queued goal continuation handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,11 @@ interface QueuedGoalMessageDetails {
   goalId?: unknown;
 }
 
+interface TextMessagePart {
+  type?: unknown;
+  text?: unknown;
+}
+
 function usageChannelTokens(value: number): number {
   if (!Number.isFinite(value)) {
     return 0;
@@ -57,15 +62,43 @@ function isQueuedGoalMessageDetails(details: unknown): details is QueuedGoalMess
   return details !== null && typeof details === "object";
 }
 
+function textContentFromMessageContent(content: unknown): string | null {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const textParts: string[] = [];
+  for (const part of content) {
+    if (part === null || typeof part !== "object") {
+      continue;
+    }
+    const textPart = part as TextMessagePart;
+    if (textPart.type === "text" && typeof textPart.text === "string") {
+      textParts.push(textPart.text);
+    }
+  }
+
+  return textParts.length > 0 ? textParts.join("\n") : null;
+}
+
+function continuationGoalIdFromMessageContent(content: unknown): string | null {
+  const text = textContentFromMessageContent(content);
+  return text === null ? null : continuationGoalIdFromPrompt(text);
+}
+
 function staleGoalContinuationMessage(queuedGoalId: string, currentGoal: ThreadGoal | null): string {
   const currentState = currentGoal
     ? `Current goal id: ${currentGoal.goalId}; current status: ${currentGoal.status}.`
     : "There is no current goal.";
   return [
-    "A queued hidden goal continuation is stale because the referenced goal is no longer active.",
+    "A queued hidden goal continuation was stale and has been cancelled before running.",
     `Queued goal id: ${queuedGoalId}.`,
     currentState,
-    "Do not perform task work. Do not call tools. Reply briefly that the queued goal continuation is no longer active.",
+    "Ignore only this stale hidden bookkeeping message; do not perform work for the queued goal id above or mention this cancellation to the user.",
   ].join("\n");
 }
 
@@ -75,6 +108,10 @@ function queuedGoalWorkMessageId(message: {
   details?: unknown;
   content?: unknown;
 }): string | null {
+  if (message.role === "user") {
+    return continuationGoalIdFromMessageContent(message.content);
+  }
+
   if (message.role !== "custom" || message.customType !== CUSTOM_ENTRY_TYPE) {
     return null;
   }
@@ -86,11 +123,34 @@ function queuedGoalWorkMessageId(message: {
     }
   }
 
-  if (typeof message.content === "string") {
-    return continuationGoalIdFromPrompt(message.content);
+  return continuationGoalIdFromMessageContent(message.content);
+}
+
+function staleGoalContinuationContextMessage<TMessage extends { role: string; content?: unknown }>(
+  message: TMessage,
+  queuedGoalId: string,
+  currentGoal: ThreadGoal | null,
+): TMessage {
+  const content = staleGoalContinuationMessage(queuedGoalId, currentGoal);
+
+  if (message.role === "custom") {
+    return {
+      ...message,
+      content,
+      display: false,
+      details: {
+        kind: "stale_continuation",
+        goalId: queuedGoalId,
+        currentGoalId: currentGoal?.goalId ?? null,
+        currentStatus: currentGoal?.status ?? null,
+      },
+    } as TMessage;
   }
 
-  return null;
+  return {
+    ...message,
+    content: [{ type: "text", text: content }],
+  } as TMessage;
 }
 
 const CONTINUATION_RETRY_MS = 50;
@@ -102,6 +162,9 @@ export default function (pi: ExtensionAPI): void {
   let continuationTimer: ReturnType<typeof setTimeout> | null = null;
   let statusContext: StatusContext | null = null;
   let statusRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  let staleQueuedGoalWorkTurnActive = false;
+  let startedStaleQueuedGoalWorkThisTurn = false;
+  let startedRunnableWorkThisTurn = false;
   const accounting: AccountingState = {
     activeGoalId: null,
     lastAccountedAt: null,
@@ -129,6 +192,28 @@ export default function (pi: ExtensionAPI): void {
   const clearContinuationState = (): void => {
     clearContinuationTimer();
     continuationQueuedFor = null;
+  };
+
+  const clearContinuationStateFor = (goalId: string): void => {
+    if (continuationQueuedFor === goalId) {
+      continuationQueuedFor = null;
+    }
+    if (continuationScheduledFor === goalId) {
+      clearContinuationTimer();
+    }
+  };
+
+  const isCurrentActiveGoalId = (goalId: string): boolean => {
+    return goal?.goalId === goalId && goal.status === "active";
+  };
+
+  const clearStaleQueuedGoalWorkTurn = (): void => {
+    staleQueuedGoalWorkTurnActive = false;
+  };
+
+  const clearStartedTurnWork = (): void => {
+    startedStaleQueuedGoalWorkThisTurn = false;
+    startedRunnableWorkThisTurn = false;
   };
 
   const clearActiveAccounting = (): void => {
@@ -357,7 +442,23 @@ export default function (pi: ExtensionAPI): void {
     },
   });
 
-  pi.on("context", async (event): Promise<{ messages: typeof event.messages } | undefined> => {
+  pi.on("input", async (event, ctx) => {
+    const continuationGoalId = continuationGoalIdFromPrompt(event.text);
+    if (continuationGoalId === null) {
+      return undefined;
+    }
+
+    clearStaleQueuedGoalWorkTurn();
+    clearContinuationStateFor(continuationGoalId);
+    if (isCurrentActiveGoalId(continuationGoalId)) {
+      return { action: "continue" } as const;
+    }
+
+    refreshUi(ctx);
+    return { action: "handled" } as const;
+  });
+
+  pi.on("context", async (event, ctx): Promise<{ messages: typeof event.messages } | undefined> => {
     let changed = false;
     const messages: typeof event.messages = event.messages.map((message) => {
       const queuedGoalId = queuedGoalWorkMessageId(message);
@@ -366,18 +467,15 @@ export default function (pi: ExtensionAPI): void {
       }
 
       changed = true;
-      return {
-        ...message,
-        content: staleGoalContinuationMessage(queuedGoalId, goal),
-        display: false,
-        details: {
-          kind: "stale_continuation",
-          goalId: queuedGoalId,
-          currentGoalId: goal?.goalId ?? null,
-          currentStatus: goal?.status ?? null,
-        },
-      } as typeof message;
+      return staleGoalContinuationContextMessage(message, queuedGoalId, goal);
     });
+
+    if (startedStaleQueuedGoalWorkThisTurn && !startedRunnableWorkThisTurn) {
+      staleQueuedGoalWorkTurnActive = true;
+      clearActiveAccounting();
+      ctx.abort();
+      refreshUi(ctx);
+    }
 
     return changed ? { messages } : undefined;
   });
@@ -404,35 +502,63 @@ export default function (pi: ExtensionAPI): void {
   pi.on("before_agent_start", async (_event, ctx) => {
     const continuationGoalId = continuationGoalIdFromPrompt(_event.prompt);
     if (continuationGoalId !== null) {
-      continuationQueuedFor = null;
-      clearContinuationTimer();
-      if (!goal || goal.goalId !== continuationGoalId || goal.status !== "active") {
-        ctx.abort();
+      clearContinuationStateFor(continuationGoalId);
+      if (!isCurrentActiveGoalId(continuationGoalId)) {
         refreshUi(ctx);
-        return {
-          systemPrompt: [
-            _event.systemPrompt,
-            "",
-            staleGoalContinuationMessage(continuationGoalId, goal),
-          ].join("\n"),
-        };
+        return undefined;
       }
+      clearStaleQueuedGoalWorkTurn();
     } else {
+      clearStaleQueuedGoalWorkTurn();
       clearContinuationState();
     }
   });
 
+  pi.on("message_start", async (event) => {
+    const queuedGoalId = queuedGoalWorkMessageId(event.message);
+    if (queuedGoalId === null) {
+      if (event.message.role === "user" || event.message.role === "custom") {
+        startedRunnableWorkThisTurn = true;
+        clearContinuationState();
+      }
+      return;
+    }
+
+    clearContinuationStateFor(queuedGoalId);
+    if (isCurrentActiveGoalId(queuedGoalId)) {
+      startedRunnableWorkThisTurn = true;
+      return;
+    }
+
+    startedStaleQueuedGoalWorkThisTurn = true;
+  });
+
   pi.on("turn_start", async (_event, ctx) => {
-    clearContinuationState();
+    clearStartedTurnWork();
+    if (staleQueuedGoalWorkTurnActive) {
+      refreshUi(ctx);
+      return;
+    }
+
     beginAccounting();
     refreshUi(ctx);
   });
 
   pi.on("tool_execution_end", async (_event, ctx) => {
+    if (staleQueuedGoalWorkTurnActive) {
+      refreshUi(ctx);
+      return;
+    }
+
     accountProgress(ctx, true, 0, true);
   });
 
   pi.on("turn_end", async (_event, ctx) => {
+    if (staleQueuedGoalWorkTurnActive) {
+      refreshUi(ctx);
+      return;
+    }
+
     const completedTurnTokens = assistantTurnTokens(_event.message);
     accountProgress(ctx, true, completedTurnTokens);
     if (isAbortedAssistantMessage(_event.message)) {
@@ -445,6 +571,12 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("agent_end", async (event, ctx) => {
+    if (staleQueuedGoalWorkTurnActive) {
+      clearStaleQueuedGoalWorkTurn();
+      refreshUi(ctx);
+      return;
+    }
+
     const abortedMessages = event.messages.filter(isAbortedAssistantMessage);
     const abortedTurnTokens = abortedMessages.reduce((sum, message) => {
       return sum + assistantTurnTokens(message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,9 +162,17 @@ export default function (pi: ExtensionAPI): void {
   let continuationTimer: ReturnType<typeof setTimeout> | null = null;
   let statusContext: StatusContext | null = null;
   let statusRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  let currentTurnIndex: number | null = null;
+  // Do not rely on agent_end after ctx.abort(): pi's normal prompt loop ends there,
+  // but compaction/shutdown and later queued turns can cross this stale cleanup boundary.
   let staleQueuedGoalWorkTurnActive = false;
+  let staleQueuedGoalWorkActiveTurnIndex: number | null = null;
+  const staleQueuedGoalWorkTurnEndSkipIndexes = new Set<number>();
+  const staleQueuedGoalWorkAgentEndGoalIds = new Set<string>();
+  let passthroughContinuationInput: { text: string; turnIndex: number | null } | null = null;
   let startedStaleQueuedGoalWorkThisTurn = false;
   let startedRunnableWorkThisTurn = false;
+  const startedStaleQueuedGoalWorkGoalIds = new Set<string>();
   const accounting: AccountingState = {
     activeGoalId: null,
     lastAccountedAt: null,
@@ -207,18 +215,59 @@ export default function (pi: ExtensionAPI): void {
     return goal?.goalId === goalId && goal.status === "active";
   };
 
-  const clearStaleQueuedGoalWorkTurn = (): void => {
-    staleQueuedGoalWorkTurnActive = false;
-  };
-
   const clearStartedTurnWork = (): void => {
     startedStaleQueuedGoalWorkThisTurn = false;
     startedRunnableWorkThisTurn = false;
+    startedStaleQueuedGoalWorkGoalIds.clear();
   };
 
   const clearActiveAccounting = (): void => {
     accounting.activeGoalId = null;
     accounting.lastAccountedAt = null;
+  };
+
+  const noteStaleQueuedGoalWorkTerminalEvents = (): void => {
+    if (currentTurnIndex !== null) {
+      staleQueuedGoalWorkActiveTurnIndex = currentTurnIndex;
+      staleQueuedGoalWorkTurnEndSkipIndexes.add(currentTurnIndex);
+    }
+    for (const goalId of startedStaleQueuedGoalWorkGoalIds) {
+      staleQueuedGoalWorkAgentEndGoalIds.add(goalId);
+    }
+  };
+
+  const clearStaleQueuedGoalWorkTerminalEvents = (): void => {
+    staleQueuedGoalWorkTurnEndSkipIndexes.clear();
+    staleQueuedGoalWorkAgentEndGoalIds.clear();
+    staleQueuedGoalWorkActiveTurnIndex = null;
+  };
+
+  const clearStaleQueuedGoalWorkTurn = (): boolean => {
+    if (!staleQueuedGoalWorkTurnActive) {
+      return false;
+    }
+    staleQueuedGoalWorkTurnActive = false;
+    staleQueuedGoalWorkActiveTurnIndex = null;
+    clearActiveAccounting();
+    return true;
+  };
+
+  const skipStaleQueuedGoalWorkLifecycle = (ctx: StatusContext): boolean => {
+    if (!staleQueuedGoalWorkTurnActive) {
+      return false;
+    }
+    clearActiveAccounting();
+    refreshUi(ctx);
+    return true;
+  };
+
+  const finishStaleQueuedGoalWorkLifecycle = (ctx: StatusContext): boolean => {
+    if (!clearStaleQueuedGoalWorkTurn()) {
+      return false;
+    }
+    clearStaleQueuedGoalWorkTerminalEvents();
+    refreshUi(ctx);
+    return true;
   };
 
   const clearStoppedRuntimeState = (): void => {
@@ -248,6 +297,116 @@ export default function (pi: ExtensionAPI): void {
     statusContext = ctx;
     ctx.ui.setStatus("codex-goal", formatFooterStatus(goalForDisplay()));
     syncStatusRefresh();
+  };
+
+  const clearPassthroughContinuationInput = (): void => {
+    passthroughContinuationInput = null;
+  };
+
+  const bindPassthroughContinuationInputToTurn = (turnIndex: number): void => {
+    if (!passthroughContinuationInput) {
+      return;
+    }
+    if (passthroughContinuationInput.turnIndex === null) {
+      passthroughContinuationInput = { ...passthroughContinuationInput, turnIndex };
+      return;
+    }
+    if (passthroughContinuationInput.turnIndex !== turnIndex) {
+      clearPassthroughContinuationInput();
+    }
+  };
+
+  const isPassthroughContinuationInput = (text: string): boolean => {
+    if (!passthroughContinuationInput || passthroughContinuationInput.text !== text) {
+      return false;
+    }
+    return passthroughContinuationInput.turnIndex === null || passthroughContinuationInput.turnIndex === currentTurnIndex;
+  };
+
+  const continuationGoalIdFromRuntimePrompt = (prompt: string): string | null => {
+    if (isPassthroughContinuationInput(prompt)) {
+      return null;
+    }
+    return continuationGoalIdFromPrompt(prompt);
+  };
+
+  const queuedGoalWorkMessageIdForRuntime = (message: {
+    role: string;
+    customType?: string;
+    details?: unknown;
+    content?: unknown;
+  }): string | null => {
+    if (message.role === "user") {
+      const text = textContentFromMessageContent(message.content);
+      return text === null ? null : continuationGoalIdFromRuntimePrompt(text);
+    }
+
+    return queuedGoalWorkMessageId(message);
+  };
+
+  const pendingStaleQueuedGoalWorkIdsFromMessages = (
+    messages: Array<{ role: string; customType?: string; details?: unknown; content?: unknown }>,
+  ): string[] => {
+    const goalIds: string[] = [];
+    for (const message of messages) {
+      const queuedGoalId = queuedGoalWorkMessageId(message);
+      if (queuedGoalId !== null && staleQueuedGoalWorkAgentEndGoalIds.has(queuedGoalId)) {
+        goalIds.push(queuedGoalId);
+      }
+    }
+    return goalIds;
+  };
+
+  const skipStaleQueuedGoalWorkTurnEnd = (
+    turnIndex: number | null,
+    message: { role: string; stopReason?: string },
+    ctx: StatusContext,
+  ): boolean => {
+    const isActiveStaleTurn =
+      staleQueuedGoalWorkTurnActive &&
+      turnIndex !== null &&
+      staleQueuedGoalWorkActiveTurnIndex === turnIndex;
+    const isPendingStaleTurnEnd =
+      turnIndex !== null &&
+      isAbortedAssistantMessage(message) &&
+      staleQueuedGoalWorkTurnEndSkipIndexes.has(turnIndex);
+
+    if (!isActiveStaleTurn && !isPendingStaleTurnEnd) {
+      return false;
+    }
+
+    if (turnIndex !== null) {
+      staleQueuedGoalWorkTurnEndSkipIndexes.delete(turnIndex);
+    }
+    if (isActiveStaleTurn) {
+      clearActiveAccounting();
+    }
+    refreshUi(ctx);
+    return true;
+  };
+
+  const skipStaleQueuedGoalWorkAgentEnd = (
+    messages: Array<{ role: string; customType?: string; details?: unknown; content?: unknown; stopReason?: string }>,
+    ctx: StatusContext,
+  ): boolean => {
+    if (finishStaleQueuedGoalWorkLifecycle(ctx)) {
+      return true;
+    }
+
+    if (!messages.some(isAbortedAssistantMessage)) {
+      return false;
+    }
+
+    const staleGoalIds = pendingStaleQueuedGoalWorkIdsFromMessages(messages);
+    if (staleGoalIds.length === 0) {
+      return false;
+    }
+
+    for (const goalId of staleGoalIds) {
+      staleQueuedGoalWorkAgentEndGoalIds.delete(goalId);
+    }
+    refreshUi(ctx);
+    return true;
   };
 
   const persistGoal = (nextGoal: ThreadGoal, source: GoalEntrySource): void => {
@@ -392,7 +551,7 @@ export default function (pi: ExtensionAPI): void {
   };
 
   const maybeContinue = (ctx: ExtensionContext): void => {
-    if (!goal || goal.status !== "active" || continuationQueuedFor === goal.goalId) {
+    if (staleQueuedGoalWorkTurnActive || !goal || goal.status !== "active" || continuationQueuedFor === goal.goalId) {
       return;
     }
 
@@ -443,7 +602,19 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("input", async (event, ctx) => {
+    clearPassthroughContinuationInput();
     const continuationGoalId = continuationGoalIdFromPrompt(event.text);
+
+    if (event.source !== "extension") {
+      if (clearStaleQueuedGoalWorkTurn()) {
+        refreshUi(ctx);
+      }
+      if (continuationGoalId !== null) {
+        passthroughContinuationInput = { text: event.text, turnIndex: null };
+      }
+      return undefined;
+    }
+
     if (continuationGoalId === null) {
       return undefined;
     }
@@ -461,7 +632,7 @@ export default function (pi: ExtensionAPI): void {
   pi.on("context", async (event, ctx): Promise<{ messages: typeof event.messages } | undefined> => {
     let changed = false;
     const messages: typeof event.messages = event.messages.map((message) => {
-      const queuedGoalId = queuedGoalWorkMessageId(message);
+      const queuedGoalId = queuedGoalWorkMessageIdForRuntime(message);
       if (queuedGoalId === null || (goal?.goalId === queuedGoalId && goal.status === "active")) {
         return message;
       }
@@ -471,6 +642,9 @@ export default function (pi: ExtensionAPI): void {
     });
 
     if (startedStaleQueuedGoalWorkThisTurn && !startedRunnableWorkThisTurn) {
+      if (!staleQueuedGoalWorkTurnActive) {
+        noteStaleQueuedGoalWorkTerminalEvents();
+      }
       staleQueuedGoalWorkTurnActive = true;
       clearActiveAccounting();
       ctx.abort();
@@ -500,7 +674,7 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("before_agent_start", async (_event, ctx) => {
-    const continuationGoalId = continuationGoalIdFromPrompt(_event.prompt);
+    const continuationGoalId = continuationGoalIdFromRuntimePrompt(_event.prompt);
     if (continuationGoalId !== null) {
       clearContinuationStateFor(continuationGoalId);
       if (!isCurrentActiveGoalId(continuationGoalId)) {
@@ -515,7 +689,7 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("message_start", async (event) => {
-    const queuedGoalId = queuedGoalWorkMessageId(event.message);
+    const queuedGoalId = queuedGoalWorkMessageIdForRuntime(event.message);
     if (queuedGoalId === null) {
       if (event.message.role === "user" || event.message.role === "custom") {
         startedRunnableWorkThisTurn = true;
@@ -531,22 +705,20 @@ export default function (pi: ExtensionAPI): void {
     }
 
     startedStaleQueuedGoalWorkThisTurn = true;
+    startedStaleQueuedGoalWorkGoalIds.add(queuedGoalId);
   });
 
   pi.on("turn_start", async (_event, ctx) => {
+    currentTurnIndex = _event.turnIndex;
+    bindPassthroughContinuationInputToTurn(_event.turnIndex);
     clearStartedTurnWork();
-    if (staleQueuedGoalWorkTurnActive) {
-      refreshUi(ctx);
-      return;
-    }
-
+    clearStaleQueuedGoalWorkTurn();
     beginAccounting();
     refreshUi(ctx);
   });
 
   pi.on("tool_execution_end", async (_event, ctx) => {
-    if (staleQueuedGoalWorkTurnActive) {
-      refreshUi(ctx);
+    if (skipStaleQueuedGoalWorkLifecycle(ctx)) {
       return;
     }
 
@@ -554,8 +726,7 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("turn_end", async (_event, ctx) => {
-    if (staleQueuedGoalWorkTurnActive) {
-      refreshUi(ctx);
+    if (skipStaleQueuedGoalWorkTurnEnd(_event.turnIndex, _event.message, ctx)) {
       return;
     }
 
@@ -571,9 +742,8 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("agent_end", async (event, ctx) => {
-    if (staleQueuedGoalWorkTurnActive) {
-      clearStaleQueuedGoalWorkTurn();
-      refreshUi(ctx);
+    clearPassthroughContinuationInput();
+    if (skipStaleQueuedGoalWorkAgentEnd(event.messages, ctx)) {
       return;
     }
 
@@ -590,10 +760,18 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("session_before_compact", async (_event, ctx) => {
+    if (skipStaleQueuedGoalWorkLifecycle(ctx)) {
+      return;
+    }
+
     accountProgress(ctx, false, 0, true);
   });
 
   pi.on("session_compact", async (_event, ctx) => {
+    if (skipStaleQueuedGoalWorkLifecycle(ctx)) {
+      return;
+    }
+
     if (goal) {
       persistGoal(goal, "runtime");
     }
@@ -602,6 +780,16 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {
+    clearPassthroughContinuationInput();
+    if (staleQueuedGoalWorkTurnActive) {
+      clearStaleQueuedGoalWorkTurn();
+      clearStaleQueuedGoalWorkTerminalEvents();
+      clearContinuationTimer();
+      stopStatusRefresh();
+      return;
+    }
+    clearStaleQueuedGoalWorkTerminalEvents();
+
     accountProgress(ctx, false, 0, true);
     clearContinuationTimer();
     stopStatusRefresh();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -551,6 +551,74 @@ test("stale prompt continuation input is handled before agent start", async () =
   assert.equal(harness.abortCount, 0);
 });
 
+for (const source of ["interactive", "rpc"] as const) {
+  test(`pasted continuation marker input from ${source} is not swallowed`, async () => {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const queued = harness.sentMessages[0];
+    assert.ok(queued);
+    const prompt = queued.message.content;
+    if (typeof prompt !== "string") {
+      assert.fail("Expected queued goal message content to be a string.");
+    }
+
+    await harness.runTool("update_goal", { status: "complete" });
+    const inputResults = await harness.emit("input", {
+      type: "input",
+      text: prompt,
+      source,
+    });
+    assert.equal(inputResults[0], undefined);
+
+    const beforeAgentStartResults = await harness.emit("before_agent_start", {
+      type: "before_agent_start",
+      prompt,
+      systemPrompt: "base prompt",
+      systemPromptOptions: {},
+    });
+    assert.equal(beforeAgentStartResults[0], undefined);
+
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: prompt }],
+      timestamp: 1,
+    };
+    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+    await harness.emit("message_start", { type: "message_start", message: userMessage });
+    await harness.emit("message_end", { type: "message_end", message: userMessage });
+    const contextResults = await harness.emit("context", {
+      type: "context",
+      messages: [userMessage],
+    });
+    const secondContextResults = await harness.emit("context", {
+      type: "context",
+      messages: [userMessage],
+    });
+
+    assert.equal(contextResults[0], undefined);
+    assert.equal(secondContextResults[0], undefined);
+    assert.equal(harness.snapshot().goal?.status, "complete");
+    assert.equal(harness.abortCount, 0);
+
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("stop", { input: 1, output: 1 }),
+      toolResults: [],
+    });
+
+    const laterUserMessage = {
+      role: "user",
+      content: [{ type: "text", text: prompt }],
+      timestamp: 2,
+    };
+    const laterContextResults = await emitQueuedTurnThroughContext(harness, [laterUserMessage], 1);
+    const laterContextResult = laterContextResults[0] as { messages?: Array<{ content?: unknown }> } | undefined;
+    assert.notEqual(laterContextResult, undefined);
+    assert.equal(harness.abortCount, 1);
+  });
+}
+
 test("stale queued continuation aborts if the goal became complete before launch", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");
@@ -807,6 +875,257 @@ test("stale custom queued work aborts without pausing, charging, or requeueing a
     assert.equal(goal?.usage.tokensUsed, 0);
     assert.equal(goal?.usage.activeSeconds, 0);
     assert.equal(harness.sentMessages.length, 0);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("stale custom abort without agent_end does not suppress the next current follow-up", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("old goal");
+    const oldQueued = harness.sentMessages[0];
+    assert.ok(oldQueued);
+    const oldMessage = queuedCustomMessage(oldQueued, 1);
+
+    await harness.runCommand("new goal");
+    const currentQueued = harness.sentMessages.at(-1);
+    assert.ok(currentQueued);
+    const currentMessage = queuedCustomMessage(currentQueued, 2);
+    const replacement = harness.snapshot().goal;
+    assert.equal(replacement?.objective, "new goal");
+    harness.sentMessages.length = 0;
+
+    await emitQueuedTurnThroughContext(harness, [oldMessage], 0);
+    assert.equal(harness.abortCount, 1);
+
+    now = 2_000;
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("aborted", { input: 20, output: 5 }),
+      toolResults: [],
+    });
+    assert.equal(harness.snapshot().goal?.usage.tokensUsed, 0);
+    assert.equal(harness.sentMessages.length, 0);
+
+    now = 3_000;
+    await emitQueuedTurnThroughContext(harness, [currentMessage], 1);
+    now = 5_000;
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 1,
+      message: assistantMessage("stop", { input: 30, output: 12 }),
+      toolResults: [],
+    });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.goalId, replacement?.goalId);
+    assert.equal(goal?.status, "active");
+    assert.equal(goal?.usage.tokensUsed, 42);
+    assert.equal(goal?.usage.activeSeconds, 2);
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "continuation",
+      goalId: replacement?.goalId,
+    });
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("late stale turn_end after the next current follow-up starts is ignored", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("old goal");
+    const oldQueued = harness.sentMessages[0];
+    assert.ok(oldQueued);
+    const oldMessage = queuedCustomMessage(oldQueued, 1);
+
+    await harness.runCommand("new goal");
+    const currentQueued = harness.sentMessages.at(-1);
+    assert.ok(currentQueued);
+    const currentMessage = queuedCustomMessage(currentQueued, 2);
+    const replacement = harness.snapshot().goal;
+    assert.equal(replacement?.objective, "new goal");
+    harness.sentMessages.length = 0;
+
+    await emitQueuedTurnThroughContext(harness, [oldMessage], 0);
+    assert.equal(harness.abortCount, 1);
+
+    now = 3_000;
+    await emitQueuedTurnThroughContext(harness, [currentMessage], 1);
+
+    now = 4_000;
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("aborted", { input: 20, output: 5 }),
+      toolResults: [],
+    });
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.equal(harness.snapshot().goal?.usage.tokensUsed, 0);
+    assert.equal(harness.sentMessages.length, 0);
+
+    now = 5_000;
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 1,
+      message: assistantMessage("stop", { input: 30, output: 12 }),
+      toolResults: [],
+    });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.goalId, replacement?.goalId);
+    assert.equal(goal?.status, "active");
+    assert.equal(goal?.usage.tokensUsed, 42);
+    assert.equal(goal?.usage.activeSeconds, 2);
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "continuation",
+      goalId: replacement?.goalId,
+    });
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("current follow-up abort is not swallowed by a pending late stale turn_end", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("old goal");
+    const oldQueued = harness.sentMessages[0];
+    assert.ok(oldQueued);
+    const oldMessage = queuedCustomMessage(oldQueued, 1);
+
+    await harness.runCommand("new goal");
+    const currentQueued = harness.sentMessages.at(-1);
+    assert.ok(currentQueued);
+    const currentMessage = queuedCustomMessage(currentQueued, 2);
+    const replacement = harness.snapshot().goal;
+    assert.equal(replacement?.objective, "new goal");
+    harness.sentMessages.length = 0;
+
+    await emitQueuedTurnThroughContext(harness, [oldMessage], 0);
+    assert.equal(harness.abortCount, 1);
+
+    now = 3_000;
+    await emitQueuedTurnThroughContext(harness, [currentMessage], 1);
+    now = 5_000;
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 1,
+      message: assistantMessage("aborted", { input: 30, output: 12 }),
+      toolResults: [],
+    });
+
+    let goal = harness.snapshot().goal;
+    assert.equal(goal?.goalId, replacement?.goalId);
+    assert.equal(goal?.status, "paused");
+    assert.equal(goal?.usage.tokensUsed, 42);
+    assert.equal(goal?.usage.activeSeconds, 2);
+    assert.equal(harness.sentMessages.length, 0);
+
+    now = 6_000;
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("aborted", { input: 20, output: 5 }),
+      toolResults: [],
+    });
+
+    goal = harness.snapshot().goal;
+    assert.equal(goal?.goalId, replacement?.goalId);
+    assert.equal(goal?.status, "paused");
+    assert.equal(goal?.usage.tokensUsed, 42);
+    assert.equal(goal?.usage.activeSeconds, 2);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("compaction between stale context abort and cleanup does not persist, account, or requeue", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("old goal");
+    const oldQueued = harness.sentMessages[0];
+    assert.ok(oldQueued);
+    const oldMessage = queuedCustomMessage(oldQueued, 1);
+
+    await harness.runCommand("clear");
+    await harness.runTool("create_goal", { objective: "new goal" });
+    const replacement = harness.snapshot().goal;
+    assert.equal(replacement?.objective, "new goal");
+    const entryCountBeforeCompaction = harness.entries.length;
+    harness.sentMessages.length = 0;
+
+    await emitQueuedTurnThroughContext(harness, [oldMessage], 0);
+    assert.equal(harness.abortCount, 1);
+
+    now = 5_000;
+    await harness.emit("session_before_compact", {
+      type: "session_before_compact",
+      preparation: {},
+      branchEntries: [],
+      signal: new AbortController().signal,
+    });
+    await harness.emit("session_compact", {
+      type: "session_compact",
+      compactionEntry: {},
+      fromExtension: false,
+    });
+
+    assert.equal(harness.entries.length, entryCountBeforeCompaction);
+    assert.equal(harness.sentMessages.length, 0);
+    assert.equal(harness.snapshot().goal?.usage.tokensUsed, 0);
+    assert.equal(harness.snapshot().goal?.usage.activeSeconds, 0);
+
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("aborted", { input: 20, output: 5 }),
+      toolResults: [],
+    });
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.equal(harness.snapshot().goal?.usage.tokensUsed, 0);
+
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: "continue now" }],
+      timestamp: 2,
+    };
+    now = 6_000;
+    await emitQueuedTurnThroughContext(harness, [userMessage], 1);
+    now = 8_000;
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 1,
+      message: assistantMessage("stop", { input: 7, output: 3 }),
+      toolResults: [],
+    });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.goalId, replacement?.goalId);
+    assert.equal(goal?.status, "active");
+    assert.equal(goal?.usage.tokensUsed, 10);
+    assert.equal(goal?.usage.activeSeconds, 2);
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "continuation",
+      goalId: replacement?.goalId,
+    });
   } finally {
     Date.now = originalNow;
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -211,6 +211,32 @@ function waitForContinuationRetry(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 75));
 }
 
+function queuedCustomMessage(sent: SentMessage, timestamp = 1) {
+  return {
+    role: "custom",
+    customType: sent.message.customType,
+    content: sent.message.content,
+    display: sent.message.display,
+    details: sent.message.details,
+    timestamp,
+  };
+}
+
+type RuntimeHarness = ReturnType<typeof createRuntimeHarness>;
+
+async function emitQueuedTurnThroughContext(
+  harness: RuntimeHarness,
+  messages: Array<Record<string, unknown>>,
+  turnIndex = 0,
+): Promise<unknown[]> {
+  await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
+  for (const message of messages) {
+    await harness.emit("message_start", { type: "message_start", message });
+    await harness.emit("message_end", { type: "message_end", message });
+  }
+  return harness.emit("context", { type: "context", messages });
+}
+
 function assistantMessage(stopReason: "stop" | "aborted" | "length" | "toolUse", usage: TestAssistantUsage) {
   const cacheRead = usage.cacheRead ?? 0;
   const cacheWrite = usage.cacheWrite ?? 0;
@@ -312,9 +338,16 @@ test("session resume prompt can reactivate a paused goal", async () => {
 test("completed turns count input plus output and continue active goals", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const queuedMessage = queuedCustomMessage(queued);
   harness.sentMessages.length = 0;
 
   await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: queuedMessage,
+  });
   await harness.emit("turn_end", {
     type: "turn_end",
     turnIndex: 0,
@@ -437,9 +470,16 @@ test("goal tools return Codex-shaped response details", async () => {
 test("agent end waits for idle before continuing active goals", async () => {
   const harness = createRuntimeHarness({ idle: false, pendingMessages: true });
   await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const queuedMessage = queuedCustomMessage(queued);
   harness.sentMessages.length = 0;
 
   await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: queuedMessage,
+  });
   await harness.emit("agent_end", {
     type: "agent_end",
     messages: [assistantMessage("stop", { input: 30, output: 12 })],
@@ -489,6 +529,28 @@ test("completing a goal cancels a scheduled continuation before it is sent", asy
   assert.equal(harness.sentMessages.length, 0);
 });
 
+test("stale prompt continuation input is handled before agent start", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const prompt = queued.message.content;
+  if (typeof prompt !== "string") {
+    assert.fail("Expected queued goal message content to be a string.");
+  }
+
+  await harness.runTool("update_goal", { status: "complete" });
+  const results = await harness.emit("input", {
+    type: "input",
+    text: prompt,
+    source: "extension",
+  });
+
+  assert.deepEqual(results[0], { action: "handled" });
+  assert.equal(harness.snapshot().goal?.status, "complete");
+  assert.equal(harness.abortCount, 0);
+});
+
 test("stale queued continuation aborts if the goal became complete before launch", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");
@@ -507,10 +569,30 @@ test("stale queued continuation aborts if the goal became complete before launch
     systemPromptOptions: {},
   });
 
-  const result = results[0] as { systemPrompt?: string } | undefined;
+  assert.equal(results[0], undefined);
+  assert.equal(harness.abortCount, 0);
+
+  const queuedMessage = {
+    role: "user",
+    content: [{ type: "text", text: prompt }],
+    timestamp: 1,
+  };
+  const contextResults = await emitQueuedTurnThroughContext(harness, [queuedMessage]);
+  const contextResult = contextResults[0] as { messages?: Array<{ content?: unknown }> } | undefined;
+  assert.deepEqual(contextResult?.messages?.[0]?.content, [
+    {
+      type: "text",
+      text: [
+        "A queued hidden goal continuation was stale and has been cancelled before running.",
+        `Queued goal id: ${harness.snapshot().goal?.goalId}.`,
+        `Current goal id: ${harness.snapshot().goal?.goalId}; current status: complete.`,
+        "Ignore only this stale hidden bookkeeping message; do not perform work for the queued goal id above or mention this cancellation to the user.",
+      ].join("\n"),
+    },
+  ]);
+
   assert.equal(harness.snapshot().goal?.status, "complete");
   assert.equal(harness.abortCount, 1);
-  assert.match(result?.systemPrompt ?? "", /queued hidden goal continuation is stale/);
 });
 
 test("stale custom goal work messages are replaced before provider context", async () => {
@@ -542,12 +624,246 @@ test("stale custom goal work messages are replaced before provider context", asy
   const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
   const replacedMessage = result?.messages?.[0];
   assert.equal(typeof replacedMessage?.content, "string");
-  assert.match(String(replacedMessage?.content), /queued hidden goal continuation is stale/);
+  assert.match(String(replacedMessage?.content), /queued hidden goal continuation was stale and has been cancelled/);
   assert.deepEqual(replacedMessage?.details, {
     kind: "stale_continuation",
     goalId: harness.snapshot().goal?.goalId,
     currentGoalId: harness.snapshot().goal?.goalId,
     currentStatus: "complete",
+  });
+});
+
+test("stale provider context replacement covers queued work kinds and prompt markers", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const queuedGoalId = harness.snapshot().goal?.goalId;
+  assert.ok(queuedGoalId);
+  const prompt = queued.message.content;
+  if (typeof prompt !== "string") {
+    assert.fail("Expected queued goal message content to be a string.");
+  }
+
+  await harness.runTool("update_goal", { status: "complete" });
+  const staleMessages = [
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: "queued by details",
+      display: false,
+      details: { kind: "continuation", goalId: queuedGoalId },
+      timestamp: 1,
+    },
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: "queued by details",
+      display: false,
+      details: { kind: "command_start", goalId: queuedGoalId },
+      timestamp: 1,
+    },
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: "queued by details",
+      display: false,
+      details: { kind: "command_resume", goalId: queuedGoalId },
+      timestamp: 1,
+    },
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: prompt,
+      display: false,
+      details: { kind: "other", goalId: queuedGoalId },
+      timestamp: 1,
+    },
+    {
+      role: "user",
+      content: [{ type: "text", text: prompt }],
+      timestamp: 1,
+    },
+  ];
+
+  const results = await harness.emit("context", {
+    type: "context",
+    messages: staleMessages,
+  });
+
+  const result = results[0] as { messages?: Array<{ role: string; content?: unknown; details?: unknown }> } | undefined;
+  assert.equal(result?.messages?.length, staleMessages.length);
+  for (const [index, message] of result?.messages?.entries() ?? []) {
+    if (message.role === "custom") {
+      assert.equal(typeof message.content, "string", `custom message ${index} should use string content`);
+      assert.match(String(message.content), /do not perform work for the queued goal id above/);
+      assert.deepEqual(message.details, {
+        kind: "stale_continuation",
+        goalId: queuedGoalId,
+        currentGoalId: queuedGoalId,
+        currentStatus: "complete",
+      });
+    } else {
+      assert.deepEqual(message.content, [
+        {
+          type: "text",
+          text: [
+            "A queued hidden goal continuation was stale and has been cancelled before running.",
+            `Queued goal id: ${queuedGoalId}.`,
+            `Current goal id: ${queuedGoalId}; current status: complete.`,
+            "Ignore only this stale hidden bookkeeping message; do not perform work for the queued goal id above or mention this cancellation to the user.",
+          ].join("\n"),
+        },
+      ]);
+    }
+  }
+});
+
+test("stale prompt-based queued work does not pause or charge a replacement goal", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("old goal");
+  const oldQueued = harness.sentMessages[0];
+  assert.ok(oldQueued);
+  const oldPrompt = oldQueued.message.content;
+  if (typeof oldPrompt !== "string") {
+    assert.fail("Expected queued goal message content to be a string.");
+  }
+  const oldMessage = {
+    role: "user",
+    content: [{ type: "text", text: oldPrompt }],
+    timestamp: 1,
+  };
+
+  await harness.runCommand("new goal");
+  const replacement = harness.snapshot().goal;
+  assert.equal(replacement?.objective, "new goal");
+  harness.sentMessages.length = 0;
+
+  await emitQueuedTurnThroughContext(harness, [oldMessage]);
+  assert.equal(harness.abortCount, 1);
+
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 0,
+    message: assistantMessage("aborted", { input: 20, output: 5 }),
+    toolResults: [],
+  });
+  await harness.emit("agent_end", {
+    type: "agent_end",
+    messages: [assistantMessage("aborted", { input: 20, output: 5 })],
+  });
+
+  const goal = harness.snapshot().goal;
+  assert.equal(goal?.goalId, replacement?.goalId);
+  assert.equal(goal?.status, "active");
+  assert.equal(goal?.usage.tokensUsed, 0);
+  assert.equal(harness.abortCount, 1);
+  assert.equal(harness.sentMessages.length, 0);
+});
+
+test("stale custom queued work aborts without pausing, charging, or requeueing a replacement goal", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("old goal");
+    const oldQueued = harness.sentMessages[0];
+    assert.ok(oldQueued);
+    const oldMessage = {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: oldQueued.message.content,
+      display: false,
+      details: oldQueued.message.details,
+      timestamp: 1,
+    };
+
+    await harness.runCommand("new goal");
+    const replacement = harness.snapshot().goal;
+    assert.equal(replacement?.objective, "new goal");
+    harness.sentMessages.length = 0;
+
+    await emitQueuedTurnThroughContext(harness, [oldMessage]);
+    assert.equal(harness.abortCount, 1);
+
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("aborted", { input: 20, output: 5 }),
+      toolResults: [],
+    });
+    await harness.emit("agent_end", {
+      type: "agent_end",
+      messages: [assistantMessage("aborted", { input: 20, output: 5 })],
+    });
+
+    now = 5_000;
+    await harness.emit("session_shutdown", { type: "session_shutdown" });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.goalId, replacement?.goalId);
+    assert.equal(goal?.status, "active");
+    assert.equal(goal?.usage.tokensUsed, 0);
+    assert.equal(goal?.usage.activeSeconds, 0);
+    assert.equal(harness.sentMessages.length, 0);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("mixed stale and current follow-up batch neutralizes stale work without aborting current goal", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("old goal");
+  const oldQueued = harness.sentMessages[0];
+  assert.ok(oldQueued);
+  const oldMessage = queuedCustomMessage(oldQueued, 1);
+  const oldGoalId = harness.snapshot().goal?.goalId;
+  assert.ok(oldGoalId);
+
+  await harness.runCommand("new goal");
+  const replacement = harness.snapshot().goal;
+  assert.equal(replacement?.objective, "new goal");
+  const currentQueued = harness.sentMessages.at(-1);
+  assert.ok(currentQueued);
+  const currentMessage = queuedCustomMessage(currentQueued, 2);
+  harness.sentMessages.length = 0;
+
+  const contextResults = await emitQueuedTurnThroughContext(harness, [oldMessage, currentMessage]);
+  const contextResult = contextResults[0] as
+    | { messages?: Array<{ content?: unknown; details?: unknown }> }
+    | undefined;
+
+  assert.equal(harness.abortCount, 0);
+  assert.equal(contextResult?.messages?.length, 2);
+  assert.match(String(contextResult?.messages?.[0]?.content), /queued hidden goal continuation was stale/);
+  assert.deepEqual(contextResult?.messages?.[0]?.details, {
+    kind: "stale_continuation",
+    goalId: oldGoalId,
+    currentGoalId: replacement?.goalId,
+    currentStatus: "active",
+  });
+  assert.deepEqual(contextResult?.messages?.[1]?.details, currentMessage.details);
+
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 0,
+    message: assistantMessage("stop", { input: 9, output: 1 }),
+    toolResults: [],
+  });
+  await harness.emit("agent_end", {
+    type: "agent_end",
+    messages: [assistantMessage("stop", { input: 9, output: 1 })],
+  });
+
+  const goal = harness.snapshot().goal;
+  assert.equal(goal?.goalId, replacement?.goalId);
+  assert.equal(goal?.status, "active");
+  assert.equal(goal?.usage.tokensUsed, 10);
+  assert.equal(harness.sentMessages.length, 1);
+  assert.deepEqual(harness.sentMessages[0]?.message.details, {
+    kind: "continuation",
+    goalId: replacement?.goalId,
   });
 });
 
@@ -583,7 +899,7 @@ test("goal follow-up guard resets when the queued prompt-based agent turn starts
   });
 });
 
-test("goal follow-up guard resets on turn start for custom-message continuations", async () => {
+test("goal follow-up guard resets when custom-message continuations start", async () => {
   const harness = createRuntimeHarness();
   await harness.runTool("create_goal", { objective: "ship it" });
   harness.sentMessages.length = 0;
@@ -593,9 +909,24 @@ test("goal follow-up guard resets on turn start for custom-message continuations
     messages: [assistantMessage("stop", { input: 30, output: 12 })],
   });
   assert.equal(harness.sentMessages.length, 1);
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const queuedMessage = {
+    role: "custom",
+    customType: CUSTOM_ENTRY_TYPE,
+    content: queued.message.content,
+    display: false,
+    details: queued.message.details,
+    timestamp: 1,
+  };
   harness.sentMessages.length = 0;
 
   await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: queuedMessage,
+  });
+  assert.equal(harness.abortCount, 0);
   await harness.emit("agent_end", {
     type: "agent_end",
     messages: [assistantMessage("stop", { input: 5, output: 6 })],
@@ -613,9 +944,16 @@ test("goal follow-up guard resets on turn start for custom-message continuations
 test("session compaction queues continuation for active goals after length stops", async () => {
   const harness = createRuntimeHarness({ idle: false, pendingMessages: true });
   await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const queuedMessage = queuedCustomMessage(queued);
   harness.sentMessages.length = 0;
 
   await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: queuedMessage,
+  });
   await harness.emit("turn_end", {
     type: "turn_end",
     turnIndex: 0,


### PR DESCRIPTION
## Summary

Fix stale hidden goal continuations so they are cancelled silently before they can trigger model-visible work.

A queued continuation can become stale when the goal is completed, cleared, paused, budget-limited, or replaced before the queued turn starts. The previous PR only covered the prompt-start path and did not fully cover custom `pi.sendMessage()` follow-up work.

## What changed

- Handle stale prompt-based continuations at `input` with `{ action: "handled" }`.
- Detect queued goal work by goal id from custom message details or continuation prompt markers.
- Replace stale queued work in provider context with an ignorable hidden bookkeeping message.
- Abort stale-only queued turns in `context`, before provider work starts.
- Preserve mixed batches that contain stale work plus current/non-goal runnable work.
- Suppress accounting, pause, and requeue side effects from stale continuation aborts.
- Clear continuation guards by the queued goal id when the queued work starts.

## Validation

- `npm run verify`
- 35 tests passed

## Notes

This supersedes #1 with a maintainer-owned branch and a clean diff.
