### PR TITLE
Bound hidden goal continuation context and dedupe repeated prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bounds hidden goal continuation provider context by superseding older active-goal continuations with short bookkeeping markers, refreshing only the latest continuation, and using compact auto-continuation prompts after `/goal` start or resume.
 - Makes goal lifecycle transitions terminal and idempotent: duplicate `update_goal complete` calls no longer append extra session entries, completed goals cannot be paused or resumed, and runtime/compaction skips unchanged goal snapshots.
 - Allows `create_goal` to replace a completed goal and clarifies recovery via `/goal <objective>` or `/goal clear`.
 - Surfaces failed goal tool calls as real pi tool errors by throwing from tool handlers.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ While a goal is active, the extension:
 - treats completed goals as terminal for automatic transitions while allowing `/goal <objective>` to replace them without extra friction
 - marks the goal `budgetLimited` when a positive token budget is reached
 - sends hidden steering messages when budget is reached or when the agent is idle but the goal is still active
+- compacts repeated hidden goal continuations before provider context so only the latest active continuation stays runnable, older ones become short bookkeeping markers, and auto-queued continuations use a compact prompt after `/goal` start or resume
 - shows Codex-style status labels with compact token or elapsed-time usage in the pi footer when UI is available
 
 Token counts are formatted with commas and compact abbreviations, for example `123M (123,456,789) tokens`. Token totals use pi's completed assistant turn input plus output usage. Cache read and cache write channels are excluded because they are provider cache accounting fields, not extra sent and received text tokens. Pi does not currently expose a separate extension usage total for automatic compaction summary calls.

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,9 @@ function dedupeActiveGoalContinuations<TMessage extends {
 }>(
   messages: TMessage[],
   goal: ThreadGoal,
+  resolveQueuedGoalWorkMessageId: (
+    message: { role: string; customType?: string; details?: unknown; content?: unknown },
+  ) => string | null,
 ): { messages: TMessage[]; changed: boolean } {
   const activeGoalId = goal.goalId;
   const indices: number[] = [];
@@ -195,7 +198,7 @@ function dedupeActiveGoalContinuations<TMessage extends {
     if (!message) {
       continue;
     }
-    const queuedGoalId = queuedGoalWorkMessageId(message);
+    const queuedGoalId = resolveQueuedGoalWorkMessageId(message);
     if (queuedGoalId === activeGoalId) {
       indices.push(index);
     }
@@ -775,7 +778,7 @@ export default function (pi: ExtensionAPI): void {
     });
 
     if (goal?.status === "active") {
-      const deduped = dedupeActiveGoalContinuations(messages, goal);
+      const deduped = dedupeActiveGoalContinuations(messages, goal, queuedGoalWorkMessageIdForRuntime);
       if (deduped.changed) {
         changed = true;
         messages = deduped.messages;

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,16 +112,12 @@ function staleGoalContinuationMessage(queuedGoalId: string, currentGoal: ThreadG
   ].join("\n");
 }
 
-function queuedGoalWorkMessageId(message: {
+function extensionQueuedGoalWorkMessageId(message: {
   role: string;
   customType?: string;
   details?: unknown;
   content?: unknown;
 }): string | null {
-  if (message.role === "user") {
-    return continuationGoalIdFromMessageContent(message.content);
-  }
-
   if (message.role !== "custom" || message.customType !== CUSTOM_ENTRY_TYPE) {
     return null;
   }
@@ -138,6 +134,19 @@ function queuedGoalWorkMessageId(message: {
   }
 
   return continuationGoalIdFromMessageContent(message.content);
+}
+
+function queuedGoalWorkMessageId(message: {
+  role: string;
+  customType?: string;
+  details?: unknown;
+  content?: unknown;
+}): string | null {
+  if (message.role === "user") {
+    return continuationGoalIdFromMessageContent(message.content);
+  }
+
+  return extensionQueuedGoalWorkMessageId(message);
 }
 
 function supersededContinuationContextMessage<TMessage extends { role: string; content?: unknown; display?: boolean; details?: unknown }>(
@@ -778,7 +787,7 @@ export default function (pi: ExtensionAPI): void {
     });
 
     if (goal?.status === "active") {
-      const deduped = dedupeActiveGoalContinuations(messages, goal, queuedGoalWorkMessageIdForRuntime);
+      const deduped = dedupeActiveGoalContinuations(messages, goal, extensionQueuedGoalWorkMessageId);
       if (deduped.changed) {
         changed = true;
         messages = deduped.messages;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,13 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 
 import { registerGoalCommand } from "./commands.js";
 import { formatFooterStatus } from "./format.js";
-import { budgetLimitPrompt, continuationGoalIdFromPrompt, continuationPrompt } from "./prompts.js";
+import {
+  budgetLimitPrompt,
+  compactContinuationPrompt,
+  continuationGoalIdFromPrompt,
+  continuationPrompt,
+  supersededContinuationMessage,
+} from "./prompts.js";
 import { applyUsage, clearEntry, goalWithLiveUsage, goalsEquivalent, reconstructGoal, setEntry, updateGoalStatus } from "./state.js";
 import { registerGoalTools } from "./tools.js";
 import { CUSTOM_ENTRY_TYPE, type GoalEntrySource, type GoalResult, type ThreadGoal } from "./types.js";
@@ -56,6 +62,10 @@ function isToolUseAssistantMessage(message: { role: string; stopReason?: string 
 
 function isQueuedGoalWorkKind(kind: unknown): boolean {
   return kind === "continuation" || kind === "command_start" || kind === "command_resume";
+}
+
+function isSupersededContinuationDetails(details: unknown): boolean {
+  return isQueuedGoalMessageDetails(details) && details.kind === "superseded_continuation";
 }
 
 function isQueuedGoalMessageDetails(details: unknown): details is QueuedGoalMessageDetails {
@@ -116,6 +126,10 @@ function queuedGoalWorkMessageId(message: {
     return null;
   }
 
+  if (isSupersededContinuationDetails(message.details)) {
+    return null;
+  }
+
   if (isQueuedGoalMessageDetails(message.details)) {
     const { kind, goalId } = message.details;
     if (isQueuedGoalWorkKind(kind) && typeof goalId === "string") {
@@ -124,6 +138,113 @@ function queuedGoalWorkMessageId(message: {
   }
 
   return continuationGoalIdFromMessageContent(message.content);
+}
+
+function supersededContinuationContextMessage<TMessage extends { role: string; content?: unknown; display?: boolean; details?: unknown }>(
+  message: TMessage,
+  goalId: string,
+): TMessage {
+  const content = supersededContinuationMessage(goalId);
+
+  if (message.role === "custom") {
+    return {
+      ...message,
+      content,
+      display: false,
+      details: {
+        kind: "superseded_continuation",
+        goalId,
+      },
+    } as TMessage;
+  }
+
+  return {
+    ...message,
+    content: [{ type: "text", text: content }],
+  } as TMessage;
+}
+
+function continuationPromptForProviderContext(
+  goal: ThreadGoal,
+  message: { details?: unknown },
+): string {
+  if (isQueuedGoalMessageDetails(message.details)) {
+    const kind = message.details.kind;
+    if (kind === "command_start" || kind === "command_resume") {
+      return continuationPrompt(goal);
+    }
+  }
+
+  return compactContinuationPrompt(goal);
+}
+
+function dedupeActiveGoalContinuations<TMessage extends {
+  role: string;
+  customType?: string;
+  details?: unknown;
+  content?: unknown;
+  display?: boolean;
+}>(
+  messages: TMessage[],
+  goal: ThreadGoal,
+): { messages: TMessage[]; changed: boolean } {
+  const activeGoalId = goal.goalId;
+  const indices: number[] = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (!message) {
+      continue;
+    }
+    const queuedGoalId = queuedGoalWorkMessageId(message);
+    if (queuedGoalId === activeGoalId) {
+      indices.push(index);
+    }
+  }
+
+  const latestIndex = indices.at(-1);
+  if (latestIndex === undefined) {
+    return { messages, changed: false };
+  }
+
+  let changed = false;
+  const nextMessages = messages.slice();
+
+  for (const index of indices.slice(0, -1)) {
+    const message = nextMessages[index];
+    if (!message) {
+      continue;
+    }
+    nextMessages[index] = supersededContinuationContextMessage(message, activeGoalId);
+    changed = true;
+  }
+
+  const latestMessage = nextMessages[latestIndex];
+  if (!latestMessage) {
+    return { messages, changed };
+  }
+  const refreshedContent = continuationPromptForProviderContext(goal, latestMessage);
+  if (latestMessage.role === "custom") {
+    if (latestMessage.content !== refreshedContent) {
+      nextMessages[latestIndex] = {
+        ...latestMessage,
+        content: refreshedContent,
+        display: false,
+      };
+      changed = true;
+    }
+  } else {
+    const refreshedUserContent = [{ type: "text", text: refreshedContent }];
+    const currentContent = textContentFromMessageContent(latestMessage.content);
+    if (currentContent !== refreshedContent) {
+      nextMessages[latestIndex] = {
+        ...latestMessage,
+        content: refreshedUserContent,
+      } as TMessage;
+      changed = true;
+    }
+  }
+
+  return { messages: nextMessages, changed };
 }
 
 function staleGoalContinuationContextMessage<TMessage extends { role: string; content?: unknown }>(
@@ -550,7 +671,7 @@ export default function (pi: ExtensionAPI): void {
     pi.sendMessage(
       {
         customType: CUSTOM_ENTRY_TYPE,
-        content: continuationPrompt(goalToContinue),
+        content: compactContinuationPrompt(goalToContinue),
         display: false,
         details: { kind: "continuation", goalId: goalToContinue.goalId },
       },
@@ -639,15 +760,27 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("context", async (event, ctx): Promise<{ messages: typeof event.messages } | undefined> => {
     let changed = false;
-    const messages: typeof event.messages = event.messages.map((message) => {
+    let messages: typeof event.messages = event.messages.map((message) => {
       const queuedGoalId = queuedGoalWorkMessageIdForRuntime(message);
-      if (queuedGoalId === null || (goal?.goalId === queuedGoalId && goal.status === "active")) {
+      if (queuedGoalId === null) {
+        return message;
+      }
+
+      if (goal?.goalId === queuedGoalId && goal.status === "active") {
         return message;
       }
 
       changed = true;
       return staleGoalContinuationContextMessage(message, queuedGoalId, goal);
     });
+
+    if (goal?.status === "active") {
+      const deduped = dedupeActiveGoalContinuations(messages, goal);
+      if (deduped.changed) {
+        changed = true;
+        messages = deduped.messages;
+      }
+    }
 
     if (startedStaleQueuedGoalWorkThisTurn && !startedRunnableWorkThisTurn) {
       if (!staleQueuedGoalWorkTurnActive) {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -51,6 +51,36 @@ export function escapeXmlText(value: string): string {
     .replaceAll(">", "&gt;");
 }
 
+export function supersededContinuationMessage(goalId: string): string {
+  return [
+    "Superseded hidden goal continuation bookkeeping.",
+    `Goal id: ${goalId}.`,
+    "A newer continuation for this active goal appears later in context.",
+    "Ignore this message; do not perform work for it or mention it to the user.",
+  ].join("\n");
+}
+
+export function compactContinuationPrompt(goal: ThreadGoal): string {
+  return [
+    `${CONTINUATION_MARKER_PREFIX}${goal.goalId}\">`,
+    "Continue working toward the active thread goal.",
+    "",
+    `Inspect the current objective and status with ${goalToolReference("get_goal")} if needed.`,
+    "",
+    "Budget:",
+    `- Time spent pursuing goal: ${formatDuration(goal.usage.activeSeconds)}`,
+    `- Tokens used: ${formatTokenValue(goal.usage.tokensUsed)}`,
+    `- Token budget: ${formatOptionalTokenBudget(goal)}`,
+    `- Tokens remaining: ${formatRemainingTokens(goal)}`,
+    "",
+    "Avoid repeating work that is already done. Choose the next concrete action toward the objective.",
+    "",
+    `Before marking the goal complete, audit progress against the objective and call ${goalToolReference("update_goal")} with status \"complete\" only when every requirement is verified.`,
+    GOAL_TOOL_NAME_GUIDANCE,
+    "</pi_goal_continuation>",
+  ].join("\n");
+}
+
 export function continuationPrompt(goal: ThreadGoal): string {
   return [
     `${CONTINUATION_MARKER_PREFIX}${goal.goalId}\">`,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,6 +4,11 @@ import test from "node:test";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 import goalExtension from "../src/index.js";
+import {
+  compactContinuationPrompt,
+  continuationGoalIdFromPrompt,
+  continuationPrompt,
+} from "../src/prompts.js";
 import { isGoalCustomEntry, reconstructGoal } from "../src/state.js";
 import { CUSTOM_ENTRY_TYPE } from "../src/types.js";
 
@@ -1322,6 +1327,188 @@ test("failed create_goal throws so pi marks the tool result as an error", async 
   await harness.runCommand("ship it");
 
   await assert.rejects(() => harness.runTool("create_goal", { objective: "duplicate" }), /already has a non-complete goal/);
+});
+
+test("provider context dedupes many active continuations to one refreshed prompt", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const goal = harness.snapshot().goal;
+  assert.ok(goal);
+
+  const fullStart = continuationPrompt(goal);
+  const olderContinuation = continuationPrompt({
+    ...goal,
+    usage: { ...goal.usage, tokensUsed: 1, activeSeconds: 1 },
+  });
+  const latestContinuation = compactContinuationPrompt({
+    ...goal,
+    usage: { ...goal.usage, tokensUsed: 99, activeSeconds: 42 },
+  });
+
+  const messages = [
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: fullStart,
+      display: false,
+      details: { kind: "command_start", goalId: goal.goalId },
+      timestamp: 1,
+    },
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: olderContinuation,
+      display: false,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 2,
+    },
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: latestContinuation,
+      display: false,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 3,
+    },
+  ];
+
+  const results = await harness.emit("context", {
+    type: "context",
+    messages,
+  });
+  const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
+  assert.ok(result?.messages);
+  assert.equal(result.messages.length, 3);
+
+  assert.match(String(result.messages[0]?.content), /Superseded hidden goal continuation bookkeeping/);
+  assert.deepEqual(result.messages[0]?.details, {
+    kind: "superseded_continuation",
+    goalId: goal.goalId,
+  });
+  assert.match(String(result.messages[1]?.content), /Superseded hidden goal continuation bookkeeping/);
+
+  const latestContent = String(result.messages[2]?.content);
+  assert.match(latestContent, /Tokens used: 0/);
+  assert.match(latestContent, /Time spent pursuing goal: 0s/);
+  assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
+  assert.doesNotMatch(latestContent, /<untrusted_objective>/);
+});
+
+test("latest active continuation remains runnable after provider-context dedupe", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const goal = harness.snapshot().goal;
+  assert.ok(goal);
+
+  const staleInBranch = continuationPrompt(goal);
+  const latestInBranch = compactContinuationPrompt(goal);
+  const contextResults = await harness.emit("context", {
+    type: "context",
+    messages: [
+      {
+        role: "custom",
+        customType: CUSTOM_ENTRY_TYPE,
+        content: staleInBranch,
+        display: false,
+        details: { kind: "continuation", goalId: goal.goalId },
+        timestamp: 1,
+      },
+      {
+        role: "custom",
+        customType: CUSTOM_ENTRY_TYPE,
+        content: latestInBranch,
+        display: false,
+        details: { kind: "continuation", goalId: goal.goalId },
+        timestamp: 2,
+      },
+    ],
+  });
+  const contextResult = contextResults[0] as { messages?: Array<{ content?: unknown }> } | undefined;
+  const latestContent = String(contextResult?.messages?.[1]?.content);
+  assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
+
+  harness.sentMessages.length = 0;
+  await harness.emit("before_agent_start", {
+    type: "before_agent_start",
+    prompt: latestContent,
+    systemPrompt: "",
+    systemPromptOptions: {},
+  });
+  await harness.emit("agent_end", {
+    type: "agent_end",
+    messages: [assistantMessage("stop", { input: 1, output: 1 })],
+  });
+
+  assert.equal(harness.snapshot().goal?.status, "active");
+  assert.equal(harness.sentMessages.length, 1);
+  assert.deepEqual(harness.sentMessages[0]?.message.details, {
+    kind: "continuation",
+    goalId: goal.goalId,
+  });
+});
+
+test("completed goals are not treated as active during continuation dedupe", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const goalId = harness.snapshot().goal?.goalId;
+  assert.ok(goalId);
+  const prompt = continuationPrompt(harness.snapshot().goal!);
+
+  await harness.runTool("update_goal", { status: "complete" });
+  const results = await harness.emit("context", {
+    type: "context",
+    messages: [
+      {
+        role: "custom",
+        customType: CUSTOM_ENTRY_TYPE,
+        content: prompt,
+        display: false,
+        details: { kind: "continuation", goalId },
+        timestamp: 1,
+      },
+      {
+        role: "custom",
+        customType: CUSTOM_ENTRY_TYPE,
+        content: prompt,
+        display: false,
+        details: { kind: "continuation", goalId },
+        timestamp: 2,
+      },
+    ],
+  });
+
+  const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
+  assert.match(String(result?.messages?.[0]?.content), /queued hidden goal continuation was stale/);
+  assert.match(String(result?.messages?.[1]?.content), /queued hidden goal continuation was stale/);
+  assert.equal(harness.snapshot().goal?.status, "complete");
+});
+
+test("auto-queued continuations use the compact prompt", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const commandStart = harness.sentMessages[0];
+  assert.ok(commandStart);
+  const startPrompt = String(commandStart.message.content);
+  assert.match(startPrompt, /<untrusted_objective>/);
+
+  harness.sentMessages.length = 0;
+  await harness.emit("before_agent_start", {
+    type: "before_agent_start",
+    prompt: startPrompt,
+    systemPrompt: "",
+    systemPromptOptions: {},
+  });
+  await harness.emit("agent_end", {
+    type: "agent_end",
+    messages: [assistantMessage("stop", { input: 1, output: 1 })],
+  });
+
+  const continuation = harness.sentMessages[0];
+  assert.ok(continuation);
+  const content = String(continuation.message.content);
+  assert.match(content, /<pi_goal_continuation goal_id="/);
+  assert.doesNotMatch(content, /<untrusted_objective>/);
+  assert.match(content, /get_goal/);
 });
 
 test("session compaction queues continuation for active goals after length stops", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1394,6 +1394,87 @@ test("provider context dedupes many active continuations to one refreshed prompt
   assert.doesNotMatch(latestContent, /<untrusted_objective>/);
 });
 
+test("active provider-context user marker without passthrough binding remains verbatim", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const goal = harness.snapshot().goal;
+  assert.ok(goal);
+
+  const userPrompt = continuationPrompt(goal);
+  const userMessage = {
+    role: "user",
+    content: [{ type: "text", text: userPrompt }],
+    timestamp: 1,
+  };
+
+  const contextResults = await harness.emit("context", {
+    type: "context",
+    messages: [userMessage],
+  });
+
+  assert.equal(contextResults[0], undefined);
+  assert.match(userPrompt, /<untrusted_objective>/);
+});
+
+test("active provider-context dedupe preserves historical user marker mixed with hidden continuations", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const goal = harness.snapshot().goal;
+  assert.ok(goal);
+
+  const userPrompt = continuationPrompt(goal);
+  const olderContinuation = continuationPrompt({
+    ...goal,
+    usage: { ...goal.usage, tokensUsed: 1, activeSeconds: 1 },
+  });
+  const latestContinuation = compactContinuationPrompt({
+    ...goal,
+    usage: { ...goal.usage, tokensUsed: 99, activeSeconds: 42 },
+  });
+
+  const userMessage = {
+    role: "user",
+    content: [{ type: "text", text: userPrompt }],
+    timestamp: 2,
+  };
+  const messages = [
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: olderContinuation,
+      display: false,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 1,
+    },
+    userMessage,
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: latestContinuation,
+      display: false,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 3,
+    },
+  ];
+
+  const contextResults = await harness.emit("context", {
+    type: "context",
+    messages,
+  });
+  const result = contextResults[0] as { messages?: Array<{ role: string; content?: unknown; details?: unknown }> } | undefined;
+  assert.ok(result?.messages);
+  assert.equal(result.messages.length, 3);
+
+  assert.match(String(result.messages[0]?.content), /Superseded hidden goal continuation bookkeeping/);
+  assert.deepEqual(result.messages[1]?.content, userMessage.content);
+  assert.match(String((result.messages[1]?.content as Array<{ text?: string }> | undefined)?.[0]?.text), /<untrusted_objective>/);
+
+  const latestContent = String(result.messages[2]?.content);
+  assert.match(latestContent, /Tokens used: 0/);
+  assert.doesNotMatch(latestContent, /<untrusted_objective>/);
+  assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
+});
+
 for (const source of ["interactive", "rpc"] as const) {
   test(`active goal pasted continuation marker from ${source} survives provider-context dedupe`, async () => {
     const harness = createRuntimeHarness();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1394,6 +1394,100 @@ test("provider context dedupes many active continuations to one refreshed prompt
   assert.doesNotMatch(latestContent, /<untrusted_objective>/);
 });
 
+for (const source of ["interactive", "rpc"] as const) {
+  test(`active goal pasted continuation marker from ${source} survives provider-context dedupe`, async () => {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const goal = harness.snapshot().goal;
+    assert.ok(goal);
+    const queued = harness.sentMessages[0];
+    assert.ok(queued);
+    const prompt = queued.message.content;
+    if (typeof prompt !== "string") {
+      assert.fail("Expected queued goal message content to be a string.");
+    }
+
+    await harness.emit("input", {
+      type: "input",
+      text: prompt,
+      source,
+    });
+
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: prompt }],
+      timestamp: 1,
+    };
+    const contextResults = await emitQueuedTurnThroughContext(harness, [userMessage], 0);
+
+    assert.equal(contextResults[0], undefined);
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.match(prompt, /<untrusted_objective>/);
+  });
+}
+
+test("active goal provider-context dedupe preserves pasted marker input mixed with hidden continuations", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const goal = harness.snapshot().goal;
+  assert.ok(goal);
+
+  const pastedPrompt = continuationPrompt(goal);
+  const olderContinuation = continuationPrompt({
+    ...goal,
+    usage: { ...goal.usage, tokensUsed: 1, activeSeconds: 1 },
+  });
+  const latestContinuation = compactContinuationPrompt({
+    ...goal,
+    usage: { ...goal.usage, tokensUsed: 99, activeSeconds: 42 },
+  });
+
+  await harness.emit("input", {
+    type: "input",
+    text: pastedPrompt,
+    source: "interactive",
+  });
+
+  const userMessage = {
+    role: "user",
+    content: [{ type: "text", text: pastedPrompt }],
+    timestamp: 2,
+  };
+  const messages = [
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: olderContinuation,
+      display: false,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 1,
+    },
+    userMessage,
+    {
+      role: "custom",
+      customType: CUSTOM_ENTRY_TYPE,
+      content: latestContinuation,
+      display: false,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 3,
+    },
+  ];
+
+  const contextResults = await emitQueuedTurnThroughContext(harness, messages, 0);
+  const result = contextResults[0] as { messages?: Array<{ role: string; content?: unknown; details?: unknown }> } | undefined;
+  assert.ok(result?.messages);
+  assert.equal(result.messages.length, 3);
+
+  assert.deepEqual(result.messages[1]?.content, userMessage.content);
+  assert.match(String((result.messages[1]?.content as Array<{ text?: string }> | undefined)?.[0]?.text), /<untrusted_objective>/);
+  assert.match(String(result.messages[0]?.content), /Superseded hidden goal continuation bookkeeping/);
+
+  const latestContent = String(result.messages[2]?.content);
+  assert.match(latestContent, /Tokens used: 0/);
+  assert.doesNotMatch(latestContent, /<untrusted_objective>/);
+  assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
+});
+
 test("latest active continuation remains runnable after provider-context dedupe", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -5,8 +5,11 @@ import {
   GOAL_TOOL_NAME_GUIDANCE,
   TOOL_PROMPT_GUIDELINES,
   budgetLimitPrompt,
+  compactContinuationPrompt,
+  continuationGoalIdFromPrompt,
   continuationPrompt,
   goalToolReference,
+  supersededContinuationMessage,
 } from "../src/prompts.js";
 import { createGoal } from "../src/state.js";
 
@@ -23,6 +26,29 @@ test("tool prompt guidelines include exposed and namespaced goal tool guidance",
   assert.match(combined, /get_goal \(or the exposed namespaced equivalent, such as pi__get_goal\)/);
   assert.match(combined, /create_goal \(or the exposed namespaced equivalent, such as pi__create_goal\)/);
   assert.match(combined, /update_goal \(or the exposed namespaced equivalent, such as pi__update_goal\)/);
+});
+
+test("compact continuation keeps marker detection without repeating the full objective", () => {
+  const created = createGoal(null, "ship it", 10).goal;
+  assert.ok(created);
+
+  const compact = compactContinuationPrompt(created);
+  const full = continuationPrompt(created);
+
+  assert.equal(continuationGoalIdFromPrompt(compact), created.goalId);
+  assert.match(compact, /<pi_goal_continuation goal_id="/);
+  assert.doesNotMatch(compact, /<untrusted_objective>/);
+  assert.match(compact, /get_goal/);
+  assert.ok(compact.length < full.length);
+});
+
+test("superseded continuation bookkeeping does not expose a runnable marker", () => {
+  const created = createGoal(null, "ship it", 10).goal;
+  assert.ok(created);
+
+  const superseded = supersededContinuationMessage(created.goalId);
+  assert.equal(continuationGoalIdFromPrompt(superseded), null);
+  assert.match(superseded, /Superseded hidden goal continuation bookkeeping/);
 });
 
 test("continuation and budget-limit prompts reference exposed goal-completion tool names", () => {


### PR DESCRIPTION
## Summary

Closes #5 by bounding hidden goal continuation content sent to the provider without reducing `/goal` autonomy.

- Supersedes older active-goal continuation messages with short bookkeeping markers before provider context, keeping at most one runnable continuation refreshed from current goal state.
- Queues compact auto-continuations after idle turns while preserving full prompts for `/goal` start and resume.
- Leaves completed, paused, and cleared goals on the existing stale-continuation path so dedupe logic cannot revive them as active.

## Test plan

- [x] `npm run verify` (typecheck + 61 tests)
- [x] Regression tests for many-branch continuations, latest runnable continuation, marker detection, completed-goal stale handling, and compact auto-queue prompts


Made with [Cursor](https://cursor.com)