### PR TITLE
Coalesce runtime goal persistence to reduce session-log spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bounds hidden goal continuation provider context by superseding older active-goal continuations with short bookkeeping markers, refreshing only the latest continuation, and using compact auto-continuation prompts after `/goal` start or resume.
 - Stops provider-error continuation retry storms by skipping immediate hidden requeues on `stopReason: "error"`, auto-compacting on context-window overflow when available, using bounded backoff for transient failures, and pausing with a recoverable `/goal resume` path when recovery is exhausted.
 - Makes goal lifecycle transitions terminal and idempotent: duplicate `update_goal complete` calls no longer append extra session entries, completed goals cannot be paused or resumed, and runtime/compaction skips unchanged goal snapshots.
+- Coalesces runtime goal persistence so repeated tool completions and unchanged compaction snapshots do not append full goal entries on every event; live footer usage stays current, and turn boundaries, shutdown, budget crossings, and bounded long-run intervals flush pending accounting to session history.
 - Allows `create_goal` to replace a completed goal and clarifies recovery via `/goal <objective>` or `/goal clear`.
 - Surfaces failed goal tool calls as real pi tool errors by throwing from tool handlers.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ While a goal is active, the extension:
 
 - tracks elapsed active time between turns and tool completions
 - adds completed assistant turn input plus output token usage when the active model reports it
+- coalesces runtime goal custom-entry writes so unchanged status and usage are not appended on every tool completion; live footer usage stays current, and meaningful usage is flushed at turn boundaries, shutdown, compaction, budget crossings, and bounded intervals during long tool-heavy runs
 - pauses when an active assistant turn is aborted, such as when you press Esc
 - recovers from provider assistant errors without immediate hidden continuation loops: context-window overflow triggers automatic compaction and then resumes the active goal, transient errors use bounded backoff retries, and repeated unrecoverable failures pause with a clear `/goal resume` path
 - prompts on session resume before reactivating a paused goal, and resumes explicitly with `/goal resume` (only from paused)

--- a/src/goal-accounting.ts
+++ b/src/goal-accounting.ts
@@ -53,8 +53,9 @@ export function isToolUseAssistantMessage(message: AssistantTurnMessage): boolea
 
 interface GoalAccountingDeps {
   getGoal: () => ThreadGoal | null;
+  setGoal: (nextGoal: ThreadGoal) => void;
   getAccounting: () => AccountingState;
-  persistGoal: (nextGoal: ThreadGoal, source: "runtime") => boolean;
+  flushGoalPersistence: (source: "runtime") => boolean;
   refreshUi: (ctx: ExtensionContext) => void;
   sendMessage: ExtensionAPI["sendMessage"];
 }
@@ -105,8 +106,12 @@ export function createGoalAccounting(deps: GoalAccountingDeps) {
       return;
     }
 
-    deps.persistGoal(result.goal, "runtime");
+    deps.setGoal(result.goal);
     deps.refreshUi(ctx);
+
+    if (result.crossedBudget) {
+      deps.flushGoalPersistence("runtime");
+    }
 
     if (allowBudgetSteering && result.crossedBudget && accounting.budgetWarningSentFor !== result.goal.goalId) {
       accounting.budgetWarningSentFor = result.goal.goalId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,6 +313,7 @@ export default function (pi: ExtensionAPI): void {
       clearActiveAccounting();
     } else if (nextGoal.status === "budgetLimited") {
       clearContinuationState();
+      clearActiveAccounting();
       resetErrorRecovery();
     }
     if (nextGoal.status !== "budgetLimited") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from "./recovery.js";
 import {
   clearEntry,
+  cloneGoal,
   goalWithLiveUsage,
   goalsEquivalent,
   hostOverflowCapResetEntry,
@@ -50,9 +51,11 @@ interface StatusContext {
 }
 
 const CONTINUATION_RETRY_MS = 50;
+const RUNTIME_PERSIST_INTERVAL_MS = 60_000;
 
 export const __testHooks = {
   continuationRetryMs: CONTINUATION_RETRY_MS,
+  runtimePersistIntervalMs: RUNTIME_PERSIST_INTERVAL_MS,
 };
 
 export default function (pi: ExtensionAPI): void {
@@ -77,6 +80,8 @@ export default function (pi: ExtensionAPI): void {
   let recoveryState: GoalRecoveryMachineState = createGoalRecoveryMachine();
   let hostOverflowRecoveryInProgress = false;
   let hostOverflowCapNeedsUserReset = false;
+  let lastPersistedGoal: ThreadGoal | null = null;
+  let lastRuntimePersistAt: number | null = null;
 
   const goalForDisplay = (): ThreadGoal | null =>
     goalWithLiveUsage(goal, accounting.activeGoalId, accounting.lastAccountedAt);
@@ -295,13 +300,8 @@ export default function (pi: ExtensionAPI): void {
     return true;
   };
 
-  const persistGoal = (nextGoal: ThreadGoal, source: GoalEntrySource): boolean => {
-    if (goal && goalsEquivalent(goal, nextGoal)) {
-      return false;
-    }
-
+  const applyGoalSideEffects = (nextGoal: ThreadGoal): void => {
     const previousGoalId = goal?.goalId ?? null;
-    goal = nextGoal;
     if (previousGoalId !== nextGoal.goalId) {
       accounting.budgetWarningSentFor = null;
       clearStoppedRuntimeState();
@@ -318,13 +318,52 @@ export default function (pi: ExtensionAPI): void {
     if (nextGoal.status !== "budgetLimited") {
       accounting.budgetWarningSentFor = null;
     }
-    pi.appendEntry(CUSTOM_ENTRY_TYPE, setEntry(nextGoal, source));
+  };
+
+  const setGoalInMemory = (nextGoal: ThreadGoal): void => {
+    applyGoalSideEffects(nextGoal);
+    goal = nextGoal;
+  };
+
+  const flushGoalPersistence = (source: GoalEntrySource): boolean => {
+    if (!goal) {
+      return false;
+    }
+    if (lastPersistedGoal && goalsEquivalent(goal, lastPersistedGoal)) {
+      return false;
+    }
+
+    pi.appendEntry(CUSTOM_ENTRY_TYPE, setEntry(goal, source));
+    lastPersistedGoal = cloneGoal(goal);
+    lastRuntimePersistAt = Date.now();
     return true;
+  };
+
+  const maybeFlushRuntimePersistence = (source: GoalEntrySource): void => {
+    if (!goal || goal.status !== "active") {
+      return;
+    }
+    const now = Date.now();
+    if (lastRuntimePersistAt !== null && now - lastRuntimePersistAt < RUNTIME_PERSIST_INTERVAL_MS) {
+      return;
+    }
+    flushGoalPersistence(source);
+  };
+
+  const persistGoal = (nextGoal: ThreadGoal, source: GoalEntrySource): boolean => {
+    if (goal && goalsEquivalent(goal, nextGoal)) {
+      return false;
+    }
+
+    setGoalInMemory(nextGoal);
+    return flushGoalPersistence(source);
   };
 
   const persistClear = (source: GoalEntrySource): void => {
     const clearedGoalId = goal?.goalId ?? null;
     goal = null;
+    lastPersistedGoal = null;
+    lastRuntimePersistAt = null;
     clearStoppedRuntimeState();
     stopStatusRefresh();
     pi.appendEntry(CUSTOM_ENTRY_TYPE, clearEntry(clearedGoalId, source));
@@ -373,6 +412,8 @@ export default function (pi: ExtensionAPI): void {
     const previousGoalId = goal?.goalId ?? null;
     const branch = ctx.sessionManager.getBranch();
     goal = reconstructGoal(branch).goal;
+    lastPersistedGoal = goal ? cloneGoal(goal) : null;
+    lastRuntimePersistAt = null;
     hostOverflowCapNeedsUserReset = reconstructHostOverflowCapNeedsUserReset(branch);
     clearContinuationState();
     if (goal?.status !== "active") {
@@ -386,8 +427,9 @@ export default function (pi: ExtensionAPI): void {
 
   const goalAccounting = createGoalAccounting({
     getGoal: () => goal,
+    setGoal: setGoalInMemory,
     getAccounting: () => accounting,
-    persistGoal,
+    flushGoalPersistence,
     refreshUi,
     sendMessage: pi.sendMessage.bind(pi),
   });
@@ -705,6 +747,7 @@ export default function (pi: ExtensionAPI): void {
     }
 
     goalAccounting.accountProgress(ctx, true, 0, true);
+    maybeFlushRuntimePersistence("runtime");
   });
 
   pi.on("turn_end", async (_event, ctx) => {
@@ -714,6 +757,7 @@ export default function (pi: ExtensionAPI): void {
 
     const completedTurnTokens = assistantTurnTokens(_event.message);
     goalAccounting.accountProgress(ctx, true, completedTurnTokens);
+    flushGoalPersistence("runtime");
     if (isAbortedAssistantMessage(_event.message)) {
       pauseForAbort(ctx);
       return;
@@ -741,6 +785,7 @@ export default function (pi: ExtensionAPI): void {
       return sum + assistantTurnTokens(message);
     }, 0);
     goalAccounting.accountProgress(ctx, false, abortedTurnTokens, true);
+    flushGoalPersistence("runtime");
     if (abortedMessages.length > 0) {
       pauseForAbort(ctx);
       return;
@@ -772,6 +817,7 @@ export default function (pi: ExtensionAPI): void {
     }
 
     goalAccounting.accountProgress(ctx, false, 0, true);
+    flushGoalPersistence("runtime");
   });
 
   pi.on("session_compact", async (_event, ctx) => {
@@ -779,9 +825,7 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
 
-    if (goal) {
-      persistGoal(goal, "runtime");
-    }
+    flushGoalPersistence("runtime");
     recoveryRuntime.onSessionCompact();
     refreshUi(ctx);
     if (!hostOverflowRecoveryInProgress) {
@@ -797,6 +841,7 @@ export default function (pi: ExtensionAPI): void {
     clearStaleQueuedGoalWorkTerminalEvents();
 
     goalAccounting.accountProgress(ctx, false, 0, true);
+    flushGoalPersistence("runtime");
     clearContinuationTimer();
     if (hasPendingRecoveryAttention()) {
       pauseForPendingRecoveryShutdown(ctx);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1620,6 +1620,56 @@ test("session_shutdown flushes pending runtime usage", async () => {
   }
 });
 
+test("runtime persistence interval flush appends one entry then coalesces until turn_end", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const goalId = harness.snapshot().goal?.goalId;
+    assert.ok(goalId);
+    const initialSetEntries = countGoalSetEntries(harness.entries, goalId);
+    assert.equal(initialSetEntries, 1);
+
+    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+
+    now += __testHooks.runtimePersistIntervalMs + 1_000;
+    await emitToolExecutionEnd(harness);
+
+    assert.equal(countGoalSetEntries(harness.entries, goalId), initialSetEntries + 1);
+    const afterIntervalFlush = harness.snapshot().goal;
+    assert.equal(
+      afterIntervalFlush?.usage.activeSeconds,
+      Math.floor((__testHooks.runtimePersistIntervalMs + 1_000) / 1_000),
+    );
+
+    for (let index = 0; index < 3; index += 1) {
+      now += 2_000;
+      await emitToolExecutionEnd(harness);
+    }
+
+    assert.equal(countGoalSetEntries(harness.entries, goalId), initialSetEntries + 1);
+
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("toolUse", { input: 10, output: 2 }),
+      toolResults: [],
+    });
+
+    assert.equal(countGoalSetEntries(harness.entries, goalId), initialSetEntries + 2);
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.usage.tokensUsed, 12);
+    assert.equal(
+      goal?.usage.activeSeconds,
+      Math.floor((__testHooks.runtimePersistIntervalMs + 1_000 + 6_000) / 1_000),
+    );
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
 test("reconstructGoal uses the latest snapshot across dense legacy and coalesced entries", () => {
   const goal = createThreadGoal("ship it", 100);
   const denseEntries = Array.from({ length: 20 }, (_, index) => ({
@@ -1679,6 +1729,52 @@ test("compaction with unchanged paused goal appends no new entry", async () => {
   assert.equal(harness.entries.length, entryCountAfterPause);
   assert.equal(harness.snapshot().goal?.status, "paused");
   assert.equal(countGoalSetEntries(harness.entries, goalId), 2);
+});
+
+test("compaction with unchanged budgetLimited goal appends no new entry", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runTool("create_goal", { objective: "ship it", token_budget: 10 });
+    const goalId = harness.snapshot().goal?.goalId;
+    assert.ok(goalId);
+
+    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("stop", { input: 8, output: 3 }),
+      toolResults: [],
+    });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.status, "budgetLimited");
+    assert.equal(goal?.usage.tokensUsed, 11);
+    const entryCountAfterBudgetLimit = harness.entries.length;
+    const setEntriesAfterBudgetLimit = countGoalSetEntries(harness.entries, goalId);
+    assert.equal(setEntriesAfterBudgetLimit, 2);
+
+    await harness.emit("session_before_compact", {
+      type: "session_before_compact",
+      preparation: {},
+      branchEntries: [],
+      signal: new AbortController().signal,
+    });
+    await harness.emit("session_compact", {
+      type: "session_compact",
+      compactionEntry: {},
+      fromExtension: false,
+    });
+
+    assert.equal(harness.entries.length, entryCountAfterBudgetLimit);
+    assert.equal(harness.snapshot().goal?.status, "budgetLimited");
+    assert.equal(countGoalSetEntries(harness.entries, goalId), setEntriesAfterBudgetLimit);
+    assert.equal(harness.snapshot().goal?.usage.tokensUsed, 11);
+  } finally {
+    Date.now = originalNow;
+  }
 });
 
 test("create_goal replaces a completed goal", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -319,6 +319,32 @@ function flushContinuationScheduler(): void {
   mock.timers.tick(__testHooks.continuationRetryMs);
 }
 
+function countGoalSetEntries(
+  entries: ReturnType<ExtensionCommandContext["sessionManager"]["getBranch"]>,
+  goalId?: string,
+): number {
+  return entries.filter((entry) => {
+    return (
+      entry.type === "custom" &&
+      entry.customType === CUSTOM_ENTRY_TYPE &&
+      isGoalCustomEntry(entry.data) &&
+      entry.data.kind === "set" &&
+      (goalId === undefined || entry.data.goal.goalId === goalId)
+    );
+  }).length;
+}
+
+async function emitToolExecutionEnd(harness: ReturnType<typeof createRuntimeHarness>): Promise<void> {
+  await harness.emit("tool_execution_end", {
+    type: "tool_execution_end",
+    toolCallId: "tool-call",
+    toolName: "bash",
+    args: {},
+    result: {},
+    isError: false,
+  });
+}
+
 function queuedCustomMessage(sent: SentMessage, timestamp = 1) {
   return {
     role: "custom",
@@ -1510,6 +1536,149 @@ test("compaction after complete does not append duplicate runtime entries", asyn
 
   assert.equal(harness.entries.length, entryCountAfterComplete);
   assert.equal(harness.snapshot().goal?.status, "complete");
+});
+
+test("repeated tool_execution_end events coalesce runtime persistence when usage is unchanged", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const goalId = harness.snapshot().goal?.goalId;
+    assert.ok(goalId);
+    const initialSetEntries = countGoalSetEntries(harness.entries, goalId);
+    assert.equal(initialSetEntries, 1);
+
+    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+
+    for (let index = 0; index < 5; index += 1) {
+      now += 2_000;
+      await emitToolExecutionEnd(harness);
+    }
+
+    assert.equal(countGoalSetEntries(harness.entries, goalId), initialSetEntries);
+    assert.match(harness.footerStatuses.at(-1) ?? "", /Pursuing goal/);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("turn_end flushes coalesced runtime usage to session entries", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const goalId = harness.snapshot().goal?.goalId;
+    assert.ok(goalId);
+
+    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+    now += 5_000;
+    await emitToolExecutionEnd(harness);
+    assert.equal(countGoalSetEntries(harness.entries, goalId), 1);
+
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("toolUse", { input: 10, output: 2 }),
+      toolResults: [],
+    });
+
+    assert.equal(countGoalSetEntries(harness.entries, goalId), 2);
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.usage.tokensUsed, 12);
+    assert.equal(goal?.usage.activeSeconds, 5);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("session_shutdown flushes pending runtime usage", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const goalId = harness.snapshot().goal?.goalId;
+    assert.ok(goalId);
+
+    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+    now += 4_000;
+    await emitToolExecutionEnd(harness);
+    assert.equal(countGoalSetEntries(harness.entries, goalId), 1);
+
+    await harness.emit("session_shutdown", { type: "session_shutdown" });
+
+    assert.equal(countGoalSetEntries(harness.entries, goalId), 2);
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.usage.activeSeconds, 4);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("reconstructGoal uses the latest snapshot across dense legacy and coalesced entries", () => {
+  const goal = createThreadGoal("ship it", 100);
+  const denseEntries = Array.from({ length: 20 }, (_, index) => ({
+    type: "custom" as const,
+    customType: CUSTOM_ENTRY_TYPE,
+    data: setEntry(
+      {
+        ...goal,
+        usage: { tokensUsed: index + 1, activeSeconds: index },
+        updatedAt: goal.updatedAt + index,
+      },
+      "runtime",
+      goal.updatedAt + index,
+    ),
+  }));
+  const coalescedEntry = {
+    type: "custom" as const,
+    customType: CUSTOM_ENTRY_TYPE,
+    data: setEntry(
+      {
+        ...goal,
+        usage: { tokensUsed: 99, activeSeconds: 42 },
+        status: "active",
+        updatedAt: goal.updatedAt + 100,
+      },
+      "runtime",
+      goal.updatedAt + 100,
+    ),
+  };
+
+  const reconstructed = reconstructGoal([...denseEntries, coalescedEntry]).goal;
+  assert.ok(reconstructed);
+  assert.equal(reconstructed.usage.tokensUsed, 99);
+  assert.equal(reconstructed.usage.activeSeconds, 42);
+});
+
+test("compaction with unchanged paused goal appends no new entry", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  await harness.runCommand("pause");
+  const goalId = harness.snapshot().goal?.goalId;
+  assert.ok(goalId);
+  const entryCountAfterPause = harness.entries.length;
+
+  await harness.emit("session_before_compact", {
+    type: "session_before_compact",
+    preparation: {},
+    branchEntries: [],
+    signal: new AbortController().signal,
+  });
+  await harness.emit("session_compact", {
+    type: "session_compact",
+    compactionEntry: {},
+    fromExtension: false,
+  });
+
+  assert.equal(harness.entries.length, entryCountAfterPause);
+  assert.equal(harness.snapshot().goal?.status, "paused");
+  assert.equal(countGoalSetEntries(harness.entries, goalId), 2);
 });
 
 test("create_goal replaces a completed goal", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1752,9 +1752,12 @@ test("compaction with unchanged budgetLimited goal appends no new entry", async 
     const goal = harness.snapshot().goal;
     assert.equal(goal?.status, "budgetLimited");
     assert.equal(goal?.usage.tokensUsed, 11);
+    const activeSecondsAtBudgetLimit = goal?.usage.activeSeconds ?? 0;
     const entryCountAfterBudgetLimit = harness.entries.length;
     const setEntriesAfterBudgetLimit = countGoalSetEntries(harness.entries, goalId);
     assert.equal(setEntriesAfterBudgetLimit, 2);
+
+    now += 60_000;
 
     await harness.emit("session_before_compact", {
       type: "session_before_compact",
@@ -1772,6 +1775,47 @@ test("compaction with unchanged budgetLimited goal appends no new entry", async 
     assert.equal(harness.snapshot().goal?.status, "budgetLimited");
     assert.equal(countGoalSetEntries(harness.entries, goalId), setEntriesAfterBudgetLimit);
     assert.equal(harness.snapshot().goal?.usage.tokensUsed, 11);
+    assert.equal(harness.snapshot().goal?.usage.activeSeconds, activeSecondsAtBudgetLimit);
+  } finally {
+    Date.now = originalNow;
+  }
+});
+
+test("session_shutdown with unchanged budgetLimited goal appends no new entry", async () => {
+  const originalNow = Date.now;
+  let now = 1_000;
+  Date.now = () => now;
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runTool("create_goal", { objective: "ship it", token_budget: 10 });
+    const goalId = harness.snapshot().goal?.goalId;
+    assert.ok(goalId);
+
+    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex: 0,
+      message: assistantMessage("stop", { input: 8, output: 3 }),
+      toolResults: [],
+    });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.status, "budgetLimited");
+    assert.equal(goal?.usage.tokensUsed, 11);
+    const activeSecondsAtBudgetLimit = goal?.usage.activeSeconds ?? 0;
+    const entryCountAfterBudgetLimit = harness.entries.length;
+    const setEntriesAfterBudgetLimit = countGoalSetEntries(harness.entries, goalId);
+    assert.equal(setEntriesAfterBudgetLimit, 2);
+
+    now += 60_000;
+
+    await harness.emit("session_shutdown", { type: "session_shutdown" });
+
+    assert.equal(harness.entries.length, entryCountAfterBudgetLimit);
+    assert.equal(harness.snapshot().goal?.status, "budgetLimited");
+    assert.equal(countGoalSetEntries(harness.entries, goalId), setEntriesAfterBudgetLimit);
+    assert.equal(harness.snapshot().goal?.usage.tokensUsed, 11);
+    assert.equal(harness.snapshot().goal?.usage.activeSeconds, activeSecondsAtBudgetLimit);
   } finally {
     Date.now = originalNow;
   }


### PR DESCRIPTION
## Summary
- Separates in-memory goal usage accounting from session custom-entry writes so repeated `tool_execution_end` events no longer append a full snapshot on every tool completion when status and usage are unchanged.
- Flushes meaningful pending usage at turn boundaries, shutdown, compaction, budget crossings, and a bounded 60s interval during long tool-heavy runs.
- Keeps live footer/status responsive via in-memory accounting and `goalWithLiveUsage`, while preserving reconstruction from both legacy dense entries and new coalesced entries.

Closes #8.

## Test plan
- [x] `npm run verify` (150 tests pass)
- [x] Repeated `tool_execution_end` events do not append extra set entries when usage is only updated in memory
- [x] `turn_end` and `session_shutdown` flush coalesced runtime usage to session entries
- [x] Compaction with unchanged complete/paused goals appends no duplicate entries
- [x] `reconstructGoal` works across dense legacy and coalesced entry sequences


Made with [Cursor](https://cursor.com)