### PR TITLE
Fold host overflow recovery flags into a typed recovery phase

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 import { formatGoalSummary } from "./format.js";
+import type { GoalStartTurnStrategy } from "./recovery-machine.js";
 import { compactContinuationPrompt, continuationPrompt } from "./prompts.js";
 import { replaceGoal, updateGoalStatus } from "./state.js";
 import { CUSTOM_ENTRY_TYPE, type GoalEntrySource, type ThreadGoal } from "./types.js";
@@ -9,7 +10,7 @@ export interface CommandHost {
   getGoal(): ThreadGoal | null;
   setGoal(goal: ThreadGoal, source: GoalEntrySource, ctx: GoalCommandContext): void;
   clearGoal(source: GoalEntrySource, ctx: GoalCommandContext): void;
-  needsHostOverflowCapReset(): boolean;
+  getGoalStartTurnStrategy(): GoalStartTurnStrategy;
 }
 
 const COMMANDS = ["pause", "resume", "clear"] as const;
@@ -111,7 +112,7 @@ export async function handleGoalCommand(
   }
   host.setGoal(result.goal, "command", ctx);
   ctx.ui.notify(result.message);
-  if (host.needsHostOverflowCapReset()) {
+  if (host.getGoalStartTurnStrategy() === "userFollowUp") {
     queueGoalUserStartTurn(pi, result.goal);
   } else {
     queueGoalTurn(pi, result.goal, "command_start");

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,14 @@ import {
   type StaleQueuedWorkGuard,
 } from "./stale-queued-work-guard.js";
 import {
-  applyPersistedHostOverflowUserReset,
-  clearHostOverflowRecoveryActive,
+  applyHostOverflowUserResetPersistence,
+  clearActiveHostOverflowRecovery,
   createGoalRecoveryMachine,
   goalStartTurnStrategy,
   recoveryPhaseBlocksContinuation,
-  recoveryPhaseNeedsUserStartTurn,
   resetRecoveryMachine,
   setRecoveryPausedAttention,
+  syncHostOverflowUserResetFromSession,
   type GoalRecoveryMachineState,
 } from "./recovery-machine.js";
 import { createGoalRecoveryRuntime } from "./recovery-runtime.js";
@@ -320,10 +320,9 @@ export default function (pi: ExtensionAPI): void {
   };
 
   const persistHostOverflowUserReset = (needsReset: boolean): void => {
-    if (recoveryPhaseNeedsUserStartTurn(recoveryState.phase) === needsReset) {
+    if (!applyHostOverflowUserResetPersistence(recoveryState, needsReset)) {
       return;
     }
-    recoveryState.phase = applyPersistedHostOverflowUserReset(recoveryState.phase, needsReset);
     pi.appendEntry(CUSTOM_ENTRY_TYPE, hostOverflowCapResetEntry(needsReset));
   };
 
@@ -333,8 +332,8 @@ export default function (pi: ExtensionAPI): void {
     goal = reconstructGoal(branch).goal;
     lastPersistedGoal = goal ? cloneGoal(goal) : null;
     lastRuntimePersistAt = null;
-    recoveryState.phase = applyPersistedHostOverflowUserReset(
-      recoveryState.phase,
+    syncHostOverflowUserResetFromSession(
+      recoveryState,
       reconstructHostOverflowCapNeedsUserReset(branch),
     );
     clearContinuationState();
@@ -454,15 +453,16 @@ export default function (pi: ExtensionAPI): void {
     }
 
     clearContinuationState();
-    recoveryState.phase = clearHostOverflowRecoveryActive(recoveryState.phase);
+    clearActiveHostOverflowRecovery(recoveryState);
     setRecoveryPausedAttention(recoveryState, reason);
     persistGoal(result.goal, "runtime");
     refreshUi(ctx);
   };
 
   const beginOverflowRecoveryAttention = (ctx: ExtensionContext): void => {
-    persistHostOverflowUserReset(true);
-    recoveryRuntime.beginOverflowRecovery(ctx);
+    if (recoveryRuntime.beginOverflowRecovery(ctx)) {
+      pi.appendEntry(CUSTOM_ENTRY_TYPE, hostOverflowCapResetEntry(true));
+    }
   };
 
   const recordAssistantContextOverflow = (
@@ -520,7 +520,7 @@ export default function (pi: ExtensionAPI): void {
     const continuationGoalId = continuationGoalIdFromPrompt(event.text);
 
     if (event.source !== "extension") {
-      recoveryState.phase = clearHostOverflowRecoveryActive(recoveryState.phase);
+      clearActiveHostOverflowRecovery(recoveryState);
       recoveryRuntime.onUserInput();
       applyStaleQueuedWorkEffects(staleQueuedWorkGuard.planUserInputClearAbort().effects, ctx);
       if (continuationGoalId !== null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -520,7 +520,6 @@ export default function (pi: ExtensionAPI): void {
     const continuationGoalId = continuationGoalIdFromPrompt(event.text);
 
     if (event.source !== "extension") {
-      clearActiveHostOverflowRecovery(recoveryState);
       recoveryRuntime.onUserInput();
       applyStaleQueuedWorkEffects(staleQueuedWorkGuard.planUserInputClearAbort().effects, ctx);
       if (continuationGoalId !== null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,12 @@ import {
   type StaleQueuedWorkGuard,
 } from "./stale-queued-work-guard.js";
 import {
+  applyPersistedHostOverflowUserReset,
+  clearHostOverflowRecoveryActive,
   createGoalRecoveryMachine,
+  goalStartTurnStrategy,
+  recoveryPhaseBlocksContinuation,
+  recoveryPhaseNeedsUserStartTurn,
   resetRecoveryMachine,
   setRecoveryPausedAttention,
   type GoalRecoveryMachineState,
@@ -76,8 +81,6 @@ export default function (pi: ExtensionAPI): void {
   let passthroughContinuationInput: { text: string; turnIndex: number | null } | null = null;
   const accounting = createAccountingState();
   let recoveryState: GoalRecoveryMachineState = createGoalRecoveryMachine();
-  let hostOverflowRecoveryInProgress = false;
-  let hostOverflowCapNeedsUserReset = false;
   let lastPersistedGoal: ThreadGoal | null = null;
   let lastRuntimePersistAt: number | null = null;
 
@@ -101,7 +104,6 @@ export default function (pi: ExtensionAPI): void {
 
   const resetErrorRecovery = (): void => {
     resetRecoveryMachine(recoveryState);
-    hostOverflowRecoveryInProgress = false;
   };
 
   const clearContinuationState = (): void => {
@@ -317,11 +319,11 @@ export default function (pi: ExtensionAPI): void {
     refreshUi(ctx);
   };
 
-  const setHostOverflowCapNeedsUserReset = (needsReset: boolean): void => {
-    if (hostOverflowCapNeedsUserReset === needsReset) {
+  const persistHostOverflowUserReset = (needsReset: boolean): void => {
+    if (recoveryPhaseNeedsUserStartTurn(recoveryState.phase) === needsReset) {
       return;
     }
-    hostOverflowCapNeedsUserReset = needsReset;
+    recoveryState.phase = applyPersistedHostOverflowUserReset(recoveryState.phase, needsReset);
     pi.appendEntry(CUSTOM_ENTRY_TYPE, hostOverflowCapResetEntry(needsReset));
   };
 
@@ -331,7 +333,10 @@ export default function (pi: ExtensionAPI): void {
     goal = reconstructGoal(branch).goal;
     lastPersistedGoal = goal ? cloneGoal(goal) : null;
     lastRuntimePersistAt = null;
-    hostOverflowCapNeedsUserReset = reconstructHostOverflowCapNeedsUserReset(branch);
+    recoveryState.phase = applyPersistedHostOverflowUserReset(
+      recoveryState.phase,
+      reconstructHostOverflowCapNeedsUserReset(branch),
+    );
     clearContinuationState();
     if (goal?.status !== "active") {
       clearActiveAccounting();
@@ -389,7 +394,7 @@ export default function (pi: ExtensionAPI): void {
       goal.status !== "active" ||
       continuationQueuedFor === goal.goalId ||
       hasPendingRecoveryAttention() ||
-      hostOverflowRecoveryInProgress
+      recoveryPhaseBlocksContinuation(recoveryState.phase)
     ) {
       return;
     }
@@ -449,15 +454,14 @@ export default function (pi: ExtensionAPI): void {
     }
 
     clearContinuationState();
-    hostOverflowRecoveryInProgress = false;
+    recoveryState.phase = clearHostOverflowRecoveryActive(recoveryState.phase);
     setRecoveryPausedAttention(recoveryState, reason);
     persistGoal(result.goal, "runtime");
     refreshUi(ctx);
   };
 
   const beginOverflowRecoveryAttention = (ctx: ExtensionContext): void => {
-    setHostOverflowCapNeedsUserReset(true);
-    hostOverflowRecoveryInProgress = true;
+    persistHostOverflowUserReset(true);
     recoveryRuntime.beginOverflowRecovery(ctx);
   };
 
@@ -489,7 +493,7 @@ export default function (pi: ExtensionAPI): void {
 
   registerGoalCommand(pi, {
     getGoal: () => goalForDisplay(),
-    needsHostOverflowCapReset: () => hostOverflowCapNeedsUserReset,
+    getGoalStartTurnStrategy: () => goalStartTurnStrategy(recoveryState.phase),
     setGoal(nextGoal, source, ctx) {
       const wasPaused = goal?.status === "paused";
       persistGoal(nextGoal, source);
@@ -516,7 +520,7 @@ export default function (pi: ExtensionAPI): void {
     const continuationGoalId = continuationGoalIdFromPrompt(event.text);
 
     if (event.source !== "extension") {
-      hostOverflowRecoveryInProgress = false;
+      recoveryState.phase = clearHostOverflowRecoveryActive(recoveryState.phase);
       recoveryRuntime.onUserInput();
       applyStaleQueuedWorkEffects(staleQueuedWorkGuard.planUserInputClearAbort().effects, ctx);
       if (continuationGoalId !== null) {
@@ -594,7 +598,7 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("message_start", async (event) => {
     if (event.message.role === "user") {
-      setHostOverflowCapNeedsUserReset(false);
+      persistHostOverflowUserReset(false);
     }
 
     const queuedGoalId = queuedGoalWorkMessageIdForRuntime(event.message);
@@ -698,7 +702,6 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
     resetErrorRecovery();
-    hostOverflowRecoveryInProgress = false;
     maybeContinue(ctx);
   });
 
@@ -723,7 +726,7 @@ export default function (pi: ExtensionAPI): void {
     flushGoalPersistence("runtime");
     recoveryRuntime.onSessionCompact();
     refreshUi(ctx);
-    if (!hostOverflowRecoveryInProgress) {
+    if (!recoveryPhaseBlocksContinuation(recoveryState.phase)) {
       maybeContinue(ctx);
     }
   });

--- a/src/recovery-machine.ts
+++ b/src/recovery-machine.ts
@@ -121,6 +121,13 @@ export function syncHostOverflowUserResetFromSession(
   state.phase = applyPersistedHostOverflowUserReset(state.phase, needsUserReset);
 }
 
+/** Session-level overflow: require a user-started goal turn even without an active goal. */
+export function requireHostOverflowUserReset(state: GoalRecoveryMachineState): boolean {
+  const persistHostOverflowCapReset = !recoveryPhaseNeedsUserStartTurn(state.phase);
+  state.phase = applyPersistedHostOverflowUserReset(state.phase, true);
+  return persistHostOverflowCapReset;
+}
+
 export function beginHostOverflowRecovery(state: GoalRecoveryMachineState): {
   attention: string;
   persistHostOverflowCapReset: boolean;

--- a/src/recovery-machine.ts
+++ b/src/recovery-machine.ts
@@ -1,7 +1,10 @@
 import {
+  applyPersistedHostOverflowUserReset,
   clearHostOverflowRecoveryActive,
-  enterHostOverflowRecoveryPhase,
+  clearHostOverflowUserReset,
+  hostOverflowRecoveringNeedsUserStartPhase,
   idleRecoveryPhase,
+  recoveryPhaseNeedsUserStartTurn,
   type RecoveryPhase,
 } from "./recovery-phase.js";
 import {
@@ -22,9 +25,6 @@ import {
 
 export type { GoalStartTurnStrategy, RecoveryPhase } from "./recovery-phase.js";
 export {
-  applyPersistedHostOverflowUserReset,
-  clearHostOverflowRecoveryActive,
-  clearHostOverflowUserReset,
   goalStartTurnStrategy,
   recoveryPhaseBlocksContinuation,
   recoveryPhaseNeedsUserStartTurn,
@@ -52,7 +52,7 @@ export function createGoalRecoveryMachine(): GoalRecoveryMachineState {
 export function resetRecoveryMachine(state: GoalRecoveryMachineState): void {
   state.counters = createErrorRecoveryCounters();
   state.attention = null;
-  state.phase = clearHostOverflowRecoveryActive(state.phase);
+  clearActiveHostOverflowRecovery(state);
 }
 
 export function resetRecoveryCounters(state: GoalRecoveryMachineState): void {
@@ -100,9 +100,40 @@ export function setRecoveryPausedAttention(state: GoalRecoveryMachineState, reas
   return message;
 }
 
-export function beginHostOverflowRecovery(state: GoalRecoveryMachineState): string {
-  state.phase = enterHostOverflowRecoveryPhase();
-  return setRecoveryPendingAttention(state, HOST_OVERFLOW_RECOVERY_REASON);
+export function clearActiveHostOverflowRecovery(state: GoalRecoveryMachineState): void {
+  state.phase = clearHostOverflowRecoveryActive(state.phase);
+}
+
+export function acknowledgeHostOverflowUserResetCleared(state: GoalRecoveryMachineState): void {
+  state.phase = clearHostOverflowUserReset(state.phase);
+}
+
+export function applyHostOverflowUserResetPersistence(
+  state: GoalRecoveryMachineState,
+  needsUserReset: boolean,
+): boolean {
+  if (recoveryPhaseNeedsUserStartTurn(state.phase) === needsUserReset) {
+    return false;
+  }
+  state.phase = applyPersistedHostOverflowUserReset(state.phase, needsUserReset);
+  return true;
+}
+
+export function syncHostOverflowUserResetFromSession(
+  state: GoalRecoveryMachineState,
+  needsUserReset: boolean,
+): void {
+  state.phase = applyPersistedHostOverflowUserReset(state.phase, needsUserReset);
+}
+
+export function beginHostOverflowRecovery(state: GoalRecoveryMachineState): {
+  attention: string;
+  persistHostOverflowCapReset: boolean;
+} {
+  const persistHostOverflowCapReset = !recoveryPhaseNeedsUserStartTurn(state.phase);
+  state.phase = hostOverflowRecoveringNeedsUserStartPhase();
+  const attention = setRecoveryPendingAttention(state, HOST_OVERFLOW_RECOVERY_REASON);
+  return { attention, persistHostOverflowCapReset };
 }
 
 function incrementOverflowCompactionAttempts(state: GoalRecoveryMachineState): RecoveryAction {

--- a/src/recovery-machine.ts
+++ b/src/recovery-machine.ts
@@ -1,4 +1,10 @@
 import {
+  clearHostOverflowRecoveryActive,
+  enterHostOverflowRecoveryPhase,
+  idleRecoveryPhase,
+  type RecoveryPhase,
+} from "./recovery-phase.js";
+import {
   CONTEXT_OVERFLOW_SIGNATURE,
   countersForFailureSignature,
   createErrorRecoveryCounters,
@@ -14,6 +20,16 @@ import {
   type ErrorRecoveryCounters,
 } from "./recovery.js";
 
+export type { GoalStartTurnStrategy, RecoveryPhase } from "./recovery-phase.js";
+export {
+  applyPersistedHostOverflowUserReset,
+  clearHostOverflowRecoveryActive,
+  clearHostOverflowUserReset,
+  goalStartTurnStrategy,
+  recoveryPhaseBlocksContinuation,
+  recoveryPhaseNeedsUserStartTurn,
+} from "./recovery-phase.js";
+
 export type RecoveryAction =
   | { type: "noop" }
   | { type: "pending"; reason: string }
@@ -22,18 +38,21 @@ export type RecoveryAction =
 export interface GoalRecoveryMachineState {
   counters: ErrorRecoveryCounters;
   attention: string | null;
+  phase: RecoveryPhase;
 }
 
 export function createGoalRecoveryMachine(): GoalRecoveryMachineState {
   return {
     counters: createErrorRecoveryCounters(),
     attention: null,
+    phase: idleRecoveryPhase,
   };
 }
 
 export function resetRecoveryMachine(state: GoalRecoveryMachineState): void {
   state.counters = createErrorRecoveryCounters();
   state.attention = null;
+  state.phase = clearHostOverflowRecoveryActive(state.phase);
 }
 
 export function resetRecoveryCounters(state: GoalRecoveryMachineState): void {
@@ -82,6 +101,7 @@ export function setRecoveryPausedAttention(state: GoalRecoveryMachineState, reas
 }
 
 export function beginHostOverflowRecovery(state: GoalRecoveryMachineState): string {
+  state.phase = enterHostOverflowRecoveryPhase();
   return setRecoveryPendingAttention(state, HOST_OVERFLOW_RECOVERY_REASON);
 }
 

--- a/src/recovery-machine.ts
+++ b/src/recovery-machine.ts
@@ -1,7 +1,6 @@
 import {
   applyPersistedHostOverflowUserReset,
   clearHostOverflowRecoveryActive,
-  clearHostOverflowUserReset,
   hostOverflowRecoveringNeedsUserStartPhase,
   idleRecoveryPhase,
   recoveryPhaseNeedsUserStartTurn,
@@ -102,10 +101,6 @@ export function setRecoveryPausedAttention(state: GoalRecoveryMachineState, reas
 
 export function clearActiveHostOverflowRecovery(state: GoalRecoveryMachineState): void {
   state.phase = clearHostOverflowRecoveryActive(state.phase);
-}
-
-export function acknowledgeHostOverflowUserResetCleared(state: GoalRecoveryMachineState): void {
-  state.phase = clearHostOverflowUserReset(state.phase);
 }
 
 export function applyHostOverflowUserResetPersistence(

--- a/src/recovery-phase.ts
+++ b/src/recovery-phase.ts
@@ -1,17 +1,17 @@
 export type RecoveryPhase =
   | { kind: "idle" }
-  | { kind: "pendingHostOverflow"; hostRecoveryActive: boolean; needsUserReset: boolean };
+  | { kind: "hostOverflowRecoveringNeedsUserStart" }
+  | { kind: "hostOverflowRecovering" }
+  | { kind: "hostOverflowNeedsUserStart" };
 
 export type GoalStartTurnStrategy = "hiddenFollowUp" | "userFollowUp";
 
 export const idleRecoveryPhase: RecoveryPhase = { kind: "idle" };
 
-export function resetRecoveryPhase(): RecoveryPhase {
-  return idleRecoveryPhase;
-}
-
 export function recoveryPhaseNeedsUserStartTurn(phase: RecoveryPhase): boolean {
-  return phase.kind === "pendingHostOverflow" && phase.needsUserReset;
+  return (
+    phase.kind === "hostOverflowRecoveringNeedsUserStart" || phase.kind === "hostOverflowNeedsUserStart"
+  );
 }
 
 export function goalStartTurnStrategy(phase: RecoveryPhase): GoalStartTurnStrategy {
@@ -19,33 +19,33 @@ export function goalStartTurnStrategy(phase: RecoveryPhase): GoalStartTurnStrate
 }
 
 export function recoveryPhaseBlocksContinuation(phase: RecoveryPhase): boolean {
-  return phase.kind === "pendingHostOverflow" && phase.hostRecoveryActive;
+  return phase.kind === "hostOverflowRecoveringNeedsUserStart" || phase.kind === "hostOverflowRecovering";
 }
 
-export function enterHostOverflowRecoveryPhase(): RecoveryPhase {
-  return {
-    kind: "pendingHostOverflow",
-    hostRecoveryActive: true,
-    needsUserReset: true,
-  };
+export function hostOverflowRecoveringNeedsUserStartPhase(): RecoveryPhase {
+  return { kind: "hostOverflowRecoveringNeedsUserStart" };
 }
 
 export function clearHostOverflowRecoveryActive(phase: RecoveryPhase): RecoveryPhase {
-  if (phase.kind !== "pendingHostOverflow" || !phase.hostRecoveryActive) {
-    return phase;
+  switch (phase.kind) {
+    case "hostOverflowRecoveringNeedsUserStart":
+      return { kind: "hostOverflowNeedsUserStart" };
+    case "hostOverflowRecovering":
+      return idleRecoveryPhase;
+    default:
+      return phase;
   }
-  return { ...phase, hostRecoveryActive: false };
 }
 
 export function clearHostOverflowUserReset(phase: RecoveryPhase): RecoveryPhase {
-  if (phase.kind !== "pendingHostOverflow" || !phase.needsUserReset) {
-    return phase;
+  switch (phase.kind) {
+    case "hostOverflowRecoveringNeedsUserStart":
+      return { kind: "hostOverflowRecovering" };
+    case "hostOverflowNeedsUserStart":
+      return idleRecoveryPhase;
+    default:
+      return phase;
   }
-  const next: RecoveryPhase = { ...phase, needsUserReset: false };
-  if (!next.hostRecoveryActive) {
-    return idleRecoveryPhase;
-  }
-  return next;
 }
 
 export function applyPersistedHostOverflowUserReset(
@@ -55,12 +55,13 @@ export function applyPersistedHostOverflowUserReset(
   if (!needsUserReset) {
     return clearHostOverflowUserReset(phase);
   }
-  if (phase.kind === "pendingHostOverflow") {
-    return { ...phase, needsUserReset: true };
+  switch (phase.kind) {
+    case "hostOverflowRecovering":
+      return { kind: "hostOverflowRecoveringNeedsUserStart" };
+    case "hostOverflowRecoveringNeedsUserStart":
+    case "hostOverflowNeedsUserStart":
+      return phase;
+    default:
+      return { kind: "hostOverflowNeedsUserStart" };
   }
-  return {
-    kind: "pendingHostOverflow",
-    hostRecoveryActive: false,
-    needsUserReset: true,
-  };
 }

--- a/src/recovery-phase.ts
+++ b/src/recovery-phase.ts
@@ -8,10 +8,21 @@ export type GoalStartTurnStrategy = "hiddenFollowUp" | "userFollowUp";
 
 export const idleRecoveryPhase: RecoveryPhase = { kind: "idle" };
 
+function assertNever(value: never): never {
+  throw new Error(`Unexpected recovery phase: ${JSON.stringify(value)}`);
+}
+
 export function recoveryPhaseNeedsUserStartTurn(phase: RecoveryPhase): boolean {
-  return (
-    phase.kind === "hostOverflowRecoveringNeedsUserStart" || phase.kind === "hostOverflowNeedsUserStart"
-  );
+  switch (phase.kind) {
+    case "idle":
+    case "hostOverflowRecovering":
+      return false;
+    case "hostOverflowRecoveringNeedsUserStart":
+    case "hostOverflowNeedsUserStart":
+      return true;
+    default:
+      return assertNever(phase);
+  }
 }
 
 export function goalStartTurnStrategy(phase: RecoveryPhase): GoalStartTurnStrategy {
@@ -19,7 +30,16 @@ export function goalStartTurnStrategy(phase: RecoveryPhase): GoalStartTurnStrate
 }
 
 export function recoveryPhaseBlocksContinuation(phase: RecoveryPhase): boolean {
-  return phase.kind === "hostOverflowRecoveringNeedsUserStart" || phase.kind === "hostOverflowRecovering";
+  switch (phase.kind) {
+    case "idle":
+    case "hostOverflowNeedsUserStart":
+      return false;
+    case "hostOverflowRecoveringNeedsUserStart":
+    case "hostOverflowRecovering":
+      return true;
+    default:
+      return assertNever(phase);
+  }
 }
 
 export function hostOverflowRecoveringNeedsUserStartPhase(): RecoveryPhase {
@@ -32,8 +52,11 @@ export function clearHostOverflowRecoveryActive(phase: RecoveryPhase): RecoveryP
       return { kind: "hostOverflowNeedsUserStart" };
     case "hostOverflowRecovering":
       return idleRecoveryPhase;
-    default:
+    case "idle":
+    case "hostOverflowNeedsUserStart":
       return phase;
+    default:
+      return assertNever(phase);
   }
 }
 
@@ -43,8 +66,11 @@ export function clearHostOverflowUserReset(phase: RecoveryPhase): RecoveryPhase 
       return { kind: "hostOverflowRecovering" };
     case "hostOverflowNeedsUserStart":
       return idleRecoveryPhase;
-    default:
+    case "idle":
+    case "hostOverflowRecovering":
       return phase;
+    default:
+      return assertNever(phase);
   }
 }
 
@@ -61,7 +87,9 @@ export function applyPersistedHostOverflowUserReset(
     case "hostOverflowRecoveringNeedsUserStart":
     case "hostOverflowNeedsUserStart":
       return phase;
-    default:
+    case "idle":
       return { kind: "hostOverflowNeedsUserStart" };
+    default:
+      return assertNever(phase);
   }
 }

--- a/src/recovery-phase.ts
+++ b/src/recovery-phase.ts
@@ -1,0 +1,66 @@
+export type RecoveryPhase =
+  | { kind: "idle" }
+  | { kind: "pendingHostOverflow"; hostRecoveryActive: boolean; needsUserReset: boolean };
+
+export type GoalStartTurnStrategy = "hiddenFollowUp" | "userFollowUp";
+
+export const idleRecoveryPhase: RecoveryPhase = { kind: "idle" };
+
+export function resetRecoveryPhase(): RecoveryPhase {
+  return idleRecoveryPhase;
+}
+
+export function recoveryPhaseNeedsUserStartTurn(phase: RecoveryPhase): boolean {
+  return phase.kind === "pendingHostOverflow" && phase.needsUserReset;
+}
+
+export function goalStartTurnStrategy(phase: RecoveryPhase): GoalStartTurnStrategy {
+  return recoveryPhaseNeedsUserStartTurn(phase) ? "userFollowUp" : "hiddenFollowUp";
+}
+
+export function recoveryPhaseBlocksContinuation(phase: RecoveryPhase): boolean {
+  return phase.kind === "pendingHostOverflow" && phase.hostRecoveryActive;
+}
+
+export function enterHostOverflowRecoveryPhase(): RecoveryPhase {
+  return {
+    kind: "pendingHostOverflow",
+    hostRecoveryActive: true,
+    needsUserReset: true,
+  };
+}
+
+export function clearHostOverflowRecoveryActive(phase: RecoveryPhase): RecoveryPhase {
+  if (phase.kind !== "pendingHostOverflow" || !phase.hostRecoveryActive) {
+    return phase;
+  }
+  return { ...phase, hostRecoveryActive: false };
+}
+
+export function clearHostOverflowUserReset(phase: RecoveryPhase): RecoveryPhase {
+  if (phase.kind !== "pendingHostOverflow" || !phase.needsUserReset) {
+    return phase;
+  }
+  const next: RecoveryPhase = { ...phase, needsUserReset: false };
+  if (!next.hostRecoveryActive) {
+    return idleRecoveryPhase;
+  }
+  return next;
+}
+
+export function applyPersistedHostOverflowUserReset(
+  phase: RecoveryPhase,
+  needsUserReset: boolean,
+): RecoveryPhase {
+  if (!needsUserReset) {
+    return clearHostOverflowUserReset(phase);
+  }
+  if (phase.kind === "pendingHostOverflow") {
+    return { ...phase, needsUserReset: true };
+  }
+  return {
+    kind: "pendingHostOverflow",
+    hostRecoveryActive: false,
+    needsUserReset: true,
+  };
+}

--- a/src/recovery-runtime.ts
+++ b/src/recovery-runtime.ts
@@ -7,6 +7,7 @@ import {
   onRecoveryUserInput,
   planRecoveryForAssistantError,
   planRecoveryForSilentContextOverflow,
+  requireHostOverflowUserReset,
   setRecoveryPausedAttention,
   setRecoveryPendingAttention,
   type GoalRecoveryMachineState,
@@ -77,14 +78,16 @@ export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
 
   const beginOverflowRecovery = (ctx: ExtensionContext): boolean => {
     const goal = deps.getGoal();
-    if (!goal || goal.status !== "active") {
-      return false;
+    const hasActiveGoal = Boolean(goal && goal.status === "active");
+
+    if (hasActiveGoal) {
+      deps.clearContinuationState();
+      const { persistHostOverflowCapReset } = beginHostOverflowRecovery(deps.getRecoveryState());
+      deps.refreshUi(ctx);
+      return persistHostOverflowCapReset;
     }
 
-    deps.clearContinuationState();
-    const { persistHostOverflowCapReset } = beginHostOverflowRecovery(deps.getRecoveryState());
-    deps.refreshUi(ctx);
-    return persistHostOverflowCapReset;
+    return requireHostOverflowUserReset(deps.getRecoveryState());
   };
 
   const finishSuccessfulAssistantTurn = (

--- a/src/recovery-runtime.ts
+++ b/src/recovery-runtime.ts
@@ -75,15 +75,16 @@ export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
     applyRecoveryAction(planRecoveryForSilentContextOverflow(deps.getRecoveryState()), ctx);
   };
 
-  const beginOverflowRecovery = (ctx: ExtensionContext): void => {
+  const beginOverflowRecovery = (ctx: ExtensionContext): boolean => {
     const goal = deps.getGoal();
     if (!goal || goal.status !== "active") {
-      return;
+      return false;
     }
 
     deps.clearContinuationState();
-    beginHostOverflowRecovery(deps.getRecoveryState());
+    const { persistHostOverflowCapReset } = beginHostOverflowRecovery(deps.getRecoveryState());
     deps.refreshUi(ctx);
+    return persistHostOverflowCapReset;
   };
 
   const finishSuccessfulAssistantTurn = (

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { handleGoalCommand, type CommandHost, type GoalCommandContext, type GoalCommandPi } from "../src/commands.js";
+import {
+  handleGoalCommand,
+  type CommandHost,
+  type GoalCommandContext,
+  type GoalCommandPi,
+} from "../src/commands.js";
+import type { GoalStartTurnStrategy } from "../src/recovery-machine.js";
 import { applyUsage, updateGoalStatus } from "../src/state.js";
 import { CUSTOM_ENTRY_TYPE, type GoalEntrySource, type ThreadGoal } from "../src/types.js";
 
@@ -39,7 +45,7 @@ function createHarness() {
     clearGoal() {
       goal = null;
     },
-    needsHostOverflowCapReset: () => false,
+    getGoalStartTurnStrategy: () => "hiddenFollowUp",
   };
 
   const ctx: GoalCommandContext = {
@@ -120,7 +126,7 @@ test("/goal resume sends a user continuation turn", async () => {
 
 test("/goal objective after overflow recovery sends a user start turn", async () => {
   const harness = createHarness();
-  let needsHostOverflowCapReset = true;
+  let startTurnStrategy: GoalStartTurnStrategy = "userFollowUp";
   const host: CommandHost = {
     getGoal: () => harness.goal,
     setGoal(nextGoal: ThreadGoal) {
@@ -129,7 +135,7 @@ test("/goal objective after overflow recovery sends a user start turn", async ()
     clearGoal() {
       harness.setGoal(null);
     },
-    needsHostOverflowCapReset: () => needsHostOverflowCapReset,
+    getGoalStartTurnStrategy: () => startTurnStrategy,
   };
 
   await handleGoalCommand(harness.pi, host, "ship the feature", harness.ctx);
@@ -147,7 +153,7 @@ test("/goal objective after overflow recovery sends a user start turn", async ()
   assert.match(content, /<pi_goal_continuation goal_id="/);
   assert.doesNotMatch(content, /<untrusted_objective>/);
 
-  needsHostOverflowCapReset = false;
+  startTurnStrategy = "hiddenFollowUp";
   harness.sentUserMessages.length = 0;
   await handleGoalCommand(harness.pi, host, "another objective", harness.ctx);
   assert.equal(harness.sentMessages.length, 1);

--- a/test/recovery-commands.test.ts
+++ b/test/recovery-commands.test.ts
@@ -5,6 +5,7 @@ import {
   continuationGoalIdFromPrompt,
   continuationPrompt,
 } from "../src/prompts.js";
+import { isGoalCustomEntry } from "../src/state.js";
 import { CUSTOM_ENTRY_TYPE } from "../src/types.js";
 import {
   createRuntimeHarness,
@@ -266,4 +267,80 @@ test("/goal clear then start after overflow pause survives extension reload and 
 
   await emitPersistentAssistantError(harness, 2, "context_length_exceeded");
   assert.equal(harness.snapshot().goal?.status, "active");
+});
+
+test("context overflow before any active goal sends user /goal start and persists cap reset", async () => {
+  const harness = createRuntimeHarness();
+  assert.equal(harness.snapshot().goal, null);
+
+  await emitPersistentAssistantError(harness, 0, "context_length_exceeded");
+  assert.equal(harness.hostOverflowRecoveryAttempted, true);
+  assert.equal(
+    harness.entries.some(
+      (entry) =>
+        entry.type === "custom" &&
+        entry.customType === CUSTOM_ENTRY_TYPE &&
+        isGoalCustomEntry(entry.data) &&
+        entry.data.kind === "host_overflow_cap_reset" &&
+        entry.data.active === true,
+    ),
+    true,
+  );
+
+  harness.sentMessages.length = 0;
+  harness.sentUserMessages.length = 0;
+  await harness.runCommand("ship the feature");
+
+  const goal = harness.snapshot().goal;
+  assert.ok(goal);
+  assert.equal(goal.status, "active");
+  assert.equal(goal.objective, "ship the feature");
+  assert.equal(harness.sentMessages.length, 0);
+  assert.equal(harness.sentUserMessages.length, 1);
+
+  const startMessage = harness.sentUserMessages[0];
+  assert.ok(startMessage);
+  assert.deepEqual(startMessage.options, { deliverAs: "followUp" });
+  const content = startMessage.content;
+  if (typeof content !== "string") {
+    assert.fail("Expected overflow goal start to send a user continuation prompt.");
+  }
+  assert.match(content, /<pi_goal_continuation goal_id="/);
+  assert.equal(continuationGoalIdFromPrompt(content), goal.goalId);
+
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: { role: "user", content },
+  });
+  assert.equal(harness.hostOverflowRecoveryAttempted, false);
+});
+
+test("context overflow while goal is paused sends user turn on replacement start", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  await harness.runCommand("pause");
+  assert.equal(harness.snapshot().goal?.status, "paused");
+
+  await emitPersistentAssistantError(harness, 1, "context_length_exceeded");
+  assert.equal(harness.snapshot().goal?.status, "paused");
+  assert.equal(harness.hostOverflowRecoveryAttempted, true);
+
+  const { goal, previousGoalId } = await replaceGoalAfterOverflowPause(harness, "ship the replacement");
+  assert.notEqual(goal.goalId, previousGoalId);
+  assert.equal(harness.sentMessages.length, 0);
+  assert.equal(harness.sentUserMessages.length, 1);
+
+  const startMessage = harness.sentUserMessages[0];
+  assert.ok(startMessage);
+  const content = startMessage.content;
+  if (typeof content !== "string") {
+    assert.fail("Expected paused-overflow replacement start to send a user continuation prompt.");
+  }
+  assert.equal(continuationGoalIdFromPrompt(content), goal.goalId);
+
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: { role: "user", content },
+  });
+  assert.equal(harness.hostOverflowRecoveryAttempted, false);
 });

--- a/test/recovery-runtime.test.ts
+++ b/test/recovery-runtime.test.ts
@@ -5,6 +5,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 import { createGoalRecoveryMachine } from "../src/recovery-machine.js";
 import { createGoalRecoveryRuntime } from "../src/recovery-runtime.js";
+import { recoveryPhaseNeedsUserStartTurn } from "../src/recovery-phase.js";
 import { CONTEXT_OVERFLOW_SIGNATURE } from "../src/recovery.js";
 import type { ThreadGoal } from "../src/types.js";
 
@@ -18,20 +19,23 @@ const activeGoal: ThreadGoal = {
   updatedAt: 0,
 };
 
-function createRecoveryTestRuntime() {
+function createRecoveryTestRuntime(goal: ThreadGoal | null = activeGoal) {
   let recoveryState = createGoalRecoveryMachine();
   let continueCount = 0;
+  let refreshCount = 0;
 
   const ctx = {
     ui: { setStatus() {} },
   } as unknown as ExtensionContext;
 
   const runtime = createGoalRecoveryRuntime({
-    getGoal: () => activeGoal,
+    getGoal: () => goal,
     getRecoveryState: () => recoveryState,
     clearContinuationState: () => {},
     pauseGoalForRecovery: () => {},
-    refreshUi: () => {},
+    refreshUi: () => {
+      refreshCount += 1;
+    },
     maybeContinue: () => {
       continueCount += 1;
     },
@@ -43,11 +47,35 @@ function createRecoveryTestRuntime() {
     get continueCount() {
       return continueCount;
     },
+    get refreshCount() {
+      return refreshCount;
+    },
     get recoveryState() {
       return recoveryState;
     },
   };
 }
+
+test("beginOverflowRecovery without an active goal records user reset only", () => {
+  const harness = createRecoveryTestRuntime(null);
+
+  assert.equal(harness.runtime.beginOverflowRecovery(harness.ctx), true);
+  assert.equal(harness.recoveryState.phase.kind, "hostOverflowNeedsUserStart");
+  assert.equal(harness.recoveryState.attention, null);
+  assert.equal(recoveryPhaseNeedsUserStartTurn(harness.recoveryState.phase), true);
+  assert.equal(harness.refreshCount, 0);
+  assert.equal(harness.runtime.beginOverflowRecovery(harness.ctx), false);
+});
+
+test("beginOverflowRecovery with a paused goal records user reset without pending attention", () => {
+  const pausedGoal: ThreadGoal = { ...activeGoal, status: "paused" };
+  const harness = createRecoveryTestRuntime(pausedGoal);
+
+  assert.equal(harness.runtime.beginOverflowRecovery(harness.ctx), true);
+  assert.equal(harness.recoveryState.phase.kind, "hostOverflowNeedsUserStart");
+  assert.equal(harness.recoveryState.attention, null);
+  assert.equal(harness.refreshCount, 0);
+});
 
 test("persistent provider errors plan pending attention without scheduling hidden continuation", () => {
   const harness = createRecoveryTestRuntime();

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -18,6 +18,7 @@ import {
   recoveryPendingAttentionMessage,
 } from "../src/recovery.js";
 import {
+  acknowledgeHostOverflowUserResetCleared,
   beginHostOverflowRecovery,
   createGoalRecoveryMachine,
   goalStartTurnStrategy,
@@ -30,7 +31,6 @@ import {
   resetRecoveryMachine,
   setRecoveryPendingAttention,
 } from "../src/recovery-machine.js";
-import { clearHostOverflowUserReset } from "../src/recovery-phase.js";
 
 test("detects context overflow error messages with host overflow classifier", () => {
   assert.equal(isContextOverflowError("context_length_exceeded: prompt too large"), true);
@@ -232,16 +232,11 @@ test("createErrorRecoveryCounters starts empty", () => {
 
 test("beginHostOverflowRecovery surfaces pending attention without pausing", () => {
   const state = createGoalRecoveryMachine();
-  assert.equal(
-    beginHostOverflowRecovery(state),
-    recoveryPendingAttentionMessage(HOST_OVERFLOW_RECOVERY_REASON),
-  );
+  const result = beginHostOverflowRecovery(state);
+  assert.equal(result.attention, recoveryPendingAttentionMessage(HOST_OVERFLOW_RECOVERY_REASON));
+  assert.equal(result.persistHostOverflowCapReset, true);
   assert.doesNotMatch(state.attention ?? "", /\/goal resume/);
-  assert.equal(state.phase.kind, "pendingHostOverflow");
-  if (state.phase.kind === "pendingHostOverflow") {
-    assert.equal(state.phase.hostRecoveryActive, true);
-    assert.equal(state.phase.needsUserReset, true);
-  }
+  assert.equal(state.phase.kind, "hostOverflowRecoveringNeedsUserStart");
   assert.equal(recoveryPhaseBlocksContinuation(state.phase), true);
   assert.equal(recoveryPhaseNeedsUserStartTurn(state.phase), true);
   assert.equal(goalStartTurnStrategy(state.phase), "userFollowUp");
@@ -251,26 +246,25 @@ test("resetRecoveryMachine clears active host overflow recovery but preserves us
   const state = createGoalRecoveryMachine();
   beginHostOverflowRecovery(state);
   resetRecoveryMachine(state);
-  assert.equal(state.phase.kind, "pendingHostOverflow");
-  if (state.phase.kind === "pendingHostOverflow") {
-    assert.equal(state.phase.hostRecoveryActive, false);
-    assert.equal(state.phase.needsUserReset, true);
-  }
+  assert.equal(state.phase.kind, "hostOverflowNeedsUserStart");
   assert.equal(recoveryPhaseNeedsUserStartTurn(state.phase), true);
   assert.equal(recoveryPhaseBlocksContinuation(state.phase), false);
 });
 
-test("clearHostOverflowUserReset keeps active host overflow recovery without user reset", () => {
+test("acknowledgeHostOverflowUserResetCleared keeps active host overflow recovery without user reset", () => {
   const state = createGoalRecoveryMachine();
   beginHostOverflowRecovery(state);
-  state.phase = clearHostOverflowUserReset(state.phase);
-  if (state.phase.kind === "pendingHostOverflow") {
-    assert.equal(state.phase.hostRecoveryActive, true);
-    assert.equal(state.phase.needsUserReset, false);
-  } else {
-    assert.fail("Expected pending host overflow phase after clearing user reset.");
-  }
+  acknowledgeHostOverflowUserResetCleared(state);
+  assert.equal(state.phase.kind, "hostOverflowRecovering");
   assert.equal(goalStartTurnStrategy(state.phase), "hiddenFollowUp");
+});
+
+test("beginHostOverflowRecovery skips cap-reset persistence when user reset already required", () => {
+  const state = createGoalRecoveryMachine();
+  state.phase = { kind: "hostOverflowNeedsUserStart" };
+  const result = beginHostOverflowRecovery(state);
+  assert.equal(result.persistHostOverflowCapReset, false);
+  assert.equal(state.phase.kind, "hostOverflowRecoveringNeedsUserStart");
 });
 
 test("recovery session compact preserves overflow attempt counts after host compaction", () => {

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -21,6 +21,7 @@ import {
   applyHostOverflowUserResetPersistence,
   beginHostOverflowRecovery,
   createGoalRecoveryMachine,
+  requireHostOverflowUserReset,
   goalStartTurnStrategy,
   isRepeatOverflowCompactionDue,
   onRecoverySessionCompact,
@@ -265,6 +266,18 @@ test("beginHostOverflowRecovery skips cap-reset persistence when user reset alre
   const result = beginHostOverflowRecovery(state);
   assert.equal(result.persistHostOverflowCapReset, false);
   assert.equal(state.phase.kind, "hostOverflowRecoveringNeedsUserStart");
+});
+
+test("requireHostOverflowUserReset records session-level user start without active recovery", () => {
+  const state = createGoalRecoveryMachine();
+  assert.equal(requireHostOverflowUserReset(state), true);
+  assert.equal(state.phase.kind, "hostOverflowNeedsUserStart");
+  assert.equal(state.attention, null);
+  assert.equal(recoveryPhaseBlocksContinuation(state.phase), false);
+  assert.equal(recoveryPhaseNeedsUserStartTurn(state.phase), true);
+  assert.equal(goalStartTurnStrategy(state.phase), "userFollowUp");
+  assert.equal(requireHostOverflowUserReset(state), false);
+  assert.equal(state.phase.kind, "hostOverflowNeedsUserStart");
 });
 
 test("recovery session compact preserves overflow attempt counts after host compaction", () => {

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -20,13 +20,17 @@ import {
 import {
   beginHostOverflowRecovery,
   createGoalRecoveryMachine,
+  goalStartTurnStrategy,
   isRepeatOverflowCompactionDue,
   onRecoverySessionCompact,
   planRecoveryForAssistantError,
   planRecoveryForSilentContextOverflow,
-  setRecoveryPausedAttention,
+  recoveryPhaseBlocksContinuation,
+  recoveryPhaseNeedsUserStartTurn,
+  resetRecoveryMachine,
   setRecoveryPendingAttention,
 } from "../src/recovery-machine.js";
+import { clearHostOverflowUserReset } from "../src/recovery-phase.js";
 
 test("detects context overflow error messages with host overflow classifier", () => {
   assert.equal(isContextOverflowError("context_length_exceeded: prompt too large"), true);
@@ -233,6 +237,40 @@ test("beginHostOverflowRecovery surfaces pending attention without pausing", () 
     recoveryPendingAttentionMessage(HOST_OVERFLOW_RECOVERY_REASON),
   );
   assert.doesNotMatch(state.attention ?? "", /\/goal resume/);
+  assert.equal(state.phase.kind, "pendingHostOverflow");
+  if (state.phase.kind === "pendingHostOverflow") {
+    assert.equal(state.phase.hostRecoveryActive, true);
+    assert.equal(state.phase.needsUserReset, true);
+  }
+  assert.equal(recoveryPhaseBlocksContinuation(state.phase), true);
+  assert.equal(recoveryPhaseNeedsUserStartTurn(state.phase), true);
+  assert.equal(goalStartTurnStrategy(state.phase), "userFollowUp");
+});
+
+test("resetRecoveryMachine clears active host overflow recovery but preserves user reset", () => {
+  const state = createGoalRecoveryMachine();
+  beginHostOverflowRecovery(state);
+  resetRecoveryMachine(state);
+  assert.equal(state.phase.kind, "pendingHostOverflow");
+  if (state.phase.kind === "pendingHostOverflow") {
+    assert.equal(state.phase.hostRecoveryActive, false);
+    assert.equal(state.phase.needsUserReset, true);
+  }
+  assert.equal(recoveryPhaseNeedsUserStartTurn(state.phase), true);
+  assert.equal(recoveryPhaseBlocksContinuation(state.phase), false);
+});
+
+test("clearHostOverflowUserReset keeps active host overflow recovery without user reset", () => {
+  const state = createGoalRecoveryMachine();
+  beginHostOverflowRecovery(state);
+  state.phase = clearHostOverflowUserReset(state.phase);
+  if (state.phase.kind === "pendingHostOverflow") {
+    assert.equal(state.phase.hostRecoveryActive, true);
+    assert.equal(state.phase.needsUserReset, false);
+  } else {
+    assert.fail("Expected pending host overflow phase after clearing user reset.");
+  }
+  assert.equal(goalStartTurnStrategy(state.phase), "hiddenFollowUp");
 });
 
 test("recovery session compact preserves overflow attempt counts after host compaction", () => {

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -18,7 +18,7 @@ import {
   recoveryPendingAttentionMessage,
 } from "../src/recovery.js";
 import {
-  acknowledgeHostOverflowUserResetCleared,
+  applyHostOverflowUserResetPersistence,
   beginHostOverflowRecovery,
   createGoalRecoveryMachine,
   goalStartTurnStrategy,
@@ -251,10 +251,10 @@ test("resetRecoveryMachine clears active host overflow recovery but preserves us
   assert.equal(recoveryPhaseBlocksContinuation(state.phase), false);
 });
 
-test("acknowledgeHostOverflowUserResetCleared keeps active host overflow recovery without user reset", () => {
+test("applyHostOverflowUserResetPersistence(false) keeps active host overflow recovery without user reset", () => {
   const state = createGoalRecoveryMachine();
   beginHostOverflowRecovery(state);
-  acknowledgeHostOverflowUserResetCleared(state);
+  assert.equal(applyHostOverflowUserResetPersistence(state, false), true);
   assert.equal(state.phase.kind, "hostOverflowRecovering");
   assert.equal(goalStartTurnStrategy(state.phase), "hiddenFollowUp");
 });


### PR DESCRIPTION
## Summary
- Add a typed `RecoveryPhase` with explicit reachable host-overflow states (`idle`, `hostOverflowRecoveringNeedsUserStart`, `hostOverflowRecovering`, `hostOverflowNeedsUserStart`) on the goal recovery machine, replacing parallel booleans in `src/index.ts`.
- Route host-overflow phase transitions through recovery-machine helpers; `src/index.ts` persists `host_overflow_cap_reset` entries from machine results but no longer composes phase internals.
- Replace `CommandHost.needsHostOverflowCapReset()` with `getGoalStartTurnStrategy()` (`hiddenFollowUp` vs `userFollowUp`) so commands no longer branch on host-overflow internals.
- Preserve session persistence via existing `host_overflow_cap_reset` custom entries and all overflow recovery / command continuation behavior covered by recovery tests.

Closes #23

## Test plan
- [x] `npm run verify` (237 tests)
- [x] `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` (only pre-existing `src/index.ts` `ctx` unused)
- [x] `git diff --check` / `git show --check`

Made with [Cursor](https://cursor.com)
