### PR TITLE
Make goal lifecycle transitions terminal, idempotent, and clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Makes goal lifecycle transitions terminal and idempotent: duplicate `update_goal complete` calls no longer append extra session entries, completed goals cannot be paused or resumed, and runtime/compaction skips unchanged goal snapshots.
+- Allows `create_goal` to replace a completed goal and clarifies recovery via `/goal <objective>` or `/goal clear`.
+- Surfaces failed goal tool calls as real pi tool errors by throwing from tool handlers.
+
 ## 0.1.12 - 2026-05-23
 
 - Updated the local pi development baseline to `@earendil-works/*` `0.75.5`, refreshed Node/tsx tooling, and regenerated the npm lockfile.

--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ This intentionally matches Codex TUI behavior: token budgets are set through the
 
 ## Model Tools
 
-`create_goal` starts a goal with an objective and optional positive token budget. It fails if a goal already exists.
+`create_goal` starts a goal with an objective and optional positive token budget. It fails if a non-complete goal already exists. After a goal is complete, `create_goal` replaces it with a new active goal.
 
 `get_goal` returns the current goal state and usage.
 
-`update_goal` only accepts `status: "complete"`, matching Codex's model-side contract. The extension reports final token and elapsed-time usage before marking the goal complete.
+`update_goal` only accepts `status: "complete"`, matching Codex's model-side contract. Calling it on an already-complete goal is idempotent and does not append duplicate session entries. The extension reports final token and elapsed-time usage before marking the goal complete.
+
+Completed goals are terminal for automatic transitions: pause, resume, and hidden continuations do not reopen them. To recover from premature completion, use `/goal <objective>` to replace the goal or `/goal clear` before starting again.
 
 In bridged MCP environments such as `pi-cursor-sdk`, pi may expose these tools under namespaced MCP names like `pi__get_goal`, `pi__create_goal`, and `pi__update_goal`. Prompt guidance tells models to call whichever goal-tool name is actually exposed in the current run, not display or transcript labels.
 
@@ -74,7 +76,9 @@ While a goal is active, the extension:
 - tracks elapsed active time between turns and tool completions
 - adds completed assistant turn input plus output token usage when the active model reports it
 - pauses when an active assistant turn is aborted, such as when you press Esc
-- prompts on session resume before reactivating a paused goal, and resumes explicitly with `/goal resume`
+- prompts on session resume before reactivating a paused goal, and resumes explicitly with `/goal resume` (only from paused)
+- rejects `/goal pause` unless the goal is active and `/goal resume` unless the goal is paused
+- treats completed goals as terminal for automatic transitions while allowing `/goal <objective>` to replace them without extra friction
 - marks the goal `budgetLimited` when a positive token budget is reached
 - sends hidden steering messages when budget is reached or when the agent is idle but the goal is still active
 - shows Codex-style status labels with compact token or elapsed-time usage in the pi footer when UI is available

--- a/src/format.ts
+++ b/src/format.ts
@@ -94,6 +94,9 @@ function commandHint(status: GoalStatus): string {
   if (status === "paused") {
     return "/goal resume, /goal clear";
   }
+  if (status === "complete") {
+    return "/goal <objective> to replace, /goal clear";
+  }
   return "/goal clear";
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { registerGoalCommand } from "./commands.js";
 import { formatFooterStatus } from "./format.js";
 import { budgetLimitPrompt, continuationGoalIdFromPrompt, continuationPrompt } from "./prompts.js";
-import { applyUsage, clearEntry, goalWithLiveUsage, reconstructGoal, setEntry, updateGoalStatus } from "./state.js";
+import { applyUsage, clearEntry, goalWithLiveUsage, goalsEquivalent, reconstructGoal, setEntry, updateGoalStatus } from "./state.js";
 import { registerGoalTools } from "./tools.js";
 import { CUSTOM_ENTRY_TYPE, type GoalEntrySource, type GoalResult, type ThreadGoal } from "./types.js";
 
@@ -409,7 +409,11 @@ export default function (pi: ExtensionAPI): void {
     return true;
   };
 
-  const persistGoal = (nextGoal: ThreadGoal, source: GoalEntrySource): void => {
+  const persistGoal = (nextGoal: ThreadGoal, source: GoalEntrySource): boolean => {
+    if (goal && goalsEquivalent(goal, nextGoal)) {
+      return false;
+    }
+
     const previousGoalId = goal?.goalId ?? null;
     goal = nextGoal;
     if (previousGoalId !== nextGoal.goalId) {
@@ -425,6 +429,7 @@ export default function (pi: ExtensionAPI): void {
       accounting.budgetWarningSentFor = null;
     }
     pi.appendEntry(CUSTOM_ENTRY_TYPE, setEntry(nextGoal, source));
+    return true;
   };
 
   const persistClear = (source: GoalEntrySource): void => {
@@ -530,6 +535,9 @@ export default function (pi: ExtensionAPI): void {
     accountProgress(ctx, false, 0, true);
     const result = updateGoalStatus(goal, "complete");
     if (!result.ok || !result.goal) {
+      return result;
+    }
+    if (goal && goalsEquivalent(goal, result.goal)) {
       return result;
     }
     persistGoal(result.goal, source);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -15,7 +15,7 @@ export function goalToolReference(toolName: GoalToolName): string {
 export const TOOL_PROMPT_GUIDELINES = [
   GOAL_TOOL_NAME_GUIDANCE,
   `Use ${goalToolReference("get_goal")} when you need to inspect the current long-running user objective.`,
-  `Use ${goalToolReference("create_goal")} only when the user explicitly asks you to start tracking a concrete goal; do not infer goals from ordinary tasks and do not create a second goal while one already exists.`,
+  `Use ${goalToolReference("create_goal")} only when the user explicitly asks you to start tracking a concrete goal; do not infer goals from ordinary tasks and do not create a second goal while a non-complete goal already exists. After a goal is complete, ${goalToolReference("create_goal")} replaces it with a new active goal.`,
   `Use ${goalToolReference("update_goal")} with status complete only after a completion audit proves the objective is actually achieved and no required work remains.`,
   `Before using ${goalToolReference("update_goal")}, map every explicit requirement in the goal to concrete evidence from files, command output, test results, PR state, or other real artifacts; uncertainty means the goal is not complete.`,
   `Do not use ${goalToolReference("update_goal")} merely because work is stopping, substantial progress was made, tests passed without covering every requirement, or the token budget is nearly exhausted.`,

--- a/src/state.ts
+++ b/src/state.ts
@@ -172,7 +172,7 @@ export function createGoal(current: ThreadGoal | null, objective: string, tokenB
     return {
       ok: false,
       message:
-        "cannot create a new goal because this thread already has an active goal; use update_goal to mark it complete, /goal clear, or /goal <objective> to replace it",
+        "cannot create a new goal because this thread already has a non-complete goal; use update_goal to mark it complete, /goal clear, or /goal <objective> to replace it",
       goal: current,
     };
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -28,6 +28,19 @@ export function cloneGoal(goal: ThreadGoal): ThreadGoal {
   };
 }
 
+export function goalsEquivalent(left: ThreadGoal, right: ThreadGoal): boolean {
+  return (
+    left.goalId === right.goalId &&
+    left.objective === right.objective &&
+    left.status === right.status &&
+    left.tokenBudget === right.tokenBudget &&
+    left.createdAt === right.createdAt &&
+    left.updatedAt === right.updatedAt &&
+    left.usage.tokensUsed === right.usage.tokensUsed &&
+    left.usage.activeSeconds === right.usage.activeSeconds
+  );
+}
+
 export function validateObjective(objective: string): string | null {
   const trimmed = objective.trim();
   if (trimmed.length === 0) {
@@ -155,11 +168,11 @@ export function reconstructGoal(entries: Iterable<SessionEntryLike>): GoalSnapsh
 }
 
 export function createGoal(current: ThreadGoal | null, objective: string, tokenBudget?: number | null): GoalResult {
-  if (current) {
+  if (current && current.status !== "complete") {
     return {
       ok: false,
       message:
-        "cannot create a new goal because this thread already has a goal; use update_goal only when the existing goal is complete",
+        "cannot create a new goal because this thread already has an active goal; use update_goal to mark it complete, /goal clear, or /goal <objective> to replace it",
       goal: current,
     };
   }
@@ -207,6 +220,48 @@ export function updateGoalStatus(current: ThreadGoal | null, status: GoalStatus)
       ok: false,
       message: "No active goal exists.",
       goal: null,
+    };
+  }
+
+  if (current.status === "complete") {
+    if (status === "complete") {
+      return {
+        ok: true,
+        message: "Goal already complete.",
+        goal: current,
+      };
+    }
+    return {
+      ok: false,
+      message: "Completed goals are terminal; use /goal <objective> to replace or /goal clear before changing status.",
+      goal: current,
+    };
+  }
+
+  if (status === "complete") {
+    const goal = cloneGoal(current);
+    goal.status = "complete";
+    goal.updatedAt = unixSeconds();
+    return {
+      ok: true,
+      message: "Goal marked complete.",
+      goal,
+    };
+  }
+
+  if (status === "paused" && current.status !== "active") {
+    return {
+      ok: false,
+      message: "Only active goals can be paused.",
+      goal: current,
+    };
+  }
+
+  if (status === "active" && current.status !== "paused") {
+    return {
+      ok: false,
+      message: "Only paused goals can be resumed.",
+      goal: current,
     };
   }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -66,7 +66,8 @@ export function registerGoalTools(pi: ExtensionAPI, host: ToolHost): void {
     name: "create_goal",
     label: "Create Goal",
     description: "Create a Codex-style long-running goal for this pi session.",
-    promptSnippet: "Create one active goal with an objective and optional positive token budget.",
+    promptSnippet:
+      "Create one goal with an objective and optional positive token budget. Fails when a non-complete goal already exists; replaces a completed goal.",
     promptGuidelines: TOOL_PROMPT_GUIDELINES,
     parameters: CreateGoalParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -36,13 +36,16 @@ export interface ToolHost {
 function textResult(
   text: string,
   goal: ThreadGoal | null,
-  isError = false,
   includeCompletionBudgetReport = false,
 ): AgentToolResult<GoalToolResponse & { error: string | null }> {
   return {
-    content: [{ type: "text", text: isError ? `Error: ${text}` : text }],
-    details: { ...goalToolResponse(goal, includeCompletionBudgetReport), error: isError ? text : null },
+    content: [{ type: "text", text }],
+    details: { ...goalToolResponse(goal, includeCompletionBudgetReport), error: null },
   };
+}
+
+function throwToolError(message: string): never {
+  throw new Error(message);
 }
 
 export function registerGoalTools(pi: ExtensionAPI, host: ToolHost): void {
@@ -69,7 +72,7 @@ export function registerGoalTools(pi: ExtensionAPI, host: ToolHost): void {
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const result = createGoal(host.getGoal(), params.objective, params.token_budget ?? null);
       if (!result.ok || !result.goal) {
-        return textResult(result.message, result.goal, true);
+        throwToolError(result.message);
       }
       host.setGoal(result.goal, "tool", ctx);
       return textResult(toToolText(result.goal), result.goal);
@@ -87,9 +90,9 @@ export function registerGoalTools(pi: ExtensionAPI, host: ToolHost): void {
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const result = host.completeGoal("tool", ctx);
       if (!result.ok || !result.goal) {
-        return textResult(result.message, result.goal, true);
+        throwToolError(result.message);
       }
-      return textResult(toToolText(result.goal, true), result.goal, false, true);
+      return textResult(toToolText(result.goal, true), result.goal, true);
     },
   });
 }

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -110,6 +110,60 @@ test("/goal resume restarts a hidden follow-up turn", async () => {
   assert.match(content, /<untrusted_objective>\nship the feature\n<\/untrusted_objective>/);
 });
 
+test("/goal pause rejects completed and paused goals", async () => {
+  const harness = createHarness();
+
+  await handleGoalCommand(harness.pi, harness.host, "ship the feature", harness.ctx);
+  const completed = updateGoalStatus(harness.goal, "complete").goal;
+  assert.ok(completed);
+  harness.setGoal(completed);
+
+  await handleGoalCommand(harness.pi, harness.host, "pause", harness.ctx);
+  assert.equal(harness.goal?.status, "complete");
+  assert.match(harness.notifications.at(-1) ?? "", /Completed goals are terminal/);
+
+  const paused = updateGoalStatus(completed, "paused");
+  assert.equal(paused.ok, false);
+});
+
+test("/goal resume rejects completed and active goals", async () => {
+  const harness = createHarness();
+
+  await handleGoalCommand(harness.pi, harness.host, "ship the feature", harness.ctx);
+  const completed = updateGoalStatus(harness.goal, "complete").goal;
+  assert.ok(completed);
+  harness.setGoal(completed);
+
+  await handleGoalCommand(harness.pi, harness.host, "resume", harness.ctx);
+  assert.equal(harness.goal?.status, "complete");
+  assert.match(harness.notifications.at(-1) ?? "", /Completed goals are terminal/);
+
+  await handleGoalCommand(harness.pi, harness.host, "ship the feature", harness.ctx);
+  assert.equal(harness.goal?.status, "active");
+  harness.sentMessages.length = 0;
+
+  await handleGoalCommand(harness.pi, harness.host, "resume", harness.ctx);
+  assert.equal(harness.goal?.status, "active");
+  assert.match(harness.notifications.at(-1) ?? "", /Only paused goals can be resumed/);
+});
+
+test("/goal objective replaces a completed goal without confirmation", async () => {
+  const harness = createHarness();
+
+  await handleGoalCommand(harness.pi, harness.host, "old objective", harness.ctx);
+  const completed = updateGoalStatus(harness.goal, "complete").goal;
+  assert.ok(completed);
+  harness.setGoal(completed);
+  harness.sentMessages.length = 0;
+
+  await handleGoalCommand(harness.pi, harness.host, "new objective", harness.ctx);
+
+  assert.equal(harness.goal?.objective, "new objective");
+  assert.equal(harness.goal?.status, "active");
+  assert.notEqual(harness.goal?.goalId, completed.goalId);
+  assert.equal(harness.sentMessages.length, 1);
+});
+
 test("/goal resume does not restart an over-budget budget-limited goal", async () => {
   const harness = createHarness();
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1321,7 +1321,7 @@ test("failed create_goal throws so pi marks the tool result as an error", async 
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");
 
-  await assert.rejects(() => harness.runTool("create_goal", { objective: "duplicate" }), /already has an active goal/);
+  await assert.rejects(() => harness.runTool("create_goal", { objective: "duplicate" }), /already has a non-complete goal/);
 });
 
 test("session compaction queues continuation for active goals after length stops", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1260,6 +1260,70 @@ test("goal follow-up guard resets when custom-message continuations start", asyn
   });
 });
 
+test("duplicate update_goal complete appends only one complete entry", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+
+  await harness.runTool("update_goal", { status: "complete" });
+  await harness.runTool("update_goal", { status: "complete" });
+
+  const completeSetEntries = harness.entries.filter((entry) => {
+    return (
+      entry.type === "custom" &&
+      entry.customType === CUSTOM_ENTRY_TYPE &&
+      isGoalCustomEntry(entry.data) &&
+      entry.data.kind === "set" &&
+      entry.data.goal.status === "complete"
+    );
+  });
+  assert.equal(completeSetEntries.length, 1);
+  assert.equal(harness.snapshot().goal?.status, "complete");
+});
+
+test("compaction after complete does not append duplicate runtime entries", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  await harness.runTool("update_goal", { status: "complete" });
+  const entryCountAfterComplete = harness.entries.length;
+
+  await harness.emit("session_before_compact", {
+    type: "session_before_compact",
+    preparation: {},
+    branchEntries: [],
+    signal: new AbortController().signal,
+  });
+  await harness.emit("session_compact", {
+    type: "session_compact",
+    compactionEntry: {},
+    fromExtension: false,
+  });
+
+  assert.equal(harness.entries.length, entryCountAfterComplete);
+  assert.equal(harness.snapshot().goal?.status, "complete");
+});
+
+test("create_goal replaces a completed goal", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const completedGoalId = harness.snapshot().goal?.goalId;
+  await harness.runTool("update_goal", { status: "complete" });
+
+  const created = (await harness.runTool("create_goal", { objective: "next objective" })) as {
+    details: Record<string, unknown>;
+  };
+
+  assert.equal((created.details.goal as { objective?: string }).objective, "next objective");
+  assert.equal(harness.snapshot().goal?.status, "active");
+  assert.notEqual(harness.snapshot().goal?.goalId, completedGoalId);
+});
+
+test("failed create_goal throws so pi marks the tool result as an error", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+
+  await assert.rejects(() => harness.runTool("create_goal", { objective: "duplicate" }), /already has an active goal/);
+});
+
 test("session compaction queues continuation for active goals after length stops", async () => {
   const harness = createRuntimeHarness({ idle: false, pendingMessages: true });
   await harness.runCommand("ship it");

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { formatBudget, formatDuration, formatFooterStatus, formatGoalSummary, formatTokenValue } from "../src/format.js";
-import { budgetLimitPrompt, continuationPrompt } from "../src/prompts.js";
+import { budgetLimitPrompt, continuationPrompt, TOOL_PROMPT_GUIDELINES } from "../src/prompts.js";
 import {
   applyUsage,
   clearEntry,
@@ -153,7 +153,7 @@ test("updateGoalStatus only allows pause from active and resume from paused", ()
   assert.equal(updateGoalStatus(resumed, "active").ok, false);
 });
 
-test("createGoal replaces completed goals and rejects active duplicates", () => {
+test("createGoal replaces completed goals and rejects non-complete duplicates", () => {
   const created = createGoal(null, "finish").goal;
   assert.ok(created);
   const completed = updateGoalStatus(created, "complete").goal;
@@ -161,6 +161,26 @@ test("createGoal replaces completed goals and rejects active duplicates", () => 
 
   assert.equal(createGoal(completed, "next").ok, true);
   assert.equal(createGoal(created, "next").ok, false);
+  assert.match(createGoal(created, "next").message ?? "", /non-complete goal/);
+
+  const paused = updateGoalStatus(created, "paused").goal;
+  assert.ok(paused);
+  assert.equal(createGoal(paused, "next").ok, false);
+  assert.match(createGoal(paused, "next").message ?? "", /non-complete goal/);
+
+  const limited = applyUsage(createGoal(null, "finish", 10).goal!, 10, 0).goal;
+  assert.ok(limited);
+  assert.equal(limited.status, "budgetLimited");
+  assert.equal(createGoal(limited, "next").ok, false);
+  assert.match(createGoal(limited, "next").message ?? "", /non-complete goal/);
+});
+
+test("model-facing create_goal guidance matches create-after-complete semantics", () => {
+  const guidance = TOOL_PROMPT_GUIDELINES.join("\n");
+
+  assert.match(guidance, /non-complete goal/);
+  assert.match(guidance, /After a goal is complete,.*replaces it with a new active goal/);
+  assert.doesNotMatch(guidance, /do not create a second goal while one already exists/);
 });
 
 test("goalsEquivalent compares full goal snapshots", () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -8,6 +8,7 @@ import {
   clearEntry,
   createGoal,
   goalWithLiveUsage,
+  goalsEquivalent,
   reconstructGoal,
   setEntry,
   updateGoalStatus,
@@ -119,6 +120,55 @@ test("goalWithLiveUsage adds in-progress active time for display", () => {
 test("maximum goal objective length remains 8000 Unicode scalars in this package", () => {
   assert.equal(createGoal(null, "x".repeat(8_000)).ok, true);
   assert.equal(createGoal(null, "x".repeat(8_001)).ok, false);
+});
+
+test("updateGoalStatus rejects pause and resume on completed goals", () => {
+  const created = createGoal(null, "finish").goal;
+  assert.ok(created);
+  const completed = updateGoalStatus(created, "complete").goal;
+  assert.ok(completed);
+  assert.equal(completed.status, "complete");
+
+  assert.equal(updateGoalStatus(completed, "complete").ok, true);
+  assert.equal(updateGoalStatus(completed, "complete").message, "Goal already complete.");
+  assert.equal(updateGoalStatus(completed, "paused").ok, false);
+  assert.equal(updateGoalStatus(completed, "active").ok, false);
+});
+
+test("updateGoalStatus only allows pause from active and resume from paused", () => {
+  const created = createGoal(null, "finish").goal;
+  assert.ok(created);
+
+  assert.equal(updateGoalStatus(created, "paused").ok, true);
+  const paused = updateGoalStatus(created, "paused").goal;
+  assert.ok(paused);
+  assert.equal(paused.status, "paused");
+
+  assert.equal(updateGoalStatus(paused, "paused").ok, false);
+
+  const resumed = updateGoalStatus(paused, "active").goal;
+  assert.ok(resumed);
+  assert.equal(resumed.status, "active");
+
+  assert.equal(updateGoalStatus(resumed, "active").ok, false);
+});
+
+test("createGoal replaces completed goals and rejects active duplicates", () => {
+  const created = createGoal(null, "finish").goal;
+  assert.ok(created);
+  const completed = updateGoalStatus(created, "complete").goal;
+  assert.ok(completed);
+
+  assert.equal(createGoal(completed, "next").ok, true);
+  assert.equal(createGoal(created, "next").ok, false);
+});
+
+test("goalsEquivalent compares full goal snapshots", () => {
+  const created = createGoal(null, "finish").goal;
+  assert.ok(created);
+  const clone = { ...created, usage: { ...created.usage } };
+  assert.equal(goalsEquivalent(created, clone), true);
+  assert.equal(goalsEquivalent(created, { ...clone, status: "paused" }), false);
 });
 
 test("budget-limited goals cannot be paused or resumed back to active while over budget", () => {


### PR DESCRIPTION
## Summary

- Enforces a clear goal lifecycle state machine: `complete` is idempotent and terminal for automatic transitions (pause/resume, hidden continuations), while `/goal <objective>` still replaces a completed goal without extra friction.
- Skips persisting unchanged goal snapshots during runtime accounting and compaction, preventing duplicate complete/paused entries in session history.
- Allows `create_goal` to replace a completed goal; failed goal tools now throw so pi marks them as real tool errors.

Closes #6

## Behavior changes

| Scenario | Before | After |
|----------|--------|-------|
| Duplicate `update_goal complete` | Appended duplicate session entries | Idempotent; returns current goal |
| `/goal pause` on complete goal | Could reopen goal | Rejected with recovery hint |
| `/goal resume` on complete/active goal | Could change status incorrectly | Rejected unless paused |
| `create_goal` with complete goal present | Confusing failure message | Replaces completed goal |
| Runtime/compaction on unchanged complete goal | Appended duplicate snapshots | No-op persist |
| Failed `create_goal` | Error text with `isError: false` | Throws; pi sets `isError: true` |

## Test plan

- [x] `npm run verify` (typecheck + 52 tests)
- [x] Duplicate complete appends only one session entry
- [x] Complete → pause/resume rejected
- [x] Compaction after complete does not append duplicate runtime entries
- [x] `create_goal` replaces completed goal; active duplicate throws
- [x] `/goal <objective>` replaces completed goal without confirmation
- [x] Long-run continuation paths unchanged (existing auto-continue tests still pass)


Made with [Cursor](https://cursor.com)