### PR TITLE
Replace cast-heavy queued-message boundary with explicit unions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,10 @@ import {
 import { compactContinuationPrompt, continuationGoalIdFromPrompt } from "./prompts.js";
 import { isCommandResumeQueuedGoalMessage } from "./queued-goal-messages.js";
 import {
-  dedupeActiveGoalContinuations,
+  applyQueuedGoalProviderContextRewrites,
   extensionQueuedGoalWorkMessageId,
   extensionQueuedGoalWorkMessageIdForRuntime,
   pendingStaleQueuedGoalWorkIdsFromMessages,
-  rewriteStaleQueuedGoalContextMessage,
 } from "./queued-goal-work.js";
 import {
   createGoalRecoveryMachine,
@@ -627,28 +626,11 @@ export default function (pi: ExtensionAPI): void {
   });
 
   pi.on("context", async (event, ctx): Promise<{ messages: typeof event.messages } | undefined> => {
-    let changed = false;
-    let messages: typeof event.messages = event.messages.map((message) => {
-      const queuedGoalId = queuedGoalWorkMessageIdForRuntime(message);
-      if (queuedGoalId === null) {
-        return message;
-      }
-
-      if (goal?.goalId === queuedGoalId && goal.status === "active") {
-        return message;
-      }
-
-      changed = true;
-      return rewriteStaleQueuedGoalContextMessage(message, queuedGoalId, goal) as typeof message;
+    const { messages, changed } = applyQueuedGoalProviderContextRewrites(event.messages, {
+      goal,
+      resolveStaleQueuedGoalWorkMessageId: queuedGoalWorkMessageIdForRuntime,
+      resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
     });
-
-    if (goal?.status === "active") {
-      const deduped = dedupeActiveGoalContinuations(messages, goal, extensionQueuedGoalWorkMessageId);
-      if (deduped.changed) {
-        changed = true;
-        messages = deduped.messages as typeof messages;
-      }
-    }
 
     if (startedStaleQueuedGoalWorkThisTurn && !startedRunnableWorkThisTurn) {
       if (!staleQueuedGoalWorkTurnActive) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   extensionQueuedGoalWorkMessageId,
   extensionQueuedGoalWorkMessageIdForRuntime,
   pendingStaleQueuedGoalWorkIdsFromMessages,
-  staleGoalContinuationContextMessage,
+  rewriteStaleQueuedGoalContextMessage,
 } from "./queued-goal-work.js";
 import {
   createGoalRecoveryMachine,
@@ -638,14 +638,14 @@ export default function (pi: ExtensionAPI): void {
       }
 
       changed = true;
-      return staleGoalContinuationContextMessage(message, queuedGoalId, goal);
+      return rewriteStaleQueuedGoalContextMessage(message, queuedGoalId, goal);
     });
 
     if (goal?.status === "active") {
       const deduped = dedupeActiveGoalContinuations(messages, goal, extensionQueuedGoalWorkMessageId);
       if (deduped.changed) {
         changed = true;
-        messages = deduped.messages;
+        messages = deduped.messages as typeof messages;
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   isToolUseAssistantMessage,
 } from "./goal-accounting.js";
 import { compactContinuationPrompt, continuationGoalIdFromPrompt } from "./prompts.js";
+import { isCommandResumeQueuedGoalMessage } from "./queued-goal-messages.js";
 import {
   dedupeActiveGoalContinuations,
   extensionQueuedGoalWorkMessageId,
@@ -638,7 +639,7 @@ export default function (pi: ExtensionAPI): void {
       }
 
       changed = true;
-      return rewriteStaleQueuedGoalContextMessage(message, queuedGoalId, goal);
+      return rewriteStaleQueuedGoalContextMessage(message, queuedGoalId, goal) as typeof message;
     });
 
     if (goal?.status === "active") {
@@ -717,13 +718,7 @@ export default function (pi: ExtensionAPI): void {
     clearContinuationStateFor(queuedGoalId);
     if (isCurrentActiveGoalId(queuedGoalId)) {
       startedRunnableWorkThisTurn = true;
-      const details = (event.message as { details?: unknown }).details;
-      if (
-        details !== null &&
-        typeof details === "object" &&
-        "kind" in details &&
-        (details as { kind?: unknown }).kind === "command_resume"
-      ) {
+      if (isCommandResumeQueuedGoalMessage(event.message)) {
         resetErrorRecovery();
       }
       return;

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -1,0 +1,162 @@
+import { CUSTOM_ENTRY_TYPE, type GoalStatus } from "./types.js";
+
+export type GoalQueuedWorkKind = "continuation" | "command_start" | "command_resume";
+
+export interface ActiveGoalQueuedDetails {
+  kind: GoalQueuedWorkKind;
+  goalId: string;
+}
+
+export interface SupersededContinuationDetails {
+  kind: "superseded_continuation";
+  goalId: string;
+}
+
+export interface StaleContinuationDetails {
+  kind: "stale_continuation";
+  goalId: string;
+  currentGoalId: string | null;
+  currentStatus: GoalStatus | null;
+}
+
+export interface QueuedGoalTextPart {
+  readonly type: "text";
+  readonly text: string;
+}
+
+export type QueuedGoalUserContent = QueuedGoalTextPart[];
+
+/** Minimal shape shared by provider-context messages this extension may rewrite. */
+export interface QueuedGoalContextCarrier {
+  role: string;
+  customType?: string;
+  content?: unknown;
+  display?: boolean;
+  details?: unknown;
+  timestamp?: number;
+}
+
+export interface QueuedGoalCustomMessage extends QueuedGoalContextCarrier {
+  role: "custom";
+  customType: string;
+  content: string | QueuedGoalUserContent;
+  display: boolean;
+  details?:
+    | ActiveGoalQueuedDetails
+    | SupersededContinuationDetails
+    | StaleContinuationDetails
+    | Record<string, unknown>;
+}
+
+export interface QueuedGoalUserMessage extends QueuedGoalContextCarrier {
+  role: "user";
+  content: QueuedGoalUserContent;
+}
+
+export type QueuedGoalWorkSourceMessage = QueuedGoalCustomMessage | QueuedGoalUserMessage;
+
+export interface SupersededQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
+  content: string;
+  display: false;
+  details: SupersededContinuationDetails;
+}
+
+export interface SupersededQueuedGoalUserMessage extends QueuedGoalUserMessage {
+  content: QueuedGoalTextPart[];
+}
+
+export interface StaleQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
+  content: string;
+  display: false;
+  details: StaleContinuationDetails;
+}
+
+export interface StaleQueuedGoalUserMessage extends QueuedGoalUserMessage {
+  content: QueuedGoalTextPart[];
+}
+
+export interface RefreshedActiveQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
+  content: string;
+  display: false;
+}
+
+export interface RefreshedActiveQueuedGoalUserMessage extends QueuedGoalUserMessage {
+  content: QueuedGoalTextPart[];
+}
+
+export type RewrittenQueuedGoalWorkMessage =
+  | SupersededQueuedGoalCustomMessage
+  | SupersededQueuedGoalUserMessage
+  | StaleQueuedGoalCustomMessage
+  | StaleQueuedGoalUserMessage
+  | RefreshedActiveQueuedGoalCustomMessage
+  | RefreshedActiveQueuedGoalUserMessage;
+
+export function isGoalCustomMessage(message: QueuedGoalContextCarrier): message is QueuedGoalCustomMessage {
+  return message.role === "custom" && typeof message.customType === "string";
+}
+
+export function isQueuedGoalWorkSourceMessage(
+  message: QueuedGoalContextCarrier,
+): message is QueuedGoalWorkSourceMessage {
+  return message.role === "user" || isGoalCustomMessage(message);
+}
+
+export function userContentFromUnknown(content: unknown): QueuedGoalUserContent {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  const parts: QueuedGoalTextPart[] = [];
+  for (const part of content) {
+    if (part === null || typeof part !== "object") {
+      continue;
+    }
+    const candidate = part as { type?: unknown; text?: unknown };
+    if (candidate.type === "text" && typeof candidate.text === "string") {
+      parts.push({ type: "text", text: candidate.text });
+    }
+  }
+  return parts;
+}
+
+/** Normalizes external provider-context messages once at the package boundary. */
+export function toQueuedGoalWorkSource(
+  message: QueuedGoalContextCarrier,
+): QueuedGoalWorkSourceMessage | null {
+  switch (message.role) {
+    case "user":
+      return {
+        ...message,
+        role: "user",
+        content: userContentFromUnknown(message.content),
+      };
+    case "custom":
+      if (!isGoalCustomMessage(message)) {
+        return null;
+      }
+      return {
+        ...message,
+        role: "custom",
+        customType: message.customType,
+        content:
+          typeof message.content === "string" || Array.isArray(message.content)
+            ? message.content
+            : "",
+        display: message.display ?? false,
+      };
+    default:
+      return null;
+  }
+}
+
+export function isPiCodexGoalCustomMessage(message: QueuedGoalContextCarrier): message is QueuedGoalCustomMessage {
+  return isGoalCustomMessage(message) && message.customType === CUSTOM_ENTRY_TYPE;
+}
+
+export function applyQueuedGoalRewrite<C extends QueuedGoalContextCarrier>(
+  carrier: C,
+  rewritten: RewrittenQueuedGoalWorkMessage,
+): C {
+  return { ...carrier, ...rewritten };
+}

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -51,11 +51,6 @@ export interface QueuedGoalCustomMessage extends QueuedGoalContextCarrier {
   customType: string;
   content: string | QueuedGoalUserContent;
   display: boolean;
-  details?:
-    | ActiveGoalQueuedDetails
-    | SupersededContinuationDetails
-    | StaleContinuationDetails
-    | Record<string, unknown>;
 }
 
 export interface QueuedGoalUserMessage extends QueuedGoalContextCarrier {
@@ -189,7 +184,7 @@ export function toQueuedGoalWorkSource(
         display: message.display ?? false,
       };
       if (message.details !== undefined) {
-        normalized.details = message.details as NonNullable<QueuedGoalCustomMessage["details"]>;
+        normalized.details = message.details;
       }
       return normalized;
     }

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -1,6 +1,6 @@
 import { CUSTOM_ENTRY_TYPE } from "./types.js";
 
-export type GoalQueuedWorkKind = "continuation" | "command_start" | "command_resume";
+type GoalQueuedWorkKind = "continuation" | "command_start" | "command_resume";
 
 export interface ActiveGoalQueuedDetails {
   kind: GoalQueuedWorkKind;

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -1,4 +1,4 @@
-import type { GoalStatus } from "./types.js";
+import { CUSTOM_ENTRY_TYPE, type GoalStatus } from "./types.js";
 
 export type GoalQueuedWorkKind = "continuation" | "command_start" | "command_resume";
 
@@ -48,7 +48,7 @@ export interface QueuedGoalContextCarrier {
 
 export interface QueuedGoalCustomMessage extends QueuedGoalContextCarrier {
   role: "custom";
-  customType: string;
+  customType: typeof CUSTOM_ENTRY_TYPE;
   content: string | QueuedGoalUserContent;
   display: boolean;
 }
@@ -100,13 +100,13 @@ export type RewrittenQueuedGoalWorkMessage =
 /** Role/customType only — does not prove normalized content or display. */
 interface QueuedGoalCustomRoleCarrier {
   role: "custom";
-  customType: string;
+  customType: typeof CUSTOM_ENTRY_TYPE;
 }
 
 function isQueuedGoalCustomRole(
   message: QueuedGoalContextCarrier,
 ): message is QueuedGoalContextCarrier & QueuedGoalCustomRoleCarrier {
-  return message.role === "custom" && typeof message.customType === "string";
+  return message.role === "custom" && message.customType === CUSTOM_ENTRY_TYPE;
 }
 
 export function userContentFromUnknown(content: unknown): QueuedGoalUserContent {

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -164,17 +164,6 @@ export function toQueuedGoalContextCarrier(message: QueuedGoalContextInput): Que
   return carrier;
 }
 
-/** Merges a rewritten queued-goal carrier onto the original provider-context message. */
-export function mergeProviderContextMessage<TMessage extends QueuedGoalContextInput>(
-  original: TMessage,
-  rewritten: QueuedGoalContextCarrier,
-): TMessage {
-  return {
-    ...original,
-    ...rewritten,
-  } as TMessage;
-}
-
 /** Normalizes external provider-context messages once at the package boundary. */
 export function toQueuedGoalWorkSource(
   message: QueuedGoalContextCarrier,

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -154,9 +154,19 @@ export function isPiCodexGoalCustomMessage(message: QueuedGoalContextCarrier): m
   return isGoalCustomMessage(message) && message.customType === CUSTOM_ENTRY_TYPE;
 }
 
-export function applyQueuedGoalRewrite<C extends QueuedGoalContextCarrier>(
-  carrier: C,
-  rewritten: RewrittenQueuedGoalWorkMessage,
-): C {
-  return { ...carrier, ...rewritten };
+export function isActiveGoalQueuedDetails(details: unknown): details is ActiveGoalQueuedDetails {
+  if (details === null || typeof details !== "object") {
+    return false;
+  }
+
+  const candidate = details as { kind?: unknown; goalId?: unknown };
+  const kind = candidate.kind;
+  return (
+    (kind === "continuation" || kind === "command_start" || kind === "command_resume") &&
+    typeof candidate.goalId === "string"
+  );
+}
+
+export function isCommandResumeQueuedGoalMessage(message: QueuedGoalContextCarrier): boolean {
+  return isGoalCustomMessage(message) && isActiveGoalQueuedDetails(message.details) && message.details.kind === "command_resume";
 }

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -127,7 +127,7 @@ export function userContentFromUnknown(content: unknown): QueuedGoalUserContent 
   return parts;
 }
 
-export function customContentFromUnknown(content: unknown): string | QueuedGoalUserContent {
+function customContentFromUnknown(content: unknown): string | QueuedGoalUserContent {
   if (typeof content === "string") {
     return content;
   }

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_ENTRY_TYPE, type GoalStatus } from "./types.js";
+import type { GoalStatus } from "./types.js";
 
 export type GoalQueuedWorkKind = "continuation" | "command_start" | "command_resume";
 
@@ -102,14 +102,16 @@ export type RewrittenQueuedGoalWorkMessage =
   | RefreshedActiveQueuedGoalCustomMessage
   | RefreshedActiveQueuedGoalUserMessage;
 
-export function isGoalCustomMessage(message: QueuedGoalContextCarrier): message is QueuedGoalCustomMessage {
-  return message.role === "custom" && typeof message.customType === "string";
+/** Role/customType only — does not prove normalized content or display. */
+interface QueuedGoalCustomRoleCarrier {
+  role: "custom";
+  customType: string;
 }
 
-export function isQueuedGoalWorkSourceMessage(
+function isQueuedGoalCustomRole(
   message: QueuedGoalContextCarrier,
-): message is QueuedGoalWorkSourceMessage {
-  return message.role === "user" || isGoalCustomMessage(message);
+): message is QueuedGoalContextCarrier & QueuedGoalCustomRoleCarrier {
+  return message.role === "custom" && typeof message.customType === "string";
 }
 
 export function userContentFromUnknown(content: unknown): QueuedGoalUserContent {
@@ -175,24 +177,25 @@ export function toQueuedGoalWorkSource(
         role: "user",
         content: userContentFromUnknown(message.content),
       };
-    case "custom":
-      if (!isGoalCustomMessage(message)) {
+    case "custom": {
+      if (!isQueuedGoalCustomRole(message)) {
         return null;
       }
-      return {
-        ...message,
+      const normalized: QueuedGoalCustomMessage = {
         role: "custom",
         customType: message.customType,
+        timestamp: message.timestamp,
         content: customContentFromUnknown(message.content),
         display: message.display ?? false,
       };
+      if (message.details !== undefined) {
+        normalized.details = message.details as NonNullable<QueuedGoalCustomMessage["details"]>;
+      }
+      return normalized;
+    }
     default:
       return null;
   }
-}
-
-export function isPiCodexGoalCustomMessage(message: QueuedGoalContextCarrier): message is QueuedGoalCustomMessage {
-  return isGoalCustomMessage(message) && message.customType === CUSTOM_ENTRY_TYPE;
 }
 
 export function isActiveGoalQueuedDetails(details: unknown): details is ActiveGoalQueuedDetails {
@@ -209,5 +212,9 @@ export function isActiveGoalQueuedDetails(details: unknown): details is ActiveGo
 }
 
 export function isCommandResumeQueuedGoalMessage(message: QueuedGoalContextCarrier): boolean {
-  return isGoalCustomMessage(message) && isActiveGoalQueuedDetails(message.details) && message.details.kind === "command_resume";
+  return (
+    isQueuedGoalCustomRole(message) &&
+    isActiveGoalQueuedDetails(message.details) &&
+    message.details.kind === "command_resume"
+  );
 }

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -26,14 +26,24 @@ export interface QueuedGoalTextPart {
 
 export type QueuedGoalUserContent = QueuedGoalTextPart[];
 
-/** Minimal shape shared by provider-context messages this extension may rewrite. */
-export interface QueuedGoalContextCarrier {
+/** External provider-context message shape before normalization. */
+export interface QueuedGoalContextInput {
   role: string;
   customType?: string;
   content?: unknown;
   display?: boolean;
   details?: unknown;
   timestamp?: number;
+}
+
+/** Normalized provider-context carrier with required runtime fields. */
+export interface QueuedGoalContextCarrier {
+  role: string;
+  timestamp: number;
+  customType?: string;
+  content?: unknown;
+  display?: boolean;
+  details?: unknown;
 }
 
 export interface QueuedGoalCustomMessage extends QueuedGoalContextCarrier {
@@ -120,6 +130,51 @@ export function userContentFromUnknown(content: unknown): QueuedGoalUserContent 
   return parts;
 }
 
+export function customContentFromUnknown(content: unknown): string | QueuedGoalUserContent {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  const normalized = userContentFromUnknown(content);
+  return normalized.length > 0 ? normalized : "";
+}
+
+/** Normalizes external provider-context messages once at the package boundary. */
+export function toQueuedGoalContextCarrier(message: QueuedGoalContextInput): QueuedGoalContextCarrier | null {
+  if (typeof message.timestamp !== "number") {
+    return null;
+  }
+
+  const carrier: QueuedGoalContextCarrier = {
+    role: message.role,
+    timestamp: message.timestamp,
+  };
+  if (message.customType !== undefined) {
+    carrier.customType = message.customType;
+  }
+  if (message.content !== undefined) {
+    carrier.content = message.content;
+  }
+  if (message.display !== undefined) {
+    carrier.display = message.display;
+  }
+  if (message.details !== undefined) {
+    carrier.details = message.details;
+  }
+  return carrier;
+}
+
+/** Merges a rewritten queued-goal carrier onto the original provider-context message. */
+export function mergeProviderContextMessage<TMessage extends QueuedGoalContextInput>(
+  original: TMessage,
+  rewritten: QueuedGoalContextCarrier,
+): TMessage {
+  return {
+    ...original,
+    ...rewritten,
+  } as TMessage;
+}
+
 /** Normalizes external provider-context messages once at the package boundary. */
 export function toQueuedGoalWorkSource(
   message: QueuedGoalContextCarrier,
@@ -139,10 +194,7 @@ export function toQueuedGoalWorkSource(
         ...message,
         role: "custom",
         customType: message.customType,
-        content:
-          typeof message.content === "string" || Array.isArray(message.content)
-            ? message.content
-            : "",
+        content: customContentFromUnknown(message.content),
         display: message.display ?? false,
       };
     default:

--- a/src/queued-goal-messages.ts
+++ b/src/queued-goal-messages.ts
@@ -1,22 +1,10 @@
-import { CUSTOM_ENTRY_TYPE, type GoalStatus } from "./types.js";
+import { CUSTOM_ENTRY_TYPE } from "./types.js";
 
 export type GoalQueuedWorkKind = "continuation" | "command_start" | "command_resume";
 
 export interface ActiveGoalQueuedDetails {
   kind: GoalQueuedWorkKind;
   goalId: string;
-}
-
-export interface SupersededContinuationDetails {
-  kind: "superseded_continuation";
-  goalId: string;
-}
-
-export interface StaleContinuationDetails {
-  kind: "stale_continuation";
-  goalId: string;
-  currentGoalId: string | null;
-  currentStatus: GoalStatus | null;
 }
 
 export interface QueuedGoalTextPart {
@@ -59,43 +47,6 @@ export interface QueuedGoalUserMessage extends QueuedGoalContextCarrier {
 }
 
 export type QueuedGoalWorkSourceMessage = QueuedGoalCustomMessage | QueuedGoalUserMessage;
-
-export interface SupersededQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
-  content: string;
-  display: false;
-  details: SupersededContinuationDetails;
-}
-
-export interface SupersededQueuedGoalUserMessage extends QueuedGoalUserMessage {
-  content: QueuedGoalTextPart[];
-}
-
-export interface StaleQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
-  content: string;
-  display: false;
-  details: StaleContinuationDetails;
-}
-
-export interface StaleQueuedGoalUserMessage extends QueuedGoalUserMessage {
-  content: QueuedGoalTextPart[];
-}
-
-export interface RefreshedActiveQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
-  content: string;
-  display: false;
-}
-
-export interface RefreshedActiveQueuedGoalUserMessage extends QueuedGoalUserMessage {
-  content: QueuedGoalTextPart[];
-}
-
-export type RewrittenQueuedGoalWorkMessage =
-  | SupersededQueuedGoalCustomMessage
-  | SupersededQueuedGoalUserMessage
-  | StaleQueuedGoalCustomMessage
-  | StaleQueuedGoalUserMessage
-  | RefreshedActiveQueuedGoalCustomMessage
-  | RefreshedActiveQueuedGoalUserMessage;
 
 /** Role/customType only — does not prove normalized content or display. */
 interface QueuedGoalCustomRoleCarrier {

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -104,7 +104,7 @@ function supersededContinuationContextMessage(
       content,
       display: false,
       details: {
-        kind: "superseded_continuation",
+        kind: "superseded_continuation" as const,
         goalId,
       },
     };

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -8,20 +8,64 @@ import {
   isActiveGoalQueuedDetails,
   type QueuedGoalContextCarrier,
   type QueuedGoalContextInput,
+  type QueuedGoalCustomMessage,
   type QueuedGoalTextPart,
+  type QueuedGoalUserMessage,
   type QueuedGoalWorkSourceMessage,
-  type RefreshedActiveQueuedGoalCustomMessage,
-  type RefreshedActiveQueuedGoalUserMessage,
-  type RewrittenQueuedGoalWorkMessage,
-  type StaleQueuedGoalCustomMessage,
-  type StaleQueuedGoalUserMessage,
-  type SupersededQueuedGoalCustomMessage,
-  type SupersededQueuedGoalUserMessage,
   toQueuedGoalContextCarrier,
   toQueuedGoalWorkSource,
   userContentFromUnknown,
 } from "./queued-goal-messages.js";
-import { CUSTOM_ENTRY_TYPE, type ThreadGoal } from "./types.js";
+import { CUSTOM_ENTRY_TYPE, type GoalStatus, type ThreadGoal } from "./types.js";
+
+interface SupersededContinuationDetails {
+  kind: "superseded_continuation";
+  goalId: string;
+}
+
+interface StaleContinuationDetails {
+  kind: "stale_continuation";
+  goalId: string;
+  currentGoalId: string | null;
+  currentStatus: GoalStatus | null;
+}
+
+interface SupersededQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
+  content: string;
+  display: false;
+  details: SupersededContinuationDetails;
+}
+
+interface SupersededQueuedGoalUserMessage extends QueuedGoalUserMessage {
+  content: QueuedGoalTextPart[];
+}
+
+interface StaleQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
+  content: string;
+  display: false;
+  details: StaleContinuationDetails;
+}
+
+interface StaleQueuedGoalUserMessage extends QueuedGoalUserMessage {
+  content: QueuedGoalTextPart[];
+}
+
+interface RefreshedActiveQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
+  content: string;
+  display: false;
+}
+
+interface RefreshedActiveQueuedGoalUserMessage extends QueuedGoalUserMessage {
+  content: QueuedGoalTextPart[];
+}
+
+type RewrittenQueuedGoalWorkMessage =
+  | SupersededQueuedGoalCustomMessage
+  | SupersededQueuedGoalUserMessage
+  | StaleQueuedGoalCustomMessage
+  | StaleQueuedGoalUserMessage
+  | RefreshedActiveQueuedGoalCustomMessage
+  | RefreshedActiveQueuedGoalUserMessage;
 
 /** Single bridge from concrete queued-goal rewrites back onto provider-context messages. */
 function mergeProviderContextMessage<TMessage extends QueuedGoalContextInput>(
@@ -215,7 +259,7 @@ export function dedupeActiveGoalContinuations<TMessage extends QueuedGoalContext
   return { messages: nextMessages, changed };
 }
 
-export function staleGoalContinuationContextMessage(
+function staleGoalContinuationContextMessage(
   message: QueuedGoalWorkSourceMessage,
   queuedGoalId: string,
   currentGoal: ThreadGoal | null,

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -243,13 +243,11 @@ export function staleGoalContinuationContextMessage(
   };
 }
 
-export type QueuedGoalStaleRewriteResult = StaleQueuedGoalCustomMessage | StaleQueuedGoalUserMessage;
-
-export function rewriteStaleQueuedGoalContextMessage(
+function rewriteStaleQueuedGoalContextMessage(
   message: QueuedGoalContextCarrier,
   queuedGoalId: string,
   currentGoal: ThreadGoal | null,
-): QueuedGoalStaleRewriteResult | null {
+): StaleQueuedGoalCustomMessage | StaleQueuedGoalUserMessage | null {
   const source = toQueuedGoalWorkSource(message);
   if (!source) {
     return null;

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -5,8 +5,7 @@ import {
   supersededContinuationMessage,
 } from "./prompts.js";
 import {
-  applyQueuedGoalRewrite,
-  type ActiveGoalQueuedDetails,
+  isActiveGoalQueuedDetails,
   type QueuedGoalContextCarrier,
   type QueuedGoalTextPart,
   type QueuedGoalWorkSourceMessage,
@@ -21,21 +20,8 @@ import {
 } from "./queued-goal-messages.js";
 import { CUSTOM_ENTRY_TYPE, type ThreadGoal } from "./types.js";
 
-interface QueuedGoalMessageDetails {
-  kind?: unknown;
-  goalId?: unknown;
-}
-
-function isQueuedGoalMessageDetails(details: unknown): details is QueuedGoalMessageDetails {
-  return details !== null && typeof details === "object";
-}
-
 function isSupersededContinuationDetails(details: unknown): boolean {
-  return isQueuedGoalMessageDetails(details) && details.kind === "superseded_continuation";
-}
-
-function isQueuedGoalWorkKind(kind: unknown): kind is ActiveGoalQueuedDetails["kind"] {
-  return kind === "continuation" || kind === "command_start" || kind === "command_resume";
+  return details !== null && typeof details === "object" && (details as { kind?: unknown }).kind === "superseded_continuation";
 }
 
 function textContentFromMessageContent(content: unknown): string | null {
@@ -77,11 +63,8 @@ export function extensionQueuedGoalWorkMessageId(message: QueuedGoalContextCarri
     return null;
   }
 
-  if (isQueuedGoalMessageDetails(message.details)) {
-    const { kind, goalId } = message.details;
-    if (isQueuedGoalWorkKind(kind) && typeof goalId === "string") {
-      return goalId;
-    }
+  if (isActiveGoalQueuedDetails(message.details)) {
+    return message.details.goalId;
   }
 
   return continuationGoalIdFromMessageContent(message.content);
@@ -124,7 +107,7 @@ function continuationPromptForProviderContext(
   goal: ThreadGoal,
   message: Pick<QueuedGoalWorkSourceMessage, "details">,
 ): string {
-  if (isQueuedGoalMessageDetails(message.details)) {
+  if (isActiveGoalQueuedDetails(message.details)) {
     const kind = message.details.kind;
     if (kind === "command_start" || kind === "command_resume") {
       return continuationPrompt(goal);
@@ -170,7 +153,7 @@ export function dedupeActiveGoalContinuations(
       continue;
     }
     const rewritten = supersededContinuationContextMessage(source, activeGoalId);
-    nextMessages[index] = applyQueuedGoalRewrite(message, rewritten);
+    nextMessages[index] = rewritten;
     changed = true;
   }
 
@@ -191,7 +174,7 @@ export function dedupeActiveGoalContinuations(
         content: refreshedContent,
         display: false,
       };
-      nextMessages[latestIndex] = applyQueuedGoalRewrite(latestMessage, refreshed);
+      nextMessages[latestIndex] = refreshed;
       changed = true;
     }
   } else {
@@ -202,7 +185,7 @@ export function dedupeActiveGoalContinuations(
         ...latestSource,
         content: refreshedUserContent,
       };
-      nextMessages[latestIndex] = applyQueuedGoalRewrite(latestMessage, refreshed);
+      nextMessages[latestIndex] = refreshed;
       changed = true;
     }
   }
@@ -238,17 +221,18 @@ export function staleGoalContinuationContextMessage(
   };
 }
 
-export function rewriteStaleQueuedGoalContextMessage<C extends QueuedGoalContextCarrier>(
-  message: C,
+export type QueuedGoalStaleRewriteResult = StaleQueuedGoalCustomMessage | StaleQueuedGoalUserMessage;
+
+export function rewriteStaleQueuedGoalContextMessage(
+  message: QueuedGoalContextCarrier,
   queuedGoalId: string,
   currentGoal: ThreadGoal | null,
-): C {
+): QueuedGoalContextCarrier | QueuedGoalStaleRewriteResult {
   const source = toQueuedGoalWorkSource(message);
   if (!source) {
     return message;
   }
-  const rewritten = staleGoalContinuationContextMessage(source, queuedGoalId, currentGoal);
-  return applyQueuedGoalRewrite(message, rewritten);
+  return staleGoalContinuationContextMessage(source, queuedGoalId, currentGoal);
 }
 
 export function extensionQueuedGoalWorkMessageIdForRuntime(

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -6,13 +6,13 @@ import {
 } from "./prompts.js";
 import {
   isActiveGoalQueuedDetails,
-  mergeProviderContextMessage,
   type QueuedGoalContextCarrier,
   type QueuedGoalContextInput,
   type QueuedGoalTextPart,
   type QueuedGoalWorkSourceMessage,
   type RefreshedActiveQueuedGoalCustomMessage,
   type RefreshedActiveQueuedGoalUserMessage,
+  type RewrittenQueuedGoalWorkMessage,
   type StaleQueuedGoalCustomMessage,
   type StaleQueuedGoalUserMessage,
   type SupersededQueuedGoalCustomMessage,
@@ -22,6 +22,17 @@ import {
   userContentFromUnknown,
 } from "./queued-goal-messages.js";
 import { CUSTOM_ENTRY_TYPE, type ThreadGoal } from "./types.js";
+
+/** Single bridge from concrete queued-goal rewrites back onto provider-context messages. */
+function mergeProviderContextMessage<TMessage extends QueuedGoalContextInput>(
+  original: TMessage,
+  rewritten: RewrittenQueuedGoalWorkMessage,
+): TMessage {
+  return {
+    ...original,
+    ...rewritten,
+  } as TMessage;
+}
 
 function isSupersededContinuationDetails(details: unknown): boolean {
   return details !== null && typeof details === "object" && (details as { kind?: unknown }).kind === "superseded_continuation";

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -4,16 +4,26 @@ import {
   continuationPrompt,
   supersededContinuationMessage,
 } from "./prompts.js";
+import {
+  applyQueuedGoalRewrite,
+  type ActiveGoalQueuedDetails,
+  type QueuedGoalContextCarrier,
+  type QueuedGoalTextPart,
+  type QueuedGoalWorkSourceMessage,
+  type RefreshedActiveQueuedGoalCustomMessage,
+  type RefreshedActiveQueuedGoalUserMessage,
+  type StaleQueuedGoalCustomMessage,
+  type StaleQueuedGoalUserMessage,
+  type SupersededQueuedGoalCustomMessage,
+  type SupersededQueuedGoalUserMessage,
+  toQueuedGoalWorkSource,
+  userContentFromUnknown,
+} from "./queued-goal-messages.js";
 import { CUSTOM_ENTRY_TYPE, type ThreadGoal } from "./types.js";
 
 interface QueuedGoalMessageDetails {
   kind?: unknown;
   goalId?: unknown;
-}
-
-interface TextMessagePart {
-  type?: unknown;
-  text?: unknown;
 }
 
 function isQueuedGoalMessageDetails(details: unknown): details is QueuedGoalMessageDetails {
@@ -24,7 +34,7 @@ function isSupersededContinuationDetails(details: unknown): boolean {
   return isQueuedGoalMessageDetails(details) && details.kind === "superseded_continuation";
 }
 
-function isQueuedGoalWorkKind(kind: unknown): boolean {
+function isQueuedGoalWorkKind(kind: unknown): kind is ActiveGoalQueuedDetails["kind"] {
   return kind === "continuation" || kind === "command_start" || kind === "command_resume";
 }
 
@@ -33,22 +43,12 @@ function textContentFromMessageContent(content: unknown): string | null {
     return content;
   }
 
-  if (!Array.isArray(content)) {
+  const parts = userContentFromUnknown(content);
+  if (parts.length === 0) {
     return null;
   }
 
-  const textParts: string[] = [];
-  for (const part of content) {
-    if (part === null || typeof part !== "object") {
-      continue;
-    }
-    const textPart = part as TextMessagePart;
-    if (textPart.type === "text" && typeof textPart.text === "string") {
-      textParts.push(textPart.text);
-    }
-  }
-
-  return textParts.length > 0 ? textParts.join("\n") : null;
+  return parts.map((part) => part.text).join("\n");
 }
 
 function continuationGoalIdFromMessageContent(content: unknown): string | null {
@@ -68,12 +68,7 @@ function staleGoalContinuationMessage(queuedGoalId: string, currentGoal: ThreadG
   ].join("\n");
 }
 
-export function extensionQueuedGoalWorkMessageId(message: {
-  role: string;
-  customType?: string;
-  details?: unknown;
-  content?: unknown;
-}): string | null {
+export function extensionQueuedGoalWorkMessageId(message: QueuedGoalContextCarrier): string | null {
   if (message.role !== "custom" || message.customType !== CUSTOM_ENTRY_TYPE) {
     return null;
   }
@@ -92,12 +87,7 @@ export function extensionQueuedGoalWorkMessageId(message: {
   return continuationGoalIdFromMessageContent(message.content);
 }
 
-export function queuedGoalWorkMessageId(message: {
-  role: string;
-  customType?: string;
-  details?: unknown;
-  content?: unknown;
-}): string | null {
+export function queuedGoalWorkMessageId(message: QueuedGoalContextCarrier): string | null {
   if (message.role === "user") {
     return continuationGoalIdFromMessageContent(message.content);
   }
@@ -105,10 +95,10 @@ export function queuedGoalWorkMessageId(message: {
   return extensionQueuedGoalWorkMessageId(message);
 }
 
-function supersededContinuationContextMessage<TMessage extends { role: string; content?: unknown; display?: boolean; details?: unknown }>(
-  message: TMessage,
+function supersededContinuationContextMessage(
+  message: QueuedGoalWorkSourceMessage,
   goalId: string,
-): TMessage {
+): SupersededQueuedGoalCustomMessage | SupersededQueuedGoalUserMessage {
   const content = supersededContinuationMessage(goalId);
 
   if (message.role === "custom") {
@@ -120,18 +110,19 @@ function supersededContinuationContextMessage<TMessage extends { role: string; c
         kind: "superseded_continuation",
         goalId,
       },
-    } as TMessage;
+    };
   }
 
+  const userContent: QueuedGoalTextPart[] = [{ type: "text", text: content }];
   return {
     ...message,
-    content: [{ type: "text", text: content }],
-  } as TMessage;
+    content: userContent,
+  };
 }
 
 function continuationPromptForProviderContext(
   goal: ThreadGoal,
-  message: { details?: unknown },
+  message: Pick<QueuedGoalWorkSourceMessage, "details">,
 ): string {
   if (isQueuedGoalMessageDetails(message.details)) {
     const kind = message.details.kind;
@@ -143,19 +134,11 @@ function continuationPromptForProviderContext(
   return compactContinuationPrompt(goal);
 }
 
-export function dedupeActiveGoalContinuations<TMessage extends {
-  role: string;
-  customType?: string;
-  details?: unknown;
-  content?: unknown;
-  display?: boolean;
-}>(
-  messages: TMessage[],
+export function dedupeActiveGoalContinuations(
+  messages: QueuedGoalContextCarrier[],
   goal: ThreadGoal,
-  resolveQueuedGoalWorkMessageId: (
-    message: { role: string; customType?: string; details?: unknown; content?: unknown },
-  ) => string | null,
-): { messages: TMessage[]; changed: boolean } {
+  resolveQueuedGoalWorkMessageId: (message: QueuedGoalContextCarrier) => string | null,
+): { messages: QueuedGoalContextCarrier[]; changed: boolean } {
   const activeGoalId = goal.goalId;
   const indices: number[] = [];
   for (let index = 0; index < messages.length; index += 1) {
@@ -182,32 +165,44 @@ export function dedupeActiveGoalContinuations<TMessage extends {
     if (!message) {
       continue;
     }
-    nextMessages[index] = supersededContinuationContextMessage(message, activeGoalId);
+    const source = toQueuedGoalWorkSource(message);
+    if (!source) {
+      continue;
+    }
+    const rewritten = supersededContinuationContextMessage(source, activeGoalId);
+    nextMessages[index] = applyQueuedGoalRewrite(message, rewritten);
     changed = true;
   }
 
   const latestMessage = nextMessages[latestIndex];
   if (!latestMessage) {
-    return { messages, changed };
+    return { messages: nextMessages, changed };
   }
-  const refreshedContent = continuationPromptForProviderContext(goal, latestMessage);
-  if (latestMessage.role === "custom") {
+  const latestSource = toQueuedGoalWorkSource(latestMessage);
+  if (!latestSource) {
+    return { messages: nextMessages, changed };
+  }
+
+  const refreshedContent = continuationPromptForProviderContext(goal, latestSource);
+  if (latestSource.role === "custom") {
     if (latestMessage.content !== refreshedContent) {
-      nextMessages[latestIndex] = {
-        ...latestMessage,
+      const refreshed: RefreshedActiveQueuedGoalCustomMessage = {
+        ...latestSource,
         content: refreshedContent,
         display: false,
       };
+      nextMessages[latestIndex] = applyQueuedGoalRewrite(latestMessage, refreshed);
       changed = true;
     }
   } else {
-    const refreshedUserContent = [{ type: "text", text: refreshedContent }];
+    const refreshedUserContent: QueuedGoalTextPart[] = [{ type: "text", text: refreshedContent }];
     const currentContent = textContentFromMessageContent(latestMessage.content);
     if (currentContent !== refreshedContent) {
-      nextMessages[latestIndex] = {
-        ...latestMessage,
+      const refreshed: RefreshedActiveQueuedGoalUserMessage = {
+        ...latestSource,
         content: refreshedUserContent,
-      } as TMessage;
+      };
+      nextMessages[latestIndex] = applyQueuedGoalRewrite(latestMessage, refreshed);
       changed = true;
     }
   }
@@ -215,40 +210,49 @@ export function dedupeActiveGoalContinuations<TMessage extends {
   return { messages: nextMessages, changed };
 }
 
-export function staleGoalContinuationContextMessage<TMessage extends { role: string; content?: unknown }>(
-  message: TMessage,
+export function staleGoalContinuationContextMessage(
+  message: QueuedGoalWorkSourceMessage,
   queuedGoalId: string,
   currentGoal: ThreadGoal | null,
-): TMessage {
+): StaleQueuedGoalCustomMessage | StaleQueuedGoalUserMessage {
   const content = staleGoalContinuationMessage(queuedGoalId, currentGoal);
+  const staleDetails = {
+    kind: "stale_continuation" as const,
+    goalId: queuedGoalId,
+    currentGoalId: currentGoal?.goalId ?? null,
+    currentStatus: currentGoal?.status ?? null,
+  };
 
   if (message.role === "custom") {
     return {
       ...message,
       content,
       display: false,
-      details: {
-        kind: "stale_continuation",
-        goalId: queuedGoalId,
-        currentGoalId: currentGoal?.goalId ?? null,
-        currentStatus: currentGoal?.status ?? null,
-      },
-    } as TMessage;
+      details: staleDetails,
+    };
   }
 
   return {
     ...message,
     content: [{ type: "text", text: content }],
-  } as TMessage;
+  };
+}
+
+export function rewriteStaleQueuedGoalContextMessage<C extends QueuedGoalContextCarrier>(
+  message: C,
+  queuedGoalId: string,
+  currentGoal: ThreadGoal | null,
+): C {
+  const source = toQueuedGoalWorkSource(message);
+  if (!source) {
+    return message;
+  }
+  const rewritten = staleGoalContinuationContextMessage(source, queuedGoalId, currentGoal);
+  return applyQueuedGoalRewrite(message, rewritten);
 }
 
 export function extensionQueuedGoalWorkMessageIdForRuntime(
-  message: {
-    role: string;
-    customType?: string;
-    details?: unknown;
-    content?: unknown;
-  },
+  message: QueuedGoalContextCarrier,
   resolveContinuationGoalIdFromPrompt: (prompt: string) => string | null,
 ): string | null {
   if (message.role === "user") {
@@ -260,7 +264,7 @@ export function extensionQueuedGoalWorkMessageIdForRuntime(
 }
 
 export function pendingStaleQueuedGoalWorkIdsFromMessages(
-  messages: Array<{ role: string; customType?: string; details?: unknown; content?: unknown }>,
+  messages: readonly QueuedGoalContextCarrier[],
   staleQueuedGoalWorkAgentEndGoalIds: ReadonlySet<string>,
 ): string[] {
   const goalIds: string[] = [];

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -6,7 +6,9 @@ import {
 } from "./prompts.js";
 import {
   isActiveGoalQueuedDetails,
+  mergeProviderContextMessage,
   type QueuedGoalContextCarrier,
+  type QueuedGoalContextInput,
   type QueuedGoalTextPart,
   type QueuedGoalWorkSourceMessage,
   type RefreshedActiveQueuedGoalCustomMessage,
@@ -15,6 +17,7 @@ import {
   type StaleQueuedGoalUserMessage,
   type SupersededQueuedGoalCustomMessage,
   type SupersededQueuedGoalUserMessage,
+  toQueuedGoalContextCarrier,
   toQueuedGoalWorkSource,
   userContentFromUnknown,
 } from "./queued-goal-messages.js";
@@ -54,7 +57,7 @@ function staleGoalContinuationMessage(queuedGoalId: string, currentGoal: ThreadG
   ].join("\n");
 }
 
-export function extensionQueuedGoalWorkMessageId(message: QueuedGoalContextCarrier): string | null {
+export function extensionQueuedGoalWorkMessageId(message: QueuedGoalContextInput): string | null {
   if (message.role !== "custom" || message.customType !== CUSTOM_ENTRY_TYPE) {
     return null;
   }
@@ -70,7 +73,7 @@ export function extensionQueuedGoalWorkMessageId(message: QueuedGoalContextCarri
   return continuationGoalIdFromMessageContent(message.content);
 }
 
-export function queuedGoalWorkMessageId(message: QueuedGoalContextCarrier): string | null {
+export function queuedGoalWorkMessageId(message: QueuedGoalContextInput): string | null {
   if (message.role === "user") {
     return continuationGoalIdFromMessageContent(message.content);
   }
@@ -117,11 +120,11 @@ function continuationPromptForProviderContext(
   return compactContinuationPrompt(goal);
 }
 
-export function dedupeActiveGoalContinuations(
-  messages: QueuedGoalContextCarrier[],
+export function dedupeActiveGoalContinuations<TMessage extends QueuedGoalContextInput>(
+  messages: readonly TMessage[],
   goal: ThreadGoal,
-  resolveQueuedGoalWorkMessageId: (message: QueuedGoalContextCarrier) => string | null,
-): { messages: QueuedGoalContextCarrier[]; changed: boolean } {
+  resolveQueuedGoalWorkMessageId: (message: QueuedGoalContextInput) => string | null,
+): { messages: TMessage[]; changed: boolean } {
   const activeGoalId = goal.goalId;
   const indices: number[] = [];
   for (let index = 0; index < messages.length; index += 1) {
@@ -137,23 +140,27 @@ export function dedupeActiveGoalContinuations(
 
   const latestIndex = indices.at(-1);
   if (latestIndex === undefined) {
-    return { messages, changed: false };
+    return { messages: [...messages], changed: false };
   }
 
   let changed = false;
-  const nextMessages = messages.slice();
+  const nextMessages = [...messages];
 
   for (const index of indices.slice(0, -1)) {
     const message = nextMessages[index];
     if (!message) {
       continue;
     }
-    const source = toQueuedGoalWorkSource(message);
+    const carrier = toQueuedGoalContextCarrier(message);
+    if (!carrier) {
+      continue;
+    }
+    const source = toQueuedGoalWorkSource(carrier);
     if (!source) {
       continue;
     }
     const rewritten = supersededContinuationContextMessage(source, activeGoalId);
-    nextMessages[index] = rewritten;
+    nextMessages[index] = mergeProviderContextMessage(message, rewritten);
     changed = true;
   }
 
@@ -161,7 +168,11 @@ export function dedupeActiveGoalContinuations(
   if (!latestMessage) {
     return { messages: nextMessages, changed };
   }
-  const latestSource = toQueuedGoalWorkSource(latestMessage);
+  const latestCarrier = toQueuedGoalContextCarrier(latestMessage);
+  if (!latestCarrier) {
+    return { messages: nextMessages, changed };
+  }
+  const latestSource = toQueuedGoalWorkSource(latestCarrier);
   if (!latestSource) {
     return { messages: nextMessages, changed };
   }
@@ -174,7 +185,7 @@ export function dedupeActiveGoalContinuations(
         content: refreshedContent,
         display: false,
       };
-      nextMessages[latestIndex] = refreshed;
+      nextMessages[latestIndex] = mergeProviderContextMessage(latestMessage, refreshed);
       changed = true;
     }
   } else {
@@ -185,7 +196,7 @@ export function dedupeActiveGoalContinuations(
         ...latestSource,
         content: refreshedUserContent,
       };
-      nextMessages[latestIndex] = refreshed;
+      nextMessages[latestIndex] = mergeProviderContextMessage(latestMessage, refreshed);
       changed = true;
     }
   }
@@ -227,16 +238,64 @@ export function rewriteStaleQueuedGoalContextMessage(
   message: QueuedGoalContextCarrier,
   queuedGoalId: string,
   currentGoal: ThreadGoal | null,
-): QueuedGoalContextCarrier | QueuedGoalStaleRewriteResult {
+): QueuedGoalStaleRewriteResult | null {
   const source = toQueuedGoalWorkSource(message);
   if (!source) {
-    return message;
+    return null;
   }
   return staleGoalContinuationContextMessage(source, queuedGoalId, currentGoal);
 }
 
+export function applyQueuedGoalProviderContextRewrites<TMessage extends QueuedGoalContextInput>(
+  messages: readonly TMessage[],
+  options: {
+    goal: ThreadGoal | null;
+    resolveStaleQueuedGoalWorkMessageId: (message: QueuedGoalContextInput) => string | null;
+    resolveActiveContinuationQueuedGoalWorkMessageId: (message: QueuedGoalContextInput) => string | null;
+  },
+): { messages: TMessage[]; changed: boolean } {
+  let changed = false;
+  let nextMessages: TMessage[] = messages.map((message) => {
+    const queuedGoalId = options.resolveStaleQueuedGoalWorkMessageId(message);
+    if (queuedGoalId === null) {
+      return message;
+    }
+
+    if (options.goal?.goalId === queuedGoalId && options.goal.status === "active") {
+      return message;
+    }
+
+    const carrier = toQueuedGoalContextCarrier(message);
+    if (!carrier) {
+      return message;
+    }
+
+    const rewritten = rewriteStaleQueuedGoalContextMessage(carrier, queuedGoalId, options.goal);
+    if (!rewritten) {
+      return message;
+    }
+
+    changed = true;
+    return mergeProviderContextMessage(message, rewritten);
+  });
+
+  if (options.goal?.status === "active") {
+    const deduped = dedupeActiveGoalContinuations(
+      nextMessages,
+      options.goal,
+      options.resolveActiveContinuationQueuedGoalWorkMessageId,
+    );
+    if (deduped.changed) {
+      changed = true;
+      nextMessages = deduped.messages;
+    }
+  }
+
+  return { messages: nextMessages, changed };
+}
+
 export function extensionQueuedGoalWorkMessageIdForRuntime(
-  message: QueuedGoalContextCarrier,
+  message: QueuedGoalContextInput,
   resolveContinuationGoalIdFromPrompt: (prompt: string) => string | null,
 ): string | null {
   if (message.role === "user") {
@@ -248,7 +307,7 @@ export function extensionQueuedGoalWorkMessageIdForRuntime(
 }
 
 export function pendingStaleQueuedGoalWorkIdsFromMessages(
-  messages: readonly QueuedGoalContextCarrier[],
+  messages: readonly QueuedGoalContextInput[],
   staleQueuedGoalWorkAgentEndGoalIds: ReadonlySet<string>,
 ): string[] {
   const goalIds: string[] = [];

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -128,7 +128,7 @@ export function extensionQueuedGoalWorkMessageId(message: QueuedGoalContextInput
   return continuationGoalIdFromMessageContent(message.content);
 }
 
-export function queuedGoalWorkMessageId(message: QueuedGoalContextInput): string | null {
+function queuedGoalWorkMessageId(message: QueuedGoalContextInput): string | null {
   if (message.role === "user") {
     return continuationGoalIdFromMessageContent(message.content);
   }
@@ -175,7 +175,7 @@ function continuationPromptForProviderContext(
   return compactContinuationPrompt(goal);
 }
 
-export function dedupeActiveGoalContinuations<TMessage extends QueuedGoalContextInput>(
+function dedupeActiveGoalContinuations<TMessage extends QueuedGoalContextInput>(
   messages: readonly TMessage[],
   goal: ThreadGoal,
   resolveQueuedGoalWorkMessageId: (message: QueuedGoalContextInput) => string | null,

--- a/src/recovery-adapters.ts
+++ b/src/recovery-adapters.ts
@@ -1,0 +1,66 @@
+import type { AssistantMessage, StopReason } from "@earendil-works/pi-ai";
+
+export interface OverflowCheckAssistantMessage {
+  stopReason?: string;
+  errorMessage?: string;
+  usage?: {
+    input: number;
+    output: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+}
+
+const OVERFLOW_CHECK_API = "pi-codex-goal-overflow-check";
+const OVERFLOW_CHECK_PROVIDER = "pi-codex-goal";
+const OVERFLOW_CHECK_MODEL = "overflow-check";
+
+function stopReasonFromAssistantError(stopReason: string | undefined): StopReason {
+  switch (stopReason) {
+    case "stop":
+    case "length":
+    case "toolUse":
+    case "error":
+    case "aborted":
+      return stopReason;
+    default:
+      return "error";
+  }
+}
+
+/** Single adapter for pi-ai overflow checks; keeps AssistantMessage casts out of recovery logic. */
+export function assistantMessageForOverflowCheck(message: OverflowCheckAssistantMessage): AssistantMessage {
+  const usage = message.usage ?? { input: 0, output: 0 };
+  const cacheRead = usage.cacheRead ?? 0;
+  const cacheWrite = usage.cacheWrite ?? 0;
+
+  const assistantMessage: AssistantMessage = {
+    role: "assistant",
+    content: [],
+    api: OVERFLOW_CHECK_API,
+    provider: OVERFLOW_CHECK_PROVIDER,
+    model: OVERFLOW_CHECK_MODEL,
+    usage: {
+      input: usage.input,
+      output: usage.output,
+      cacheRead,
+      cacheWrite,
+      totalTokens: usage.input + usage.output + cacheRead + cacheWrite,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: stopReasonFromAssistantError(message.stopReason),
+    timestamp: 0,
+  };
+
+  if (message.errorMessage !== undefined) {
+    assistantMessage.errorMessage = message.errorMessage;
+  }
+
+  return assistantMessage;
+}

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -1,4 +1,6 @@
-import { isContextOverflow, type AssistantMessage } from "@earendil-works/pi-ai";
+import { isContextOverflow } from "@earendil-works/pi-ai";
+
+import { assistantMessageForOverflowCheck } from "./recovery-adapters.js";
 
 export const CONTEXT_OVERFLOW_SIGNATURE = "context_overflow";
 
@@ -56,15 +58,16 @@ export function isAssistantContextOverflow(
   if (contextWindow <= 0) {
     return isContextOverflowError(message.errorMessage);
   }
-  return isContextOverflow(message as AssistantMessage, contextWindow);
+  return isContextOverflow(assistantMessageForOverflowCheck(message), contextWindow);
 }
 
 export function isContextOverflowError(errorMessage: string | undefined): boolean {
-  return isContextOverflow({
-    role: "assistant",
-    stopReason: "error",
-    errorMessage: errorMessage ?? "",
-  } as AssistantMessage);
+  return isContextOverflow(
+    assistantMessageForOverflowCheck({
+      stopReason: "error",
+      errorMessage: errorMessage ?? "",
+    }),
+  );
 }
 
 /**

--- a/test/provider-context.test.ts
+++ b/test/provider-context.test.ts
@@ -6,6 +6,7 @@ import {
   continuationGoalIdFromPrompt,
   continuationPrompt,
 } from "../src/prompts.js";
+import { userContentFromUnknown } from "../src/queued-goal-messages.js";
 import {
   assistantMessage,
   createRuntimeHarness,
@@ -13,6 +14,8 @@ import {
   emitQueuedTurnThroughContext,
   goalCustomContextMessage,
   goalUserContextMessage,
+  providerContextMessageAt,
+  requireProviderContextResult,
 } from "./support/runtime-harness.js";
 
 test("provider context dedupes many active continuations to one refreshed prompt", async () => {
@@ -50,18 +53,17 @@ test("provider context dedupes many active continuations to one refreshed prompt
   ];
 
   const results = await emitProviderContext(harness, messages);
-  const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
-  assert.ok(result?.messages);
+  const result = requireProviderContextResult(results);
   assert.equal(result.messages.length, 3);
 
-  assert.match(String(result.messages[0]?.content), /Superseded hidden goal continuation bookkeeping/);
-  assert.deepEqual(result.messages[0]?.details, {
+  assert.match(String(providerContextMessageAt(result, 0).content), /Superseded hidden goal continuation bookkeeping/);
+  assert.deepEqual(providerContextMessageAt(result, 0).details, {
     kind: "superseded_continuation",
     goalId: goal.goalId,
   });
-  assert.match(String(result.messages[1]?.content), /Superseded hidden goal continuation bookkeeping/);
+  assert.match(String(providerContextMessageAt(result, 1).content), /Superseded hidden goal continuation bookkeeping/);
 
-  const latestContent = String(result.messages[2]?.content);
+  const latestContent = String(providerContextMessageAt(result, 2).content);
   assert.match(latestContent, /Tokens used: 0/);
   assert.match(latestContent, /Time spent pursuing goal: 0s/);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
@@ -115,15 +117,14 @@ test("active provider-context dedupe preserves historical user marker mixed with
   ];
 
   const contextResults = await emitProviderContext(harness, messages);
-  const result = contextResults[0] as { messages?: Array<{ role: string; content?: unknown; details?: unknown }> } | undefined;
-  assert.ok(result?.messages);
+  const result = requireProviderContextResult(contextResults);
   assert.equal(result.messages.length, 3);
 
-  assert.match(String(result.messages[0]?.content), /Superseded hidden goal continuation bookkeeping/);
-  assert.deepEqual(result.messages[1]?.content, userMessage.content);
-  assert.match(String((result.messages[1]?.content as Array<{ text?: string }> | undefined)?.[0]?.text), /<untrusted_objective>/);
+  assert.match(String(providerContextMessageAt(result, 0).content), /Superseded hidden goal continuation bookkeeping/);
+  assert.deepEqual(providerContextMessageAt(result, 1).content, userMessage.content);
+  assert.match(String(userContentFromUnknown(providerContextMessageAt(result, 1).content)[0]?.text), /<untrusted_objective>/);
 
-  const latestContent = String(result.messages[2]?.content);
+  const latestContent = String(providerContextMessageAt(result, 2).content);
   assert.match(latestContent, /Tokens used: 0/);
   assert.doesNotMatch(latestContent, /<untrusted_objective>/);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
@@ -195,15 +196,14 @@ test("active goal provider-context dedupe preserves pasted marker input mixed wi
   ];
 
   const contextResults = await emitQueuedTurnThroughContext(harness, messages, 0);
-  const result = contextResults[0] as { messages?: Array<{ role: string; content?: unknown; details?: unknown }> } | undefined;
-  assert.ok(result?.messages);
+  const result = requireProviderContextResult(contextResults);
   assert.equal(result.messages.length, 3);
 
-  assert.deepEqual(result.messages[1]?.content, userMessage.content);
-  assert.match(String((result.messages[1]?.content as Array<{ text?: string }> | undefined)?.[0]?.text), /<untrusted_objective>/);
-  assert.match(String(result.messages[0]?.content), /Superseded hidden goal continuation bookkeeping/);
+  assert.deepEqual(providerContextMessageAt(result, 1).content, userMessage.content);
+  assert.match(String(userContentFromUnknown(providerContextMessageAt(result, 1).content)[0]?.text), /<untrusted_objective>/);
+  assert.match(String(providerContextMessageAt(result, 0).content), /Superseded hidden goal continuation bookkeeping/);
 
-  const latestContent = String(result.messages[2]?.content);
+  const latestContent = String(providerContextMessageAt(result, 2).content);
   assert.match(latestContent, /Tokens used: 0/);
   assert.doesNotMatch(latestContent, /<untrusted_objective>/);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
@@ -229,8 +229,8 @@ test("latest active continuation remains runnable after provider-context dedupe"
       timestamp: 2,
     }),
   ]);
-  const contextResult = contextResults[0] as { messages?: Array<{ content?: unknown }> } | undefined;
-  const latestContent = String(contextResult?.messages?.[1]?.content);
+  const contextResult = requireProviderContextResult(contextResults);
+  const latestContent = String(providerContextMessageAt(contextResult, 1).content);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
 
   harness.sentMessages.length = 0;
@@ -274,8 +274,8 @@ test("completed goals are not treated as active during continuation dedupe", asy
     }),
   ]);
 
-  const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
-  assert.match(String(result?.messages?.[0]?.content), /queued hidden goal continuation was stale/);
-  assert.match(String(result?.messages?.[1]?.content), /queued hidden goal continuation was stale/);
+  const result = requireProviderContextResult(results);
+  assert.match(String(providerContextMessageAt(result, 0).content), /queued hidden goal continuation was stale/);
+  assert.match(String(providerContextMessageAt(result, 1).content), /queued hidden goal continuation was stale/);
   assert.equal(harness.snapshot().goal?.status, "complete");
 });

--- a/test/provider-context.test.ts
+++ b/test/provider-context.test.ts
@@ -6,11 +6,13 @@ import {
   continuationGoalIdFromPrompt,
   continuationPrompt,
 } from "../src/prompts.js";
-import { CUSTOM_ENTRY_TYPE } from "../src/types.js";
 import {
   assistantMessage,
   createRuntimeHarness,
+  emitProviderContext,
   emitQueuedTurnThroughContext,
+  goalCustomContextMessage,
+  goalUserContextMessage,
 } from "./support/runtime-harness.js";
 
 test("provider context dedupes many active continuations to one refreshed prompt", async () => {
@@ -30,36 +32,24 @@ test("provider context dedupes many active continuations to one refreshed prompt
   });
 
   const messages = [
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    goalCustomContextMessage({
       content: fullStart,
-      display: false,
       details: { kind: "command_start", goalId: goal.goalId },
       timestamp: 1,
-    },
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    }),
+    goalCustomContextMessage({
       content: olderContinuation,
-      display: false,
       details: { kind: "continuation", goalId: goal.goalId },
       timestamp: 2,
-    },
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    }),
+    goalCustomContextMessage({
       content: latestContinuation,
-      display: false,
       details: { kind: "continuation", goalId: goal.goalId },
       timestamp: 3,
-    },
+    }),
   ];
 
-  const results = await harness.emit("context", {
-    type: "context",
-    messages,
-  });
+  const results = await emitProviderContext(harness, messages);
   const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
   assert.ok(result?.messages);
   assert.equal(result.messages.length, 3);
@@ -85,16 +75,9 @@ test("active provider-context user marker without passthrough binding remains ve
   assert.ok(goal);
 
   const userPrompt = continuationPrompt(goal);
-  const userMessage = {
-    role: "user",
-    content: [{ type: "text", text: userPrompt }],
-    timestamp: 1,
-  };
+  const userMessage = goalUserContextMessage(userPrompt, 1);
 
-  const contextResults = await harness.emit("context", {
-    type: "context",
-    messages: [userMessage],
-  });
+  const contextResults = await emitProviderContext(harness, [userMessage]);
 
   assert.equal(contextResults[0], undefined);
   assert.match(userPrompt, /<untrusted_objective>/);
@@ -116,35 +99,22 @@ test("active provider-context dedupe preserves historical user marker mixed with
     usage: { ...goal.usage, tokensUsed: 99, activeSeconds: 42 },
   });
 
-  const userMessage = {
-    role: "user",
-    content: [{ type: "text", text: userPrompt }],
-    timestamp: 2,
-  };
+  const userMessage = goalUserContextMessage(userPrompt, 2);
   const messages = [
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    goalCustomContextMessage({
       content: olderContinuation,
-      display: false,
       details: { kind: "continuation", goalId: goal.goalId },
       timestamp: 1,
-    },
+    }),
     userMessage,
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    goalCustomContextMessage({
       content: latestContinuation,
-      display: false,
       details: { kind: "continuation", goalId: goal.goalId },
       timestamp: 3,
-    },
+    }),
   ];
 
-  const contextResults = await harness.emit("context", {
-    type: "context",
-    messages,
-  });
+  const contextResults = await emitProviderContext(harness, messages);
   const result = contextResults[0] as { messages?: Array<{ role: string; content?: unknown; details?: unknown }> } | undefined;
   assert.ok(result?.messages);
   assert.equal(result.messages.length, 3);
@@ -178,11 +148,7 @@ for (const source of ["interactive", "rpc"] as const) {
       source,
     });
 
-    const userMessage = {
-      role: "user",
-      content: [{ type: "text", text: prompt }],
-      timestamp: 1,
-    };
+    const userMessage = goalUserContextMessage(prompt, 1);
     const contextResults = await emitQueuedTurnThroughContext(harness, [userMessage], 0);
 
     assert.equal(contextResults[0], undefined);
@@ -213,29 +179,19 @@ test("active goal provider-context dedupe preserves pasted marker input mixed wi
     source: "interactive",
   });
 
-  const userMessage = {
-    role: "user",
-    content: [{ type: "text", text: pastedPrompt }],
-    timestamp: 2,
-  };
+  const userMessage = goalUserContextMessage(pastedPrompt, 2);
   const messages = [
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    goalCustomContextMessage({
       content: olderContinuation,
-      display: false,
       details: { kind: "continuation", goalId: goal.goalId },
       timestamp: 1,
-    },
+    }),
     userMessage,
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    goalCustomContextMessage({
       content: latestContinuation,
-      display: false,
       details: { kind: "continuation", goalId: goal.goalId },
       timestamp: 3,
-    },
+    }),
   ];
 
   const contextResults = await emitQueuedTurnThroughContext(harness, messages, 0);
@@ -261,27 +217,18 @@ test("latest active continuation remains runnable after provider-context dedupe"
 
   const staleInBranch = continuationPrompt(goal);
   const latestInBranch = compactContinuationPrompt(goal);
-  const contextResults = await harness.emit("context", {
-    type: "context",
-    messages: [
-      {
-        role: "custom",
-        customType: CUSTOM_ENTRY_TYPE,
-        content: staleInBranch,
-        display: false,
-        details: { kind: "continuation", goalId: goal.goalId },
-        timestamp: 1,
-      },
-      {
-        role: "custom",
-        customType: CUSTOM_ENTRY_TYPE,
-        content: latestInBranch,
-        display: false,
-        details: { kind: "continuation", goalId: goal.goalId },
-        timestamp: 2,
-      },
-    ],
-  });
+  const contextResults = await emitProviderContext(harness, [
+    goalCustomContextMessage({
+      content: staleInBranch,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 1,
+    }),
+    goalCustomContextMessage({
+      content: latestInBranch,
+      details: { kind: "continuation", goalId: goal.goalId },
+      timestamp: 2,
+    }),
+  ]);
   const contextResult = contextResults[0] as { messages?: Array<{ content?: unknown }> } | undefined;
   const latestContent = String(contextResult?.messages?.[1]?.content);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
@@ -314,27 +261,18 @@ test("completed goals are not treated as active during continuation dedupe", asy
   const prompt = continuationPrompt(harness.snapshot().goal!);
 
   await harness.runTool("update_goal", { status: "complete" });
-  const results = await harness.emit("context", {
-    type: "context",
-    messages: [
-      {
-        role: "custom",
-        customType: CUSTOM_ENTRY_TYPE,
-        content: prompt,
-        display: false,
-        details: { kind: "continuation", goalId },
-        timestamp: 1,
-      },
-      {
-        role: "custom",
-        customType: CUSTOM_ENTRY_TYPE,
-        content: prompt,
-        display: false,
-        details: { kind: "continuation", goalId },
-        timestamp: 2,
-      },
-    ],
-  });
+  const results = await emitProviderContext(harness, [
+    goalCustomContextMessage({
+      content: prompt,
+      details: { kind: "continuation", goalId },
+      timestamp: 1,
+    }),
+    goalCustomContextMessage({
+      content: prompt,
+      details: { kind: "continuation", goalId },
+      timestamp: 2,
+    }),
+  ]);
 
   const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
   assert.match(String(result?.messages?.[0]?.content), /queued hidden goal continuation was stale/);

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { toQueuedGoalWorkSource } from "../src/queued-goal-messages.js";
+import {
+  dedupeActiveGoalContinuations,
+  extensionQueuedGoalWorkMessageId,
+  staleGoalContinuationContextMessage,
+} from "../src/queued-goal-work.js";
+import { compactContinuationPrompt, continuationPrompt } from "../src/prompts.js";
+import type { ThreadGoal } from "../src/types.js";
+import { goalCustomContextMessage, goalUserContextMessage } from "./support/runtime-harness.js";
+
+const activeGoal: ThreadGoal = {
+  goalId: "goal-1",
+  objective: "ship it",
+  status: "active",
+  tokenBudget: null,
+  usage: { tokensUsed: 0, activeSeconds: 0 },
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+test("staleGoalContinuationContextMessage rewrites custom and user queued messages", () => {
+  const customSource = toQueuedGoalWorkSource(
+    goalCustomContextMessage({
+      content: "old",
+      details: { kind: "continuation", goalId: "goal-1" },
+    }),
+  );
+  assert.ok(customSource);
+  const staleCustom = staleGoalContinuationContextMessage(
+    customSource,
+    "goal-1",
+    { ...activeGoal, status: "complete" },
+  );
+
+  assert.equal(staleCustom.role, "custom");
+  assert.equal(staleCustom.display, false);
+  assert.equal(staleCustom.details.kind, "stale_continuation");
+  assert.match(String(staleCustom.content), /queued hidden goal continuation was stale/);
+
+  const userSource = toQueuedGoalWorkSource(goalUserContextMessage(continuationPrompt(activeGoal)));
+  assert.ok(userSource);
+  const staleUser = staleGoalContinuationContextMessage(
+    userSource,
+    "goal-1",
+    { ...activeGoal, status: "complete" },
+  );
+
+  assert.equal(staleUser.role, "user");
+  assert.match(String(staleUser.content[0]?.text), /queued hidden goal continuation was stale/);
+});
+
+test("dedupeActiveGoalContinuations supersedes older custom continuations and refreshes the latest", () => {
+  const older = goalCustomContextMessage({
+    content: continuationPrompt(activeGoal),
+    details: { kind: "continuation", goalId: activeGoal.goalId },
+    timestamp: 1,
+  });
+  const latest = goalCustomContextMessage({
+    content: compactContinuationPrompt({
+      ...activeGoal,
+      usage: { tokensUsed: 99, activeSeconds: 42 },
+    }),
+    details: { kind: "continuation", goalId: activeGoal.goalId },
+    timestamp: 2,
+  });
+
+  const { messages, changed } = dedupeActiveGoalContinuations(
+    [older, latest],
+    activeGoal,
+    extensionQueuedGoalWorkMessageId,
+  );
+
+  assert.equal(changed, true);
+  assert.equal(messages.length, 2);
+  assert.match(String(messages[0]?.content), /Superseded hidden goal continuation bookkeeping/);
+  assert.deepEqual(messages[0]?.details, {
+    kind: "superseded_continuation",
+    goalId: activeGoal.goalId,
+  });
+  assert.match(String(messages[1]?.content), /Tokens used: 0/);
+});
+
+test("dedupeActiveGoalContinuations leaves an active user marker verbatim", () => {
+  const userMarker = goalUserContextMessage(continuationPrompt(activeGoal), 2);
+  const olderHidden = goalCustomContextMessage({
+    content: continuationPrompt({
+      ...activeGoal,
+      usage: { tokensUsed: 1, activeSeconds: 1 },
+    }),
+    details: { kind: "continuation", goalId: activeGoal.goalId },
+    timestamp: 1,
+  });
+  const latestHidden = goalCustomContextMessage({
+    content: compactContinuationPrompt(activeGoal),
+    details: { kind: "continuation", goalId: activeGoal.goalId },
+    timestamp: 3,
+  });
+
+  const { messages, changed } = dedupeActiveGoalContinuations(
+    [olderHidden, userMarker, latestHidden],
+    activeGoal,
+    extensionQueuedGoalWorkMessageId,
+  );
+
+  assert.equal(changed, true);
+  assert.deepEqual(messages[1]?.content, userMarker.content);
+  assert.match(String((messages[1]?.content as Array<{ text?: string }> | undefined)?.[0]?.text), /<untrusted_objective>/);
+});

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -3,8 +3,10 @@ import { test } from "node:test";
 
 import { toQueuedGoalWorkSource } from "../src/queued-goal-messages.js";
 import {
+  applyQueuedGoalProviderContextRewrites,
   dedupeActiveGoalContinuations,
   extensionQueuedGoalWorkMessageId,
+  queuedGoalWorkMessageId,
   staleGoalContinuationContextMessage,
 } from "../src/queued-goal-work.js";
 import { compactContinuationPrompt, continuationPrompt } from "../src/prompts.js";
@@ -82,6 +84,29 @@ test("dedupeActiveGoalContinuations supersedes older custom continuations and re
     goalId: activeGoal.goalId,
   });
   assert.match(String(messages[1]?.content), /Tokens used: 0/);
+});
+
+test("applyQueuedGoalProviderContextRewrites marks stale continuations for completed goals", () => {
+  const staleContinuation = goalCustomContextMessage({
+    content: continuationPrompt(activeGoal),
+    details: { kind: "continuation", goalId: activeGoal.goalId },
+    timestamp: 1,
+  });
+
+  const { messages, changed } = applyQueuedGoalProviderContextRewrites([staleContinuation], {
+    goal: { ...activeGoal, status: "complete" },
+    resolveStaleQueuedGoalWorkMessageId: queuedGoalWorkMessageId,
+    resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
+  });
+
+  assert.equal(changed, true);
+  assert.match(String(messages[0]?.content), /queued hidden goal continuation was stale/);
+  assert.deepEqual(messages[0]?.details, {
+    kind: "stale_continuation",
+    goalId: activeGoal.goalId,
+    currentGoalId: activeGoal.goalId,
+    currentStatus: "complete",
+  });
 });
 
 test("dedupeActiveGoalContinuations leaves an active user marker verbatim", () => {

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -7,7 +7,6 @@ import {
   dedupeActiveGoalContinuations,
   extensionQueuedGoalWorkMessageId,
   queuedGoalWorkMessageId,
-  staleGoalContinuationContextMessage,
 } from "../src/queued-goal-work.js";
 import { compactContinuationPrompt, continuationPrompt } from "../src/prompts.js";
 import type { ThreadGoal } from "../src/types.js";
@@ -34,36 +33,39 @@ test("toQueuedGoalWorkSource ignores unrelated custom messages", () => {
   assert.equal(toQueuedGoalWorkSource(unrelated), null);
 });
 
-test("staleGoalContinuationContextMessage rewrites custom and user queued messages", () => {
-  const customSource = toQueuedGoalWorkSource(
-    goalCustomContextMessage({
-      content: "old",
-      details: { kind: "continuation", goalId: "goal-1" },
-      timestamp: 1,
-    }),
-  );
-  assert.ok(customSource);
-  const staleCustom = staleGoalContinuationContextMessage(
-    customSource,
-    "goal-1",
-    { ...activeGoal, status: "complete" },
-  );
+test("applyQueuedGoalProviderContextRewrites rewrites stale custom and user queued messages", () => {
+  const completedGoal = { ...activeGoal, status: "complete" as const };
+  const staleCustom = goalCustomContextMessage({
+    content: "old",
+    details: { kind: "continuation", goalId: activeGoal.goalId },
+    timestamp: 1,
+  });
+  const staleUser = goalUserContextMessage(continuationPrompt(activeGoal), 2);
 
-  assert.equal(staleCustom.role, "custom");
-  assert.equal(staleCustom.display, false);
-  assert.equal(staleCustom.details.kind, "stale_continuation");
-  assert.match(String(staleCustom.content), /queued hidden goal continuation was stale/);
+  const customResult = applyQueuedGoalProviderContextRewrites([staleCustom], {
+    goal: completedGoal,
+    resolveStaleQueuedGoalWorkMessageId: queuedGoalWorkMessageId,
+    resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
+  });
 
-  const userSource = toQueuedGoalWorkSource(goalUserContextMessage(continuationPrompt(activeGoal)));
-  assert.ok(userSource);
-  const staleUser = staleGoalContinuationContextMessage(
-    userSource,
-    "goal-1",
-    { ...activeGoal, status: "complete" },
-  );
+  assert.equal(customResult.changed, true);
+  assert.equal(customResult.messages[0]?.display, false);
+  assert.match(String(customResult.messages[0]?.content), /queued hidden goal continuation was stale/);
+  assert.deepEqual(customResult.messages[0]?.details, {
+    kind: "stale_continuation",
+    goalId: activeGoal.goalId,
+    currentGoalId: activeGoal.goalId,
+    currentStatus: "complete",
+  });
 
-  assert.equal(staleUser.role, "user");
-  assert.match(String(staleUser.content[0]?.text), /queued hidden goal continuation was stale/);
+  const userResult = applyQueuedGoalProviderContextRewrites([staleUser], {
+    goal: completedGoal,
+    resolveStaleQueuedGoalWorkMessageId: queuedGoalWorkMessageId,
+    resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
+  });
+
+  assert.equal(userResult.changed, true);
+  assert.match(String(userContentFromUnknown(userResult.messages[0]?.content)[0]?.text), /queued hidden goal continuation was stale/);
 });
 
 test("dedupeActiveGoalContinuations supersedes older custom continuations and refreshes the latest", () => {

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { toQueuedGoalWorkSource, userContentFromUnknown } from "../src/queued-goal-messages.js";
+import { toQueuedGoalContextCarrier, toQueuedGoalWorkSource, userContentFromUnknown } from "../src/queued-goal-messages.js";
 import {
   applyQueuedGoalProviderContextRewrites,
   dedupeActiveGoalContinuations,
@@ -22,6 +22,17 @@ const activeGoal: ThreadGoal = {
   createdAt: 0,
   updatedAt: 0,
 };
+
+test("toQueuedGoalWorkSource ignores unrelated custom messages", () => {
+  const unrelated = toQueuedGoalContextCarrier({
+    role: "custom",
+    customType: "other-extension",
+    content: "ignored",
+    timestamp: 1,
+  });
+  assert.ok(unrelated);
+  assert.equal(toQueuedGoalWorkSource(unrelated), null);
+});
 
 test("staleGoalContinuationContextMessage rewrites custom and user queued messages", () => {
   const customSource = toQueuedGoalWorkSource(

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -26,6 +26,7 @@ test("staleGoalContinuationContextMessage rewrites custom and user queued messag
     goalCustomContextMessage({
       content: "old",
       details: { kind: "continuation", goalId: "goal-1" },
+      timestamp: 1,
     }),
   );
   assert.ok(customSource);

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -4,11 +4,10 @@ import { test } from "node:test";
 import { toQueuedGoalContextCarrier, toQueuedGoalWorkSource, userContentFromUnknown } from "../src/queued-goal-messages.js";
 import {
   applyQueuedGoalProviderContextRewrites,
-  dedupeActiveGoalContinuations,
   extensionQueuedGoalWorkMessageId,
-  queuedGoalWorkMessageId,
+  extensionQueuedGoalWorkMessageIdForRuntime,
 } from "../src/queued-goal-work.js";
-import { compactContinuationPrompt, continuationPrompt } from "../src/prompts.js";
+import { compactContinuationPrompt, continuationGoalIdFromPrompt, continuationPrompt } from "../src/prompts.js";
 import type { ThreadGoal } from "../src/types.js";
 import { goalCustomContextMessage, goalUserContextMessage } from "./support/runtime-harness.js";
 
@@ -21,6 +20,9 @@ const activeGoal: ThreadGoal = {
   createdAt: 0,
   updatedAt: 0,
 };
+
+const resolveStaleQueuedGoalWorkMessageId = (message: Parameters<typeof extensionQueuedGoalWorkMessageIdForRuntime>[0]) =>
+  extensionQueuedGoalWorkMessageIdForRuntime(message, continuationGoalIdFromPrompt);
 
 test("toQueuedGoalWorkSource ignores unrelated custom messages", () => {
   const unrelated = toQueuedGoalContextCarrier({
@@ -44,7 +46,7 @@ test("applyQueuedGoalProviderContextRewrites rewrites stale custom and user queu
 
   const customResult = applyQueuedGoalProviderContextRewrites([staleCustom], {
     goal: completedGoal,
-    resolveStaleQueuedGoalWorkMessageId: queuedGoalWorkMessageId,
+    resolveStaleQueuedGoalWorkMessageId,
     resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
   });
 
@@ -60,7 +62,7 @@ test("applyQueuedGoalProviderContextRewrites rewrites stale custom and user queu
 
   const userResult = applyQueuedGoalProviderContextRewrites([staleUser], {
     goal: completedGoal,
-    resolveStaleQueuedGoalWorkMessageId: queuedGoalWorkMessageId,
+    resolveStaleQueuedGoalWorkMessageId,
     resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
   });
 
@@ -68,7 +70,7 @@ test("applyQueuedGoalProviderContextRewrites rewrites stale custom and user queu
   assert.match(String(userContentFromUnknown(userResult.messages[0]?.content)[0]?.text), /queued hidden goal continuation was stale/);
 });
 
-test("dedupeActiveGoalContinuations supersedes older custom continuations and refreshes the latest", () => {
+test("applyQueuedGoalProviderContextRewrites supersedes older custom continuations and refreshes the latest", () => {
   const older = goalCustomContextMessage({
     content: continuationPrompt(activeGoal),
     details: { kind: "continuation", goalId: activeGoal.goalId },
@@ -83,11 +85,11 @@ test("dedupeActiveGoalContinuations supersedes older custom continuations and re
     timestamp: 2,
   });
 
-  const { messages, changed } = dedupeActiveGoalContinuations(
-    [older, latest],
-    activeGoal,
-    extensionQueuedGoalWorkMessageId,
-  );
+  const { messages, changed } = applyQueuedGoalProviderContextRewrites([older, latest], {
+    goal: activeGoal,
+    resolveStaleQueuedGoalWorkMessageId,
+    resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
+  });
 
   assert.equal(changed, true);
   assert.equal(messages.length, 2);
@@ -108,7 +110,7 @@ test("applyQueuedGoalProviderContextRewrites marks stale continuations for compl
 
   const { messages, changed } = applyQueuedGoalProviderContextRewrites([staleContinuation], {
     goal: { ...activeGoal, status: "complete" },
-    resolveStaleQueuedGoalWorkMessageId: queuedGoalWorkMessageId,
+    resolveStaleQueuedGoalWorkMessageId,
     resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
   });
 
@@ -122,7 +124,7 @@ test("applyQueuedGoalProviderContextRewrites marks stale continuations for compl
   });
 });
 
-test("dedupeActiveGoalContinuations leaves an active user marker verbatim", () => {
+test("applyQueuedGoalProviderContextRewrites leaves an active user marker verbatim", () => {
   const userMarker = goalUserContextMessage(continuationPrompt(activeGoal), 2);
   const olderHidden = goalCustomContextMessage({
     content: continuationPrompt({
@@ -138,10 +140,13 @@ test("dedupeActiveGoalContinuations leaves an active user marker verbatim", () =
     timestamp: 3,
   });
 
-  const { messages, changed } = dedupeActiveGoalContinuations(
+  const { messages, changed } = applyQueuedGoalProviderContextRewrites(
     [olderHidden, userMarker, latestHidden],
-    activeGoal,
-    extensionQueuedGoalWorkMessageId,
+    {
+      goal: activeGoal,
+      resolveStaleQueuedGoalWorkMessageId,
+      resolveActiveContinuationQueuedGoalWorkMessageId: extensionQueuedGoalWorkMessageId,
+    },
   );
 
   assert.equal(changed, true);

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { toQueuedGoalWorkSource } from "../src/queued-goal-messages.js";
+import { toQueuedGoalWorkSource, userContentFromUnknown } from "../src/queued-goal-messages.js";
 import {
   applyQueuedGoalProviderContextRewrites,
   dedupeActiveGoalContinuations,
@@ -133,5 +133,5 @@ test("dedupeActiveGoalContinuations leaves an active user marker verbatim", () =
 
   assert.equal(changed, true);
   assert.deepEqual(messages[1]?.content, userMarker.content);
-  assert.match(String((messages[1]?.content as Array<{ text?: string }> | undefined)?.[0]?.text), /<untrusted_objective>/);
+  assert.match(String(userContentFromUnknown(messages[1]?.content)[0]?.text), /<untrusted_objective>/);
 });

--- a/test/stale-queued-work.test.ts
+++ b/test/stale-queued-work.test.ts
@@ -5,6 +5,7 @@ import { CUSTOM_ENTRY_TYPE } from "../src/types.js";
 import {
   assistantMessage,
   createRuntimeHarness,
+  emitProviderContext,
   emitQueuedTurnThroughContext,
   queuedCustomMessage,
 } from "./support/runtime-harness.js";
@@ -149,25 +150,12 @@ test("stale custom goal work messages are replaced before provider context", asy
   const queued = harness.sentMessages[0];
   assert.ok(queued);
 
-  const contextMessage = {
-    role: "custom",
-    customType: CUSTOM_ENTRY_TYPE,
-    content: queued.message.content,
-    display: false,
-    details: queued.message.details,
-    timestamp: 1,
-  };
-  const activeResults = await harness.emit("context", {
-    type: "context",
-    messages: [contextMessage],
-  });
+  const contextMessage = queuedCustomMessage(queued, 1);
+  const activeResults = await emitProviderContext(harness, [contextMessage]);
   assert.equal(activeResults[0], undefined);
 
   await harness.runTool("update_goal", { status: "complete" });
-  const results = await harness.emit("context", {
-    type: "context",
-    messages: [contextMessage],
-  });
+  const results = await emitProviderContext(harness, [contextMessage]);
 
   const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
   const replacedMessage = result?.messages?.[0];

--- a/test/stale-queued-work.test.ts
+++ b/test/stale-queued-work.test.ts
@@ -7,7 +7,11 @@ import {
   createRuntimeHarness,
   emitProviderContext,
   emitQueuedTurnThroughContext,
+  goalCustomContextMessage,
+  goalUserContextMessage,
+  providerContextMessageAt,
   queuedCustomMessage,
+  requireProviderContextResult,
 } from "./support/runtime-harness.js";
 
 test("stale prompt continuation input is handled before agent start", async () => {
@@ -59,22 +63,9 @@ for (const source of ["interactive", "rpc"] as const) {
     });
     assert.equal(beforeAgentStartResults[0], undefined);
 
-    const userMessage = {
-      role: "user",
-      content: [{ type: "text", text: prompt }],
-      timestamp: 1,
-    };
-    await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
-    await harness.emit("message_start", { type: "message_start", message: userMessage });
-    await harness.emit("message_end", { type: "message_end", message: userMessage });
-    const contextResults = await harness.emit("context", {
-      type: "context",
-      messages: [userMessage],
-    });
-    const secondContextResults = await harness.emit("context", {
-      type: "context",
-      messages: [userMessage],
-    });
+    const userMessage = goalUserContextMessage(prompt, 1);
+    const contextResults = await emitQueuedTurnThroughContext(harness, [userMessage], 0);
+    const secondContextResults = await emitProviderContext(harness, [userMessage]);
 
     assert.equal(contextResults[0], undefined);
     assert.equal(secondContextResults[0], undefined);
@@ -88,14 +79,9 @@ for (const source of ["interactive", "rpc"] as const) {
       toolResults: [],
     });
 
-    const laterUserMessage = {
-      role: "user",
-      content: [{ type: "text", text: prompt }],
-      timestamp: 2,
-    };
+    const laterUserMessage = goalUserContextMessage(prompt, 2);
     const laterContextResults = await emitQueuedTurnThroughContext(harness, [laterUserMessage], 1);
-    const laterContextResult = laterContextResults[0] as { messages?: Array<{ content?: unknown }> } | undefined;
-    assert.notEqual(laterContextResult, undefined);
+    requireProviderContextResult(laterContextResults);
     assert.equal(harness.abortCount, 1);
   });
 }
@@ -121,14 +107,10 @@ test("stale queued continuation aborts if the goal became complete before launch
   assert.equal(results[0], undefined);
   assert.equal(harness.abortCount, 0);
 
-  const queuedMessage = {
-    role: "user",
-    content: [{ type: "text", text: prompt }],
-    timestamp: 1,
-  };
+  const queuedMessage = goalUserContextMessage(prompt, 1);
   const contextResults = await emitQueuedTurnThroughContext(harness, [queuedMessage]);
-  const contextResult = contextResults[0] as { messages?: Array<{ content?: unknown }> } | undefined;
-  assert.deepEqual(contextResult?.messages?.[0]?.content, [
+  const contextResult = requireProviderContextResult(contextResults);
+  assert.deepEqual(providerContextMessageAt(contextResult, 0).content, [
     {
       type: "text",
       text: [
@@ -157,8 +139,8 @@ test("stale custom goal work messages are replaced before provider context", asy
   await harness.runTool("update_goal", { status: "complete" });
   const results = await emitProviderContext(harness, [contextMessage]);
 
-  const result = results[0] as { messages?: Array<{ content?: unknown; details?: unknown }> } | undefined;
-  const replacedMessage = result?.messages?.[0];
+  const result = requireProviderContextResult(results);
+  const replacedMessage = providerContextMessageAt(result, 0);
   assert.equal(typeof replacedMessage?.content, "string");
   assert.match(String(replacedMessage?.content), /queued hidden goal continuation was stale and has been cancelled/);
   assert.deepEqual(replacedMessage?.details, {
@@ -183,53 +165,33 @@ test("stale provider context replacement covers queued work kinds and prompt mar
 
   await harness.runTool("update_goal", { status: "complete" });
   const staleMessages = [
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    goalCustomContextMessage({
       content: "queued by details",
-      display: false,
       details: { kind: "continuation", goalId: queuedGoalId },
       timestamp: 1,
-    },
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    }),
+    goalCustomContextMessage({
       content: "queued by details",
-      display: false,
       details: { kind: "command_start", goalId: queuedGoalId },
       timestamp: 1,
-    },
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    }),
+    goalCustomContextMessage({
       content: "queued by details",
-      display: false,
       details: { kind: "command_resume", goalId: queuedGoalId },
       timestamp: 1,
-    },
-    {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
+    }),
+    goalCustomContextMessage({
       content: prompt,
-      display: false,
       details: { kind: "other", goalId: queuedGoalId },
       timestamp: 1,
-    },
-    {
-      role: "user",
-      content: [{ type: "text", text: prompt }],
-      timestamp: 1,
-    },
+    }),
+    goalUserContextMessage(prompt, 1),
   ];
 
-  const results = await harness.emit("context", {
-    type: "context",
-    messages: staleMessages,
-  });
-
-  const result = results[0] as { messages?: Array<{ role: string; content?: unknown; details?: unknown }> } | undefined;
-  assert.equal(result?.messages?.length, staleMessages.length);
-  for (const [index, message] of result?.messages?.entries() ?? []) {
+  const results = await emitProviderContext(harness, staleMessages);
+  const result = requireProviderContextResult(results);
+  assert.equal(result.messages.length, staleMessages.length);
+  for (const [index, message] of result.messages.entries()) {
     if (message.role === "custom") {
       assert.equal(typeof message.content, "string", `custom message ${index} should use string content`);
       assert.match(String(message.content), /do not perform work for the queued goal id above/);
@@ -617,20 +579,18 @@ test("mixed stale and current follow-up batch neutralizes stale work without abo
   harness.sentMessages.length = 0;
 
   const contextResults = await emitQueuedTurnThroughContext(harness, [oldMessage, currentMessage]);
-  const contextResult = contextResults[0] as
-    | { messages?: Array<{ content?: unknown; details?: unknown }> }
-    | undefined;
+  const contextResult = requireProviderContextResult(contextResults);
 
   assert.equal(harness.abortCount, 0);
-  assert.equal(contextResult?.messages?.length, 2);
-  assert.match(String(contextResult?.messages?.[0]?.content), /queued hidden goal continuation was stale/);
-  assert.deepEqual(contextResult?.messages?.[0]?.details, {
+  assert.equal(contextResult.messages.length, 2);
+  assert.match(String(providerContextMessageAt(contextResult, 0).content), /queued hidden goal continuation was stale/);
+  assert.deepEqual(providerContextMessageAt(contextResult, 0).details, {
     kind: "stale_continuation",
     goalId: oldGoalId,
     currentGoalId: replacement?.goalId,
     currentStatus: "active",
   });
-  assert.deepEqual(contextResult?.messages?.[1]?.details, currentMessage.details);
+  assert.deepEqual(providerContextMessageAt(contextResult, 1).details, currentMessage.details);
 
   await harness.emit("turn_end", {
     type: "turn_end",

--- a/test/stale-queued-work.test.ts
+++ b/test/stale-queued-work.test.ts
@@ -519,11 +519,7 @@ test("compaction between stale context abort and cleanup does not persist, accou
     assert.equal(harness.snapshot().goal?.status, "active");
     assert.equal(harness.snapshot().goal?.usage.tokensUsed, 0);
 
-    const userMessage = {
-      role: "user",
-      content: [{ type: "text", text: "continue now" }],
-      timestamp: 2,
-    };
+    const userMessage = goalUserContextMessage("continue now", 2);
     now = 6_000;
     await emitQueuedTurnThroughContext(harness, [userMessage], 1);
     now = 8_000;

--- a/test/stale-queued-work.test.ts
+++ b/test/stale-queued-work.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { CUSTOM_ENTRY_TYPE } from "../src/types.js";
 import {
   assistantMessage,
   createRuntimeHarness,
@@ -226,11 +225,7 @@ test("stale prompt-based queued work does not pause or charge a replacement goal
   if (typeof oldPrompt !== "string") {
     assert.fail("Expected queued goal message content to be a string.");
   }
-  const oldMessage = {
-    role: "user",
-    content: [{ type: "text", text: oldPrompt }],
-    timestamp: 1,
-  };
+  const oldMessage = goalUserContextMessage(oldPrompt, 1);
 
   await harness.runCommand("new goal");
   const replacement = harness.snapshot().goal;
@@ -268,14 +263,7 @@ test("stale custom queued work aborts without pausing, charging, or requeueing a
     await harness.runCommand("old goal");
     const oldQueued = harness.sentMessages[0];
     assert.ok(oldQueued);
-    const oldMessage = {
-      role: "custom",
-      customType: CUSTOM_ENTRY_TYPE,
-      content: oldQueued.message.content,
-      display: false,
-      details: oldQueued.message.details,
-      timestamp: 1,
-    };
+    const oldMessage = queuedCustomMessage(oldQueued, 1);
 
     await harness.runCommand("new goal");
     const replacement = harness.snapshot().goal;

--- a/test/support/runtime-harness.ts
+++ b/test/support/runtime-harness.ts
@@ -6,10 +6,12 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import goalExtension, { __testHooks } from "../../src/index.js";
 import { isContextOverflowError } from "../../src/recovery.js";
 import { isGoalCustomEntry, reconstructGoal } from "../../src/state.js";
-import type {
-  ActiveGoalQueuedDetails,
-  QueuedGoalContextCarrier,
-  QueuedGoalUserContent,
+import {
+  toQueuedGoalContextCarrier,
+  type ActiveGoalQueuedDetails,
+  type QueuedGoalContextCarrier,
+  type QueuedGoalContextInput,
+  type QueuedGoalUserContent,
 } from "../../src/queued-goal-messages.js";
 import { CUSTOM_ENTRY_TYPE } from "../../src/types.js";
 
@@ -354,18 +356,65 @@ export function goalCustomContextMessage(options: {
   content: string;
   details: ActiveGoalQueuedDetails | Record<string, unknown>;
   display?: boolean;
-  timestamp?: number;
+  timestamp: number;
 }): QueuedGoalContextCarrier {
-  const message: QueuedGoalContextCarrier = {
+  return {
     role: "custom",
     customType: CUSTOM_ENTRY_TYPE,
     content: options.content,
     display: options.display ?? false,
     details: options.details,
+    timestamp: options.timestamp,
   };
-  if (options.timestamp !== undefined) {
-    message.timestamp = options.timestamp;
+}
+
+export interface ProviderContextResult {
+  messages: QueuedGoalContextCarrier[];
+}
+
+export type ProviderContextHandlerResult = ProviderContextResult | undefined;
+
+function parseProviderContextHandlerResult(result: unknown): ProviderContextHandlerResult {
+  if (result === undefined) {
+    return undefined;
   }
+
+  assert.ok(result && typeof result === "object", "Expected provider context handler result object.");
+  const candidate = result as { messages?: unknown };
+  assert.ok(Array.isArray(candidate.messages), "Expected provider context handler messages array.");
+
+  const messages: QueuedGoalContextCarrier[] = [];
+  for (const [index, message] of candidate.messages.entries()) {
+    const carrier = toQueuedGoalContextCarrier(message as QueuedGoalContextInput);
+    assert.ok(carrier, `Expected provider context message ${index} to include a numeric timestamp.`);
+    messages.push(carrier);
+  }
+
+  return { messages };
+}
+
+export function firstProviderContextResult(
+  results: ProviderContextHandlerResult[],
+): ProviderContextResult | undefined {
+  return results[0];
+}
+
+export function requireProviderContextResult(
+  results: ProviderContextHandlerResult[],
+): ProviderContextResult {
+  const result = results[0];
+  if (result === undefined) {
+    assert.fail("Expected provider context handler to return rewritten messages.");
+  }
+  return result;
+}
+
+export function providerContextMessageAt(
+  result: ProviderContextResult,
+  index: number,
+): QueuedGoalContextCarrier {
+  const message = result.messages[index];
+  assert.ok(message, `Expected provider context message at index ${index}.`);
   return message;
 }
 
@@ -381,8 +430,9 @@ export function goalUserContextMessage(text: string, timestamp = 1): QueuedGoalC
 export async function emitProviderContext(
   harness: RuntimeHarness,
   messages: QueuedGoalContextCarrier[],
-): Promise<unknown[]> {
-  return harness.emit("context", { type: "context", messages });
+): Promise<ProviderContextHandlerResult[]> {
+  const results = await harness.emit("context", { type: "context", messages });
+  return results.map(parseProviderContextHandlerResult);
 }
 
 export type RuntimeHarness = ReturnType<typeof createRuntimeHarness>;
@@ -391,13 +441,14 @@ export async function emitQueuedTurnThroughContext(
   harness: RuntimeHarness,
   messages: QueuedGoalContextCarrier[],
   turnIndex = 0,
-): Promise<unknown[]> {
+): Promise<ProviderContextHandlerResult[]> {
   await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
   for (const message of messages) {
     await harness.emit("message_start", { type: "message_start", message });
     await harness.emit("message_end", { type: "message_end", message });
   }
-  return harness.emit("context", { type: "context", messages });
+  const results = await harness.emit("context", { type: "context", messages });
+  return results.map(parseProviderContextHandlerResult);
 }
 
 export function assistantMessage(

--- a/test/support/runtime-harness.ts
+++ b/test/support/runtime-harness.ts
@@ -6,6 +6,11 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import goalExtension, { __testHooks } from "../../src/index.js";
 import { isContextOverflowError } from "../../src/recovery.js";
 import { isGoalCustomEntry, reconstructGoal } from "../../src/state.js";
+import type {
+  ActiveGoalQueuedDetails,
+  QueuedGoalContextCarrier,
+  QueuedGoalUserContent,
+} from "../../src/queued-goal-messages.js";
 import { CUSTOM_ENTRY_TYPE } from "../../src/types.js";
 
 type EventHandler = (event: object, ctx: ExtensionContext) => unknown | Promise<unknown>;
@@ -334,7 +339,7 @@ export async function emitToolExecutionEnd(harness: ReturnType<typeof createRunt
   });
 }
 
-export function queuedCustomMessage(sent: SentMessage, timestamp = 1) {
+export function queuedCustomMessage(sent: SentMessage, timestamp = 1): QueuedGoalContextCarrier {
   return {
     role: "custom",
     customType: sent.message.customType,
@@ -345,11 +350,46 @@ export function queuedCustomMessage(sent: SentMessage, timestamp = 1) {
   };
 }
 
+export function goalCustomContextMessage(options: {
+  content: string;
+  details: ActiveGoalQueuedDetails | Record<string, unknown>;
+  display?: boolean;
+  timestamp?: number;
+}): QueuedGoalContextCarrier {
+  const message: QueuedGoalContextCarrier = {
+    role: "custom",
+    customType: CUSTOM_ENTRY_TYPE,
+    content: options.content,
+    display: options.display ?? false,
+    details: options.details,
+  };
+  if (options.timestamp !== undefined) {
+    message.timestamp = options.timestamp;
+  }
+  return message;
+}
+
+export function goalUserContextMessage(text: string, timestamp = 1): QueuedGoalContextCarrier {
+  const content: QueuedGoalUserContent = [{ type: "text", text }];
+  return {
+    role: "user",
+    content,
+    timestamp,
+  };
+}
+
+export async function emitProviderContext(
+  harness: RuntimeHarness,
+  messages: QueuedGoalContextCarrier[],
+): Promise<unknown[]> {
+  return harness.emit("context", { type: "context", messages });
+}
+
 export type RuntimeHarness = ReturnType<typeof createRuntimeHarness>;
 
 export async function emitQueuedTurnThroughContext(
   harness: RuntimeHarness,
-  messages: Array<Record<string, unknown>>,
+  messages: QueuedGoalContextCarrier[],
   turnIndex = 0,
 ): Promise<unknown[]> {
   await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });

--- a/test/support/runtime-harness.ts
+++ b/test/support/runtime-harness.ts
@@ -393,12 +393,6 @@ function parseProviderContextHandlerResult(result: unknown): ProviderContextHand
   return { messages };
 }
 
-export function firstProviderContextResult(
-  results: ProviderContextHandlerResult[],
-): ProviderContextResult | undefined {
-  return results[0];
-}
-
 export function requireProviderContextResult(
   results: ProviderContextHandlerResult[],
 ): ProviderContextResult {


### PR DESCRIPTION
## Summary
- Introduces explicit queued-goal provider-context message unions (`queued-goal-messages.ts`) and rewrites `queued-goal-work.ts` helpers to use concrete superseded/stale/refreshed shapes behind the adapter boundary instead of identity-generic call-site casts.
- Queued custom work-source messages are bound to `CUSTOM_ENTRY_TYPE`; unrelated custom provider-context messages are rejected by `toQueuedGoalWorkSource`.
- Centralizes unavoidable `@earendil-works/pi-ai` `AssistantMessage` construction for overflow checks in `recovery-adapters.ts`.
- Adds typed test harness emit/result helpers and focused `test/queued-goal-work.test.ts` boundary coverage.

## Cast isolation
- Provider-context messages now normalize through `toQueuedGoalContextCarrier` / `toQueuedGoalWorkSource`; normalized carriers require runtime `timestamp` and user/custom array content is normalized through text-part helpers.
- Provider-context rewrites are applied through `applyQueuedGoalProviderContextRewrites`; rewrite-result unions, stale rewrite helpers, and active continuation dedupe stay module-private in `queued-goal-work.ts`, with the remaining bridge cast isolated in unexported `mergeProviderContextMessage`.
- Recovery overflow casts are isolated in `assistantMessageForOverflowCheck` in `recovery-adapters.ts`.

## Test plan
- [x] `npm run verify` (158 tests)
- [x] `npx tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false` (only known pre-existing unused symbols in `src/index.ts` and `test/recovery.test.ts`)
- [x] `git diff --check`
- [x] `git show --check --oneline HEAD`

Closes #25