### PR TITLE
Centralize goal transition side effects behind one atomic API

### DIFF
--- a/src/goal-accounting.ts
+++ b/src/goal-accounting.ts
@@ -53,10 +53,12 @@ export function isToolUseAssistantMessage(message: AssistantTurnMessage): boolea
 
 interface GoalAccountingDeps {
   getGoal: () => ThreadGoal | null;
-  setGoal: (nextGoal: ThreadGoal) => void;
   getAccounting: () => AccountingState;
-  flushGoalPersistence: (source: "runtime") => boolean;
-  refreshUi: (ctx: ExtensionContext) => void;
+  applyRuntimeAccountingTransition: (
+    ctx: ExtensionContext,
+    nextGoal: ThreadGoal,
+    crossedBudget: boolean,
+  ) => void;
   sendMessage: ExtensionAPI["sendMessage"];
 }
 
@@ -106,12 +108,7 @@ export function createGoalAccounting(deps: GoalAccountingDeps) {
       return;
     }
 
-    deps.setGoal(result.goal);
-    deps.refreshUi(ctx);
-
-    if (result.crossedBudget) {
-      deps.flushGoalPersistence("runtime");
-    }
+    deps.applyRuntimeAccountingTransition(ctx, result.goal, result.crossedBudget);
 
     if (allowBudgetSteering && result.crossedBudget && accounting.budgetWarningSentFor !== result.goal.goalId) {
       accounting.budgetWarningSentFor = result.goal.goalId;

--- a/src/goal-accounting.ts
+++ b/src/goal-accounting.ts
@@ -54,11 +54,7 @@ export function isToolUseAssistantMessage(message: AssistantTurnMessage): boolea
 interface GoalAccountingDeps {
   getGoal: () => ThreadGoal | null;
   getAccounting: () => AccountingState;
-  applyRuntimeAccountingTransition: (
-    ctx: ExtensionContext,
-    nextGoal: ThreadGoal,
-    crossedBudget: boolean,
-  ) => void;
+  applyRuntimeAccountingTransition: (ctx: ExtensionContext, nextGoal: ThreadGoal) => void;
   sendMessage: ExtensionAPI["sendMessage"];
 }
 
@@ -108,7 +104,7 @@ export function createGoalAccounting(deps: GoalAccountingDeps) {
       return;
     }
 
-    deps.applyRuntimeAccountingTransition(ctx, result.goal, result.crossedBudget);
+    deps.applyRuntimeAccountingTransition(ctx, result.goal);
 
     if (allowBudgetSteering && result.crossedBudget && accounting.budgetWarningSentFor !== result.goal.goalId) {
       accounting.budgetWarningSentFor = result.goal.goalId;

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -152,12 +152,6 @@ function commandAfterPersistEffects(
   return effects;
 }
 
-const ABORT_PAUSE_BEFORE_PERSIST: GoalTransitionEffect[] = [
-  { type: "clearContinuation" },
-  { type: "clearActiveAccounting" },
-  { type: "resetRecovery" },
-];
-
 const ABORT_PAUSE_SET_BEFORE_PERSIST: GoalTransitionEffect[] = [
   { type: "clearContinuation" },
   { type: "clearActiveAccounting" },
@@ -273,15 +267,6 @@ export function planGoalTransition(
     case "abort_pause": {
       const { nextGoal } = request;
       validateAbortPause(current, nextGoal);
-      if (current && goalsEquivalent(current, nextGoal)) {
-        return {
-          persist: "skip",
-          nextGoal,
-          source: "runtime",
-          beforePersist: ABORT_PAUSE_BEFORE_PERSIST,
-          afterPersist: [],
-        };
-      }
       return {
         persist: "set",
         nextGoal,
@@ -296,15 +281,6 @@ export function planGoalTransition(
     case "resume_active": {
       const { nextGoal } = request;
       validateResumeActive(current, nextGoal);
-      if (current && goalsEquivalent(current, nextGoal)) {
-        return {
-          persist: "skip",
-          nextGoal,
-          source: "runtime",
-          beforePersist: RESUME_ACTIVE_BEFORE_PERSIST,
-          afterPersist: [],
-        };
-      }
       return {
         persist: "set",
         nextGoal,
@@ -323,15 +299,6 @@ export function planGoalTransition(
         { type: "clearContinuation" },
         { type: "setRecoveryPausedAttention", reason: recoveryReason },
       ];
-      if (current && goalsEquivalent(current, nextGoal)) {
-        return {
-          persist: "skip",
-          nextGoal,
-          source: "runtime",
-          beforePersist: recoveryEffects,
-          afterPersist: [],
-        };
-      }
       return {
         persist: "set",
         nextGoal,
@@ -351,15 +318,6 @@ export function planGoalTransition(
         { type: "clearHostOverflowRecovery" },
         { type: "setRecoveryPausedAttention", reason: recoveryReason },
       ];
-      if (current && goalsEquivalent(current, nextGoal)) {
-        return {
-          persist: "skip",
-          nextGoal,
-          source: "runtime",
-          beforePersist: recoveryEffects,
-          afterPersist: [],
-        };
-      }
       return {
         persist: "set",
         nextGoal,

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -12,7 +12,11 @@ export type GoalTransitionRequest =
   | { kind: "clear"; source: GoalEntrySource }
   | { kind: "abort_pause"; nextGoal: ThreadGoal }
   | { kind: "resume_active"; nextGoal: ThreadGoal }
-  | { kind: "recovery_pause"; nextGoal: ThreadGoal }
+  | {
+      kind: "recovery_pause";
+      nextGoal: ThreadGoal;
+      recoveryReason: string;
+    }
   | {
       kind: "recovery_shutdown_pause";
       nextGoal: ThreadGoal;
@@ -27,10 +31,7 @@ export interface GoalMemoryEffectPlan {
   clearBudgetWarning: boolean;
 }
 
-export interface GoalTransitionEffectPlan {
-  memory: GoalMemoryEffectPlan;
-  persist: "set" | "clear" | "skip";
-  nextGoal: ThreadGoal | null;
+interface GoalTransitionEffectPlanShared {
   source: GoalEntrySource;
   markContinuationQueued: boolean;
   resetRecoveryBeforePersist: boolean;
@@ -42,6 +43,22 @@ export interface GoalTransitionEffectPlan {
   stopStatusRefresh: boolean;
   refreshUi: boolean;
 }
+
+export type GoalTransitionEffectPlan =
+  | (GoalTransitionEffectPlanShared & {
+      persist: "skip";
+      nextGoal: ThreadGoal | null;
+    })
+  | (GoalTransitionEffectPlanShared & {
+      persist: "set";
+      nextGoal: ThreadGoal;
+      memory: GoalMemoryEffectPlan;
+    })
+  | (GoalTransitionEffectPlanShared & {
+      persist: "clear";
+      nextGoal: null;
+      memory: GoalMemoryEffectPlan;
+    });
 
 export function planMemoryEffectsOnGoalChange(
   previous: ThreadGoal | null,
@@ -92,10 +109,28 @@ function mergeMemoryPlans(...plans: readonly GoalMemoryEffectPlan[]): GoalMemory
   };
 }
 
+function recoveryPauseShared(
+  recoveryReason: string,
+  clearHostOverflowRecovery: boolean,
+): GoalTransitionEffectPlanShared {
+  return {
+    source: "runtime",
+    markContinuationQueued: false,
+    resetRecoveryBeforePersist: false,
+    resetRecoveryAfterPersist: false,
+    resetStoppedRuntimeBeforePersist: false,
+    clearContinuationBeforePersist: true,
+    clearHostOverflowRecovery,
+    recoveryPausedReason: recoveryReason,
+    stopStatusRefresh: false,
+    refreshUi: true,
+  };
+}
+
 export function planGoalTransition(
   current: ThreadGoal | null,
   request: GoalTransitionRequest,
-): GoalTransitionEffectPlan | null {
+): GoalTransitionEffectPlan {
   switch (request.kind) {
     case "clear": {
       return {
@@ -122,19 +157,7 @@ export function planGoalTransition(
     }
     case "abort_pause": {
       const { nextGoal } = request;
-      return {
-        memory: mergeMemoryPlans(
-          {
-            resetStoppedRuntime: true,
-            clearContinuation: true,
-            clearActiveAccounting: true,
-            resetRecovery: true,
-            clearBudgetWarning: true,
-          },
-          planMemoryEffectsOnGoalChange(current, nextGoal),
-        ),
-        persist: current && goalsEquivalent(current, nextGoal) ? "skip" : "set",
-        nextGoal,
+      const shared: GoalTransitionEffectPlanShared = {
         source: "runtime",
         markContinuationQueued: false,
         resetRecoveryBeforePersist: false,
@@ -146,13 +169,28 @@ export function planGoalTransition(
         stopStatusRefresh: false,
         refreshUi: true,
       };
+      if (current && goalsEquivalent(current, nextGoal)) {
+        return { ...shared, persist: "skip", nextGoal };
+      }
+      return {
+        ...shared,
+        persist: "set",
+        nextGoal,
+        memory: mergeMemoryPlans(
+          {
+            resetStoppedRuntime: true,
+            clearContinuation: true,
+            clearActiveAccounting: true,
+            resetRecovery: true,
+            clearBudgetWarning: true,
+          },
+          planMemoryEffectsOnGoalChange(current, nextGoal),
+        ),
+      };
     }
     case "resume_active": {
       const { nextGoal } = request;
-      return {
-        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
-        persist: current && goalsEquivalent(current, nextGoal) ? "skip" : "set",
-        nextGoal,
+      const shared: GoalTransitionEffectPlanShared = {
         source: "runtime",
         markContinuationQueued: false,
         resetRecoveryBeforePersist: true,
@@ -164,45 +202,44 @@ export function planGoalTransition(
         stopStatusRefresh: false,
         refreshUi: true,
       };
+      if (current && goalsEquivalent(current, nextGoal)) {
+        return { ...shared, persist: "skip", nextGoal };
+      }
+      return {
+        ...shared,
+        persist: "set",
+        nextGoal,
+        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
+      };
     }
     case "recovery_pause": {
+      const { nextGoal, recoveryReason } = request;
+      const shared = recoveryPauseShared(recoveryReason, false);
+      if (current && goalsEquivalent(current, nextGoal)) {
+        return { ...shared, persist: "skip", nextGoal };
+      }
       return {
-        memory: planMemoryEffectsOnGoalChange(current, request.nextGoal),
-        persist: current && goalsEquivalent(current, request.nextGoal) ? "skip" : "set",
-        nextGoal: request.nextGoal,
-        source: "runtime",
-        markContinuationQueued: false,
-        resetRecoveryBeforePersist: false,
-        resetRecoveryAfterPersist: false,
-        resetStoppedRuntimeBeforePersist: false,
-        clearContinuationBeforePersist: false,
-        clearHostOverflowRecovery: false,
-        recoveryPausedReason: null,
-        stopStatusRefresh: false,
-        refreshUi: false,
+        ...shared,
+        persist: "set",
+        nextGoal,
+        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
       };
     }
     case "recovery_shutdown_pause": {
+      const { nextGoal, recoveryReason } = request;
+      const shared = recoveryPauseShared(recoveryReason, true);
+      if (current && goalsEquivalent(current, nextGoal)) {
+        return { ...shared, persist: "skip", nextGoal };
+      }
       return {
-        memory: planMemoryEffectsOnGoalChange(current, request.nextGoal),
-        persist: current && goalsEquivalent(current, request.nextGoal) ? "skip" : "set",
-        nextGoal: request.nextGoal,
-        source: "runtime",
-        markContinuationQueued: false,
-        resetRecoveryBeforePersist: false,
-        resetRecoveryAfterPersist: false,
-        resetStoppedRuntimeBeforePersist: false,
-        clearContinuationBeforePersist: true,
-        clearHostOverflowRecovery: true,
-        recoveryPausedReason: request.recoveryReason,
-        stopStatusRefresh: false,
-        refreshUi: true,
+        ...shared,
+        persist: "set",
+        nextGoal,
+        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
       };
     }
     case "set": {
       const { nextGoal, source, wasPausedBefore = false } = request;
-      const persist =
-        current && goalsEquivalent(current, nextGoal) ? ("skip" as const) : ("set" as const);
       const commandEffects =
         source === "command"
           ? {
@@ -220,11 +257,7 @@ export function planGoalTransition(
               resetStoppedRuntimeBeforePersist: false,
               clearContinuationBeforePersist: false,
             };
-
-      return {
-        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
-        persist,
-        nextGoal,
+      const shared: GoalTransitionEffectPlanShared = {
         source,
         markContinuationQueued: commandEffects.markContinuationQueued,
         resetRecoveryBeforePersist: commandEffects.resetRecoveryBeforePersist,
@@ -235,6 +268,15 @@ export function planGoalTransition(
         recoveryPausedReason: null,
         stopStatusRefresh: false,
         refreshUi: true,
+      };
+      if (current && goalsEquivalent(current, nextGoal)) {
+        return { ...shared, persist: "skip", nextGoal };
+      }
+      return {
+        ...shared,
+        persist: "set",
+        nextGoal,
+        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
       };
     }
     default: {
@@ -281,7 +323,7 @@ export interface GoalTransitionPostPersistHandlers {
 export function applyGoalTransitionPostPersistEffects(
   plan: Pick<
     GoalTransitionEffectPlan,
-    "resetRecoveryAfterPersist" | "markContinuationQueued" | "nextGoal"
+    "resetRecoveryAfterPersist" | "markContinuationQueued" | "nextGoal" | "persist"
   >,
   handlers: GoalTransitionPostPersistHandlers,
 ): void {

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -1,5 +1,5 @@
 import { goalsEquivalent } from "./state.js";
-import type { GoalEntrySource, ThreadGoal } from "./types.js";
+import type { GoalEntrySource, GoalStatus, ThreadGoal } from "./types.js";
 
 export type GoalTransitionRequest =
   | {
@@ -177,6 +177,85 @@ const CLEAR_BEFORE_PERSIST: GoalTransitionEffect[] = [
   { type: "clearBudgetWarning" },
 ];
 
+const RUNTIME_ACCOUNTING_STATUSES = new Set<GoalStatus>(["active", "budgetLimited"]);
+
+function transitionInvariantError(kind: string, detail: string): Error {
+  return new Error(`Invalid ${kind} transition: ${detail}`);
+}
+
+function requireCurrentGoal(
+  current: ThreadGoal | null,
+  kind: string,
+): asserts current is ThreadGoal {
+  if (!current) {
+    throw transitionInvariantError(kind, "current goal is required");
+  }
+}
+
+function requireSameGoalId(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
+  if (current.goalId !== nextGoal.goalId) {
+    throw transitionInvariantError(
+      kind,
+      `goalId mismatch (current=${current.goalId}, next=${nextGoal.goalId})`,
+    );
+  }
+}
+
+function validateActiveToPausedTransition(
+  kind: "abort_pause" | "recovery_pause" | "recovery_shutdown_pause",
+  current: ThreadGoal | null,
+  nextGoal: ThreadGoal,
+): void {
+  requireCurrentGoal(current, kind);
+  requireSameGoalId(current, nextGoal, kind);
+  if (current.status !== "active") {
+    throw transitionInvariantError(
+      kind,
+      `current status must be active (got ${current.status})`,
+    );
+  }
+  if (nextGoal.status !== "paused") {
+    throw transitionInvariantError(kind, `next status must be paused (got ${nextGoal.status})`);
+  }
+}
+
+function validateAbortPause(current: ThreadGoal | null, nextGoal: ThreadGoal): void {
+  validateActiveToPausedTransition("abort_pause", current, nextGoal);
+}
+
+function validateResumeActive(current: ThreadGoal | null, nextGoal: ThreadGoal): void {
+  const kind = "resume_active";
+  requireCurrentGoal(current, kind);
+  requireSameGoalId(current, nextGoal, kind);
+  if (current.status !== "paused") {
+    throw transitionInvariantError(
+      kind,
+      `current status must be paused (got ${current.status})`,
+    );
+  }
+  if (nextGoal.status !== "active") {
+    throw transitionInvariantError(kind, `next status must be active (got ${nextGoal.status})`);
+  }
+}
+
+function validateRuntimeAccounting(current: ThreadGoal | null, nextGoal: ThreadGoal): void {
+  const kind = "runtime_accounting";
+  requireCurrentGoal(current, kind);
+  requireSameGoalId(current, nextGoal, kind);
+  if (!RUNTIME_ACCOUNTING_STATUSES.has(current.status)) {
+    throw transitionInvariantError(
+      kind,
+      `current status must be active or budgetLimited (got ${current.status})`,
+    );
+  }
+  if (!RUNTIME_ACCOUNTING_STATUSES.has(nextGoal.status)) {
+    throw transitionInvariantError(
+      kind,
+      `next status must be active or budgetLimited (got ${nextGoal.status})`,
+    );
+  }
+}
+
 export function planGoalTransition(
   current: ThreadGoal | null,
   request: GoalTransitionRequest,
@@ -193,6 +272,7 @@ export function planGoalTransition(
     }
     case "abort_pause": {
       const { nextGoal } = request;
+      validateAbortPause(current, nextGoal);
       if (current && goalsEquivalent(current, nextGoal)) {
         return {
           persist: "skip",
@@ -215,6 +295,7 @@ export function planGoalTransition(
     }
     case "resume_active": {
       const { nextGoal } = request;
+      validateResumeActive(current, nextGoal);
       if (current && goalsEquivalent(current, nextGoal)) {
         return {
           persist: "skip",
@@ -237,6 +318,7 @@ export function planGoalTransition(
     }
     case "recovery_pause": {
       const { nextGoal, recoveryReason } = request;
+      validateActiveToPausedTransition("recovery_pause", current, nextGoal);
       const recoveryEffects: GoalTransitionEffect[] = [
         { type: "clearContinuation" },
         { type: "setRecoveryPausedAttention", reason: recoveryReason },
@@ -263,6 +345,7 @@ export function planGoalTransition(
     }
     case "recovery_shutdown_pause": {
       const { nextGoal, recoveryReason } = request;
+      validateActiveToPausedTransition("recovery_shutdown_pause", current, nextGoal);
       const recoveryEffects: GoalTransitionEffect[] = [
         { type: "clearContinuation" },
         { type: "clearHostOverflowRecovery" },
@@ -290,6 +373,7 @@ export function planGoalTransition(
     }
     case "runtime_accounting": {
       const { nextGoal } = request;
+      validateRuntimeAccounting(current, nextGoal);
       if (current && goalsEquivalent(current, nextGoal)) {
         return {
           persist: "skip",

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -195,6 +195,68 @@ function requireSameGoalId(current: ThreadGoal, nextGoal: ThreadGoal, kind: stri
   }
 }
 
+function requireUnchangedObjective(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
+  if (current.objective !== nextGoal.objective) {
+    throw transitionInvariantError(kind, "objective must be unchanged");
+  }
+}
+
+function requireUnchangedTokenBudget(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
+  if (current.tokenBudget !== nextGoal.tokenBudget) {
+    throw transitionInvariantError(kind, "tokenBudget must be unchanged");
+  }
+}
+
+function requireUnchangedCreatedAt(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
+  if (current.createdAt !== nextGoal.createdAt) {
+    throw transitionInvariantError(kind, "createdAt must be unchanged");
+  }
+}
+
+function requireUnchangedUsage(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
+  if (current.usage.tokensUsed !== nextGoal.usage.tokensUsed) {
+    throw transitionInvariantError(kind, "usage.tokensUsed must be unchanged");
+  }
+  if (current.usage.activeSeconds !== nextGoal.usage.activeSeconds) {
+    throw transitionInvariantError(kind, "usage.activeSeconds must be unchanged");
+  }
+}
+
+function requireStatusHelperImmutableFields(
+  current: ThreadGoal,
+  nextGoal: ThreadGoal,
+  kind: string,
+): void {
+  requireUnchangedObjective(current, nextGoal, kind);
+  requireUnchangedTokenBudget(current, nextGoal, kind);
+  requireUnchangedUsage(current, nextGoal, kind);
+  requireUnchangedCreatedAt(current, nextGoal, kind);
+}
+
+function requireNonDecreasingUsage(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
+  if (nextGoal.usage.tokensUsed < current.usage.tokensUsed) {
+    throw transitionInvariantError(kind, "usage.tokensUsed must not decrease");
+  }
+  if (nextGoal.usage.activeSeconds < current.usage.activeSeconds) {
+    throw transitionInvariantError(kind, "usage.activeSeconds must not decrease");
+  }
+}
+
+function requireBudgetLimitedUsageAtOrOverBudget(nextGoal: ThreadGoal, kind: string): void {
+  if (nextGoal.tokenBudget === null) {
+    throw transitionInvariantError(
+      kind,
+      "tokenBudget must be set when next status is budgetLimited",
+    );
+  }
+  if (nextGoal.usage.tokensUsed < nextGoal.tokenBudget) {
+    throw transitionInvariantError(
+      kind,
+      "usage.tokensUsed must be at or above tokenBudget when next status is budgetLimited",
+    );
+  }
+}
+
 function validateActiveToPausedTransition(
   kind: "abort_pause" | "recovery_pause" | "recovery_shutdown_pause",
   current: ThreadGoal | null,
@@ -211,6 +273,7 @@ function validateActiveToPausedTransition(
   if (nextGoal.status !== "paused") {
     throw transitionInvariantError(kind, `next status must be paused (got ${nextGoal.status})`);
   }
+  requireStatusHelperImmutableFields(current, nextGoal, kind);
 }
 
 function validateAbortPause(current: ThreadGoal | null, nextGoal: ThreadGoal): void {
@@ -230,6 +293,7 @@ function validateResumeActive(current: ThreadGoal | null, nextGoal: ThreadGoal):
   if (nextGoal.status !== "active") {
     throw transitionInvariantError(kind, `next status must be active (got ${nextGoal.status})`);
   }
+  requireStatusHelperImmutableFields(current, nextGoal, kind);
 }
 
 function validateRuntimeAccounting(current: ThreadGoal | null, nextGoal: ThreadGoal): void {
@@ -242,11 +306,30 @@ function validateRuntimeAccounting(current: ThreadGoal | null, nextGoal: ThreadG
       `current status must be active or budgetLimited (got ${current.status})`,
     );
   }
+  if (nextGoal.status === "paused" || nextGoal.status === "complete") {
+    throw transitionInvariantError(
+      kind,
+      `next status must be active or budgetLimited (got ${nextGoal.status})`,
+    );
+  }
   if (!RUNTIME_ACCOUNTING_STATUSES.has(nextGoal.status)) {
     throw transitionInvariantError(
       kind,
       `next status must be active or budgetLimited (got ${nextGoal.status})`,
     );
+  }
+  if (current.status === "budgetLimited" && nextGoal.status === "active") {
+    throw transitionInvariantError(
+      kind,
+      "budgetLimited goals cannot transition to active via runtime accounting",
+    );
+  }
+  requireUnchangedObjective(current, nextGoal, kind);
+  requireUnchangedTokenBudget(current, nextGoal, kind);
+  requireUnchangedCreatedAt(current, nextGoal, kind);
+  requireNonDecreasingUsage(current, nextGoal, kind);
+  if (nextGoal.status === "budgetLimited") {
+    requireBudgetLimitedUsageAtOrOverBudget(nextGoal, kind);
   }
 }
 

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -6,8 +6,6 @@ export type GoalTransitionRequest =
       kind: "set";
       nextGoal: ThreadGoal;
       source: GoalEntrySource;
-      /** Command /goal resume: goal was paused immediately before this transition. */
-      wasPausedBefore?: boolean;
     }
   | { kind: "clear"; source: GoalEntrySource }
   | { kind: "abort_pause"; nextGoal: ThreadGoal }
@@ -25,8 +23,25 @@ export type GoalTransitionRequest =
   | {
       kind: "runtime_accounting";
       nextGoal: ThreadGoal;
-      crossedBudget: boolean;
     };
+
+export type GoalTransitionEffect =
+  | { type: "clearContinuation" }
+  | { type: "clearActiveAccounting" }
+  | { type: "resetRecovery" }
+  | { type: "clearBudgetWarning" }
+  | { type: "clearHostOverflowRecovery" }
+  | { type: "setRecoveryPausedAttention"; reason: string }
+  | { type: "markContinuationQueued"; goalId: string }
+  | { type: "stopStatusRefresh" };
+
+export type GoalTransitionPlan = {
+  persist: "skip" | "defer" | "set" | "clear";
+  nextGoal: ThreadGoal | null;
+  source: GoalEntrySource;
+  beforePersist: GoalTransitionEffect[];
+  afterPersist: GoalTransitionEffect[];
+};
 
 export interface GoalMemoryEffectPlan {
   clearContinuation: boolean;
@@ -34,38 +49,6 @@ export interface GoalMemoryEffectPlan {
   resetRecovery: boolean;
   clearBudgetWarning: boolean;
 }
-
-interface GoalTransitionEffectPlanShared {
-  source: GoalEntrySource;
-  markContinuationQueued: boolean;
-  resetRecoveryBeforePersist: boolean;
-  resetRecoveryAfterPersist: boolean;
-  clearContinuationBeforePersist: boolean;
-  clearActiveAccountingBeforePersist: boolean;
-  clearHostOverflowRecovery: boolean;
-  recoveryPausedReason: string | null;
-}
-
-export type GoalTransitionEffectPlan =
-  | (GoalTransitionEffectPlanShared & {
-      persist: "skip";
-      nextGoal: ThreadGoal | null;
-    })
-  | (GoalTransitionEffectPlanShared & {
-      persist: "defer";
-      nextGoal: ThreadGoal;
-      memory: GoalMemoryEffectPlan;
-    })
-  | (GoalTransitionEffectPlanShared & {
-      persist: "set";
-      nextGoal: ThreadGoal;
-      memory: GoalMemoryEffectPlan;
-    })
-  | (GoalTransitionEffectPlanShared & {
-      persist: "clear";
-      nextGoal: null;
-      memory: GoalMemoryEffectPlan;
-    });
 
 export function planMemoryEffectsOnGoalChange(
   previous: ThreadGoal | null,
@@ -108,206 +91,248 @@ export function planMemoryEffectsOnGoalChange(
   };
 }
 
-function mergeMemoryPlans(...plans: readonly GoalMemoryEffectPlan[]): GoalMemoryEffectPlan {
-  return {
-    clearContinuation: plans.some((plan) => plan.clearContinuation),
-    clearActiveAccounting: plans.some((plan) => plan.clearActiveAccounting),
-    resetRecovery: plans.some((plan) => plan.resetRecovery),
-    clearBudgetWarning: plans.some((plan) => plan.clearBudgetWarning),
-  };
+function memoryEffectsFromGoalChange(
+  previous: ThreadGoal | null,
+  next: ThreadGoal,
+): GoalTransitionEffect[] {
+  const plan = planMemoryEffectsOnGoalChange(previous, next);
+  const effects: GoalTransitionEffect[] = [];
+  if (plan.clearContinuation) {
+    effects.push({ type: "clearContinuation" });
+  }
+  if (plan.clearActiveAccounting) {
+    effects.push({ type: "clearActiveAccounting" });
+  }
+  if (plan.resetRecovery) {
+    effects.push({ type: "resetRecovery" });
+  }
+  if (plan.clearBudgetWarning) {
+    effects.push({ type: "clearBudgetWarning" });
+  }
+  return effects;
 }
 
-function runtimeTransitionShared(): GoalTransitionEffectPlanShared {
-  return {
-    source: "runtime",
-    markContinuationQueued: false,
-    resetRecoveryBeforePersist: false,
-    resetRecoveryAfterPersist: false,
-    clearContinuationBeforePersist: false,
-    clearActiveAccountingBeforePersist: false,
-    clearHostOverflowRecovery: false,
-    recoveryPausedReason: null,
-  };
+function effectKey(effect: GoalTransitionEffect): string {
+  return effect.type;
 }
 
-function recoveryPauseShared(
-  recoveryReason: string,
-  clearHostOverflowRecovery: boolean,
-): GoalTransitionEffectPlanShared {
-  return {
-    source: "runtime",
-    markContinuationQueued: false,
-    resetRecoveryBeforePersist: false,
-    resetRecoveryAfterPersist: false,
-    clearContinuationBeforePersist: true,
-    clearActiveAccountingBeforePersist: false,
-    clearHostOverflowRecovery,
-    recoveryPausedReason: recoveryReason,
-  };
+function uniqueEffects(effects: readonly GoalTransitionEffect[]): GoalTransitionEffect[] {
+  const seen = new Set<string>();
+  const result: GoalTransitionEffect[] = [];
+  for (const effect of effects) {
+    const key = effectKey(effect);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(effect);
+  }
+  return result;
 }
+
+function crossedBudgetTransition(current: ThreadGoal | null, nextGoal: ThreadGoal): boolean {
+  return current?.status !== "budgetLimited" && nextGoal.status === "budgetLimited";
+}
+
+function commandAfterPersistEffects(
+  nextGoal: ThreadGoal,
+  wasPausedBefore: boolean,
+): GoalTransitionEffect[] {
+  const effects: GoalTransitionEffect[] = [];
+  if (nextGoal.status === "active") {
+    effects.push({ type: "markContinuationQueued", goalId: nextGoal.goalId });
+  }
+  if ((nextGoal.status === "active" && wasPausedBefore) || nextGoal.status === "paused") {
+    effects.push({ type: "resetRecovery" });
+  }
+  return effects;
+}
+
+const ABORT_PAUSE_BEFORE_PERSIST: GoalTransitionEffect[] = [
+  { type: "clearContinuation" },
+  { type: "clearActiveAccounting" },
+  { type: "resetRecovery" },
+];
+
+const ABORT_PAUSE_SET_BEFORE_PERSIST: GoalTransitionEffect[] = [
+  { type: "clearContinuation" },
+  { type: "clearActiveAccounting" },
+  { type: "resetRecovery" },
+  { type: "clearBudgetWarning" },
+];
+
+const RESUME_ACTIVE_BEFORE_PERSIST: GoalTransitionEffect[] = [
+  { type: "clearContinuation" },
+  { type: "resetRecovery" },
+];
+
+const CLEAR_BEFORE_PERSIST: GoalTransitionEffect[] = [
+  { type: "clearContinuation" },
+  { type: "clearActiveAccounting" },
+  { type: "resetRecovery" },
+  { type: "clearBudgetWarning" },
+];
 
 export function planGoalTransition(
   current: ThreadGoal | null,
   request: GoalTransitionRequest,
-): GoalTransitionEffectPlan {
+): GoalTransitionPlan {
   switch (request.kind) {
     case "clear": {
       return {
-        memory: {
-          clearContinuation: true,
-          clearActiveAccounting: true,
-          resetRecovery: true,
-          clearBudgetWarning: true,
-        },
         persist: "clear",
         nextGoal: null,
         source: request.source,
-        markContinuationQueued: false,
-        resetRecoveryBeforePersist: false,
-        resetRecoveryAfterPersist: false,
-        clearContinuationBeforePersist: false,
-        clearActiveAccountingBeforePersist: false,
-        clearHostOverflowRecovery: false,
-        recoveryPausedReason: null,
+        beforePersist: CLEAR_BEFORE_PERSIST,
+        afterPersist: [{ type: "stopStatusRefresh" }],
       };
     }
     case "abort_pause": {
       const { nextGoal } = request;
-      const shared: GoalTransitionEffectPlanShared = {
-        source: "runtime",
-        markContinuationQueued: false,
-        resetRecoveryBeforePersist: true,
-        resetRecoveryAfterPersist: false,
-        clearContinuationBeforePersist: true,
-        clearActiveAccountingBeforePersist: true,
-        clearHostOverflowRecovery: false,
-        recoveryPausedReason: null,
-      };
       if (current && goalsEquivalent(current, nextGoal)) {
-        return { ...shared, persist: "skip", nextGoal };
+        return {
+          persist: "skip",
+          nextGoal,
+          source: "runtime",
+          beforePersist: ABORT_PAUSE_BEFORE_PERSIST,
+          afterPersist: [],
+        };
       }
       return {
-        ...shared,
         persist: "set",
         nextGoal,
-        memory: mergeMemoryPlans(
-          {
-            clearContinuation: true,
-            clearActiveAccounting: true,
-            resetRecovery: true,
-            clearBudgetWarning: true,
-          },
-          planMemoryEffectsOnGoalChange(current, nextGoal),
-        ),
+        source: "runtime",
+        beforePersist: uniqueEffects([
+          ...ABORT_PAUSE_SET_BEFORE_PERSIST,
+          ...memoryEffectsFromGoalChange(current, nextGoal),
+        ]),
+        afterPersist: [],
       };
     }
     case "resume_active": {
       const { nextGoal } = request;
-      const shared: GoalTransitionEffectPlanShared = {
-        source: "runtime",
-        markContinuationQueued: false,
-        resetRecoveryBeforePersist: true,
-        resetRecoveryAfterPersist: false,
-        clearContinuationBeforePersist: true,
-        clearActiveAccountingBeforePersist: false,
-        clearHostOverflowRecovery: false,
-        recoveryPausedReason: null,
-      };
       if (current && goalsEquivalent(current, nextGoal)) {
-        return { ...shared, persist: "skip", nextGoal };
+        return {
+          persist: "skip",
+          nextGoal,
+          source: "runtime",
+          beforePersist: RESUME_ACTIVE_BEFORE_PERSIST,
+          afterPersist: [],
+        };
       }
       return {
-        ...shared,
         persist: "set",
         nextGoal,
-        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
+        source: "runtime",
+        beforePersist: uniqueEffects([
+          ...RESUME_ACTIVE_BEFORE_PERSIST,
+          ...memoryEffectsFromGoalChange(current, nextGoal),
+        ]),
+        afterPersist: [],
       };
     }
     case "recovery_pause": {
       const { nextGoal, recoveryReason } = request;
-      const shared = recoveryPauseShared(recoveryReason, false);
+      const recoveryEffects: GoalTransitionEffect[] = [
+        { type: "clearContinuation" },
+        { type: "setRecoveryPausedAttention", reason: recoveryReason },
+      ];
       if (current && goalsEquivalent(current, nextGoal)) {
-        return { ...shared, persist: "skip", nextGoal };
+        return {
+          persist: "skip",
+          nextGoal,
+          source: "runtime",
+          beforePersist: recoveryEffects,
+          afterPersist: [],
+        };
       }
       return {
-        ...shared,
         persist: "set",
         nextGoal,
-        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
+        source: "runtime",
+        beforePersist: uniqueEffects([
+          ...recoveryEffects,
+          ...memoryEffectsFromGoalChange(current, nextGoal),
+        ]),
+        afterPersist: [],
       };
     }
     case "recovery_shutdown_pause": {
       const { nextGoal, recoveryReason } = request;
-      const shared = recoveryPauseShared(recoveryReason, true);
+      const recoveryEffects: GoalTransitionEffect[] = [
+        { type: "clearContinuation" },
+        { type: "clearHostOverflowRecovery" },
+        { type: "setRecoveryPausedAttention", reason: recoveryReason },
+      ];
       if (current && goalsEquivalent(current, nextGoal)) {
-        return { ...shared, persist: "skip", nextGoal };
-      }
-      return {
-        ...shared,
-        persist: "set",
-        nextGoal,
-        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
-      };
-    }
-    case "runtime_accounting": {
-      const { nextGoal, crossedBudget } = request;
-      const shared = runtimeTransitionShared();
-      if (current && goalsEquivalent(current, nextGoal)) {
-        return { ...shared, persist: "skip", nextGoal };
-      }
-      const memory = planMemoryEffectsOnGoalChange(current, nextGoal);
-      if (crossedBudget) {
         return {
-          ...shared,
-          persist: "set",
+          persist: "skip",
           nextGoal,
-          memory,
+          source: "runtime",
+          beforePersist: recoveryEffects,
+          afterPersist: [],
         };
       }
       return {
-        ...shared,
+        persist: "set",
+        nextGoal,
+        source: "runtime",
+        beforePersist: uniqueEffects([
+          ...recoveryEffects,
+          ...memoryEffectsFromGoalChange(current, nextGoal),
+        ]),
+        afterPersist: [],
+      };
+    }
+    case "runtime_accounting": {
+      const { nextGoal } = request;
+      if (current && goalsEquivalent(current, nextGoal)) {
+        return {
+          persist: "skip",
+          nextGoal,
+          source: "runtime",
+          beforePersist: [],
+          afterPersist: [],
+        };
+      }
+      const beforePersist = memoryEffectsFromGoalChange(current, nextGoal);
+      if (crossedBudgetTransition(current, nextGoal)) {
+        return {
+          persist: "set",
+          nextGoal,
+          source: "runtime",
+          beforePersist,
+          afterPersist: [],
+        };
+      }
+      return {
         persist: "defer",
         nextGoal,
-        memory,
+        source: "runtime",
+        beforePersist,
+        afterPersist: [],
       };
     }
     case "set": {
-      const { nextGoal, source, wasPausedBefore = false } = request;
-      const commandEffects =
-        source === "command"
-          ? {
-              markContinuationQueued: nextGoal.status === "active",
-              resetRecoveryBeforePersist: false,
-              resetRecoveryAfterPersist:
-                (nextGoal.status === "active" && wasPausedBefore) || nextGoal.status === "paused",
-              clearContinuationBeforePersist: false,
-              clearActiveAccountingBeforePersist: false,
-            }
-          : {
-              markContinuationQueued: false,
-              resetRecoveryBeforePersist: false,
-              resetRecoveryAfterPersist: false,
-              clearContinuationBeforePersist: false,
-              clearActiveAccountingBeforePersist: false,
-            };
-      const shared: GoalTransitionEffectPlanShared = {
-        source,
-        markContinuationQueued: commandEffects.markContinuationQueued,
-        resetRecoveryBeforePersist: commandEffects.resetRecoveryBeforePersist,
-        resetRecoveryAfterPersist: commandEffects.resetRecoveryAfterPersist,
-        clearContinuationBeforePersist: commandEffects.clearContinuationBeforePersist,
-        clearActiveAccountingBeforePersist: commandEffects.clearActiveAccountingBeforePersist,
-        clearHostOverflowRecovery: false,
-        recoveryPausedReason: null,
-      };
+      const { nextGoal, source } = request;
+      const wasPausedBefore = current?.status === "paused";
+      const afterPersist =
+        source === "command" ? commandAfterPersistEffects(nextGoal, wasPausedBefore) : [];
       if (current && goalsEquivalent(current, nextGoal)) {
-        return { ...shared, persist: "skip", nextGoal };
+        return {
+          persist: "skip",
+          nextGoal,
+          source,
+          beforePersist: [],
+          afterPersist,
+        };
       }
       return {
-        ...shared,
         persist: "set",
         nextGoal,
-        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
+        source,
+        beforePersist: memoryEffectsFromGoalChange(current, nextGoal),
+        afterPersist,
       };
     }
     default: {
@@ -317,47 +342,51 @@ export function planGoalTransition(
   }
 }
 
-export interface GoalMemoryEffectHandlers {
+export interface GoalTransitionEffectHandlers {
   clearContinuation: () => void;
   clearActiveAccounting: () => void;
   resetRecovery: () => void;
   clearBudgetWarning: () => void;
-}
-
-export function applyGoalMemoryEffects(
-  plan: GoalMemoryEffectPlan,
-  handlers: GoalMemoryEffectHandlers,
-): void {
-  if (plan.clearContinuation) {
-    handlers.clearContinuation();
-  }
-  if (plan.clearActiveAccounting) {
-    handlers.clearActiveAccounting();
-  }
-  if (plan.resetRecovery) {
-    handlers.resetRecovery();
-  }
-  if (plan.clearBudgetWarning) {
-    handlers.clearBudgetWarning();
-  }
-}
-
-export interface GoalTransitionPostPersistHandlers {
-  resetRecoveryAfterPersist: () => void;
+  clearHostOverflowRecovery: () => void;
+  setRecoveryPausedAttention: (reason: string) => void;
   markContinuationQueued: (goalId: string) => void;
+  stopStatusRefresh: () => void;
 }
 
-export function applyGoalTransitionPostPersistEffects(
-  plan: Pick<
-    GoalTransitionEffectPlan,
-    "resetRecoveryAfterPersist" | "markContinuationQueued" | "nextGoal"
-  >,
-  handlers: GoalTransitionPostPersistHandlers,
+export function applyGoalTransitionEffects(
+  effects: readonly GoalTransitionEffect[],
+  handlers: GoalTransitionEffectHandlers,
 ): void {
-  if (plan.resetRecoveryAfterPersist) {
-    handlers.resetRecoveryAfterPersist();
-  }
-  if (plan.markContinuationQueued && plan.nextGoal) {
-    handlers.markContinuationQueued(plan.nextGoal.goalId);
+  for (const effect of effects) {
+    switch (effect.type) {
+      case "clearContinuation":
+        handlers.clearContinuation();
+        break;
+      case "clearActiveAccounting":
+        handlers.clearActiveAccounting();
+        break;
+      case "resetRecovery":
+        handlers.resetRecovery();
+        break;
+      case "clearBudgetWarning":
+        handlers.clearBudgetWarning();
+        break;
+      case "clearHostOverflowRecovery":
+        handlers.clearHostOverflowRecovery();
+        break;
+      case "setRecoveryPausedAttention":
+        handlers.setRecoveryPausedAttention(effect.reason);
+        break;
+      case "markContinuationQueued":
+        handlers.markContinuationQueued(effect.goalId);
+        break;
+      case "stopStatusRefresh":
+        handlers.stopStatusRefresh();
+        break;
+      default: {
+        const _exhaustive: never = effect;
+        throw new Error(`Unhandled goal transition effect: ${String(_exhaustive)}`);
+      }
+    }
   }
 }

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -21,10 +21,14 @@ export type GoalTransitionRequest =
       kind: "recovery_shutdown_pause";
       nextGoal: ThreadGoal;
       recoveryReason: string;
+    }
+  | {
+      kind: "runtime_accounting";
+      nextGoal: ThreadGoal;
+      crossedBudget: boolean;
     };
 
 export interface GoalMemoryEffectPlan {
-  resetStoppedRuntime: boolean;
   clearContinuation: boolean;
   clearActiveAccounting: boolean;
   resetRecovery: boolean;
@@ -36,18 +40,21 @@ interface GoalTransitionEffectPlanShared {
   markContinuationQueued: boolean;
   resetRecoveryBeforePersist: boolean;
   resetRecoveryAfterPersist: boolean;
-  resetStoppedRuntimeBeforePersist: boolean;
   clearContinuationBeforePersist: boolean;
+  clearActiveAccountingBeforePersist: boolean;
   clearHostOverflowRecovery: boolean;
   recoveryPausedReason: string | null;
-  stopStatusRefresh: boolean;
-  refreshUi: boolean;
 }
 
 export type GoalTransitionEffectPlan =
   | (GoalTransitionEffectPlanShared & {
       persist: "skip";
       nextGoal: ThreadGoal | null;
+    })
+  | (GoalTransitionEffectPlanShared & {
+      persist: "defer";
+      nextGoal: ThreadGoal;
+      memory: GoalMemoryEffectPlan;
     })
   | (GoalTransitionEffectPlanShared & {
       persist: "set";
@@ -66,18 +73,21 @@ export function planMemoryEffectsOnGoalChange(
 ): GoalMemoryEffectPlan {
   const goalIdChanged = (previous?.goalId ?? null) !== next.goalId;
 
-  let resetStoppedRuntime = false;
   let clearContinuation = false;
   let clearActiveAccounting = false;
   let resetRecovery = false;
   let clearBudgetWarning = false;
 
   if (goalIdChanged) {
-    resetStoppedRuntime = true;
+    clearContinuation = true;
+    clearActiveAccounting = true;
+    resetRecovery = true;
     clearBudgetWarning = true;
   }
   if (next.status === "complete") {
-    resetStoppedRuntime = true;
+    clearContinuation = true;
+    clearActiveAccounting = true;
+    resetRecovery = true;
   } else if (next.status === "paused") {
     clearContinuation = true;
     clearActiveAccounting = true;
@@ -91,7 +101,6 @@ export function planMemoryEffectsOnGoalChange(
   }
 
   return {
-    resetStoppedRuntime,
     clearContinuation,
     clearActiveAccounting,
     resetRecovery,
@@ -101,11 +110,23 @@ export function planMemoryEffectsOnGoalChange(
 
 function mergeMemoryPlans(...plans: readonly GoalMemoryEffectPlan[]): GoalMemoryEffectPlan {
   return {
-    resetStoppedRuntime: plans.some((plan) => plan.resetStoppedRuntime),
     clearContinuation: plans.some((plan) => plan.clearContinuation),
     clearActiveAccounting: plans.some((plan) => plan.clearActiveAccounting),
     resetRecovery: plans.some((plan) => plan.resetRecovery),
     clearBudgetWarning: plans.some((plan) => plan.clearBudgetWarning),
+  };
+}
+
+function runtimeTransitionShared(): GoalTransitionEffectPlanShared {
+  return {
+    source: "runtime",
+    markContinuationQueued: false,
+    resetRecoveryBeforePersist: false,
+    resetRecoveryAfterPersist: false,
+    clearContinuationBeforePersist: false,
+    clearActiveAccountingBeforePersist: false,
+    clearHostOverflowRecovery: false,
+    recoveryPausedReason: null,
   };
 }
 
@@ -118,12 +139,10 @@ function recoveryPauseShared(
     markContinuationQueued: false,
     resetRecoveryBeforePersist: false,
     resetRecoveryAfterPersist: false,
-    resetStoppedRuntimeBeforePersist: false,
     clearContinuationBeforePersist: true,
+    clearActiveAccountingBeforePersist: false,
     clearHostOverflowRecovery,
     recoveryPausedReason: recoveryReason,
-    stopStatusRefresh: false,
-    refreshUi: true,
   };
 }
 
@@ -135,7 +154,6 @@ export function planGoalTransition(
     case "clear": {
       return {
         memory: {
-          resetStoppedRuntime: true,
           clearContinuation: true,
           clearActiveAccounting: true,
           resetRecovery: true,
@@ -147,12 +165,10 @@ export function planGoalTransition(
         markContinuationQueued: false,
         resetRecoveryBeforePersist: false,
         resetRecoveryAfterPersist: false,
-        resetStoppedRuntimeBeforePersist: false,
         clearContinuationBeforePersist: false,
+        clearActiveAccountingBeforePersist: false,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
-        stopStatusRefresh: true,
-        refreshUi: true,
       };
     }
     case "abort_pause": {
@@ -160,14 +176,12 @@ export function planGoalTransition(
       const shared: GoalTransitionEffectPlanShared = {
         source: "runtime",
         markContinuationQueued: false,
-        resetRecoveryBeforePersist: false,
+        resetRecoveryBeforePersist: true,
         resetRecoveryAfterPersist: false,
-        resetStoppedRuntimeBeforePersist: true,
-        clearContinuationBeforePersist: false,
+        clearContinuationBeforePersist: true,
+        clearActiveAccountingBeforePersist: true,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
-        stopStatusRefresh: false,
-        refreshUi: true,
       };
       if (current && goalsEquivalent(current, nextGoal)) {
         return { ...shared, persist: "skip", nextGoal };
@@ -178,7 +192,6 @@ export function planGoalTransition(
         nextGoal,
         memory: mergeMemoryPlans(
           {
-            resetStoppedRuntime: true,
             clearContinuation: true,
             clearActiveAccounting: true,
             resetRecovery: true,
@@ -195,12 +208,10 @@ export function planGoalTransition(
         markContinuationQueued: false,
         resetRecoveryBeforePersist: true,
         resetRecoveryAfterPersist: false,
-        resetStoppedRuntimeBeforePersist: false,
         clearContinuationBeforePersist: true,
+        clearActiveAccountingBeforePersist: false,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
-        stopStatusRefresh: false,
-        refreshUi: true,
       };
       if (current && goalsEquivalent(current, nextGoal)) {
         return { ...shared, persist: "skip", nextGoal };
@@ -238,6 +249,28 @@ export function planGoalTransition(
         memory: planMemoryEffectsOnGoalChange(current, nextGoal),
       };
     }
+    case "runtime_accounting": {
+      const { nextGoal, crossedBudget } = request;
+      const shared = runtimeTransitionShared();
+      if (current && goalsEquivalent(current, nextGoal)) {
+        return { ...shared, persist: "skip", nextGoal };
+      }
+      const memory = planMemoryEffectsOnGoalChange(current, nextGoal);
+      if (crossedBudget) {
+        return {
+          ...shared,
+          persist: "set",
+          nextGoal,
+          memory,
+        };
+      }
+      return {
+        ...shared,
+        persist: "defer",
+        nextGoal,
+        memory,
+      };
+    }
     case "set": {
       const { nextGoal, source, wasPausedBefore = false } = request;
       const commandEffects =
@@ -247,27 +280,25 @@ export function planGoalTransition(
               resetRecoveryBeforePersist: false,
               resetRecoveryAfterPersist:
                 (nextGoal.status === "active" && wasPausedBefore) || nextGoal.status === "paused",
-              resetStoppedRuntimeBeforePersist: false,
               clearContinuationBeforePersist: false,
+              clearActiveAccountingBeforePersist: false,
             }
           : {
               markContinuationQueued: false,
               resetRecoveryBeforePersist: false,
               resetRecoveryAfterPersist: false,
-              resetStoppedRuntimeBeforePersist: false,
               clearContinuationBeforePersist: false,
+              clearActiveAccountingBeforePersist: false,
             };
       const shared: GoalTransitionEffectPlanShared = {
         source,
         markContinuationQueued: commandEffects.markContinuationQueued,
         resetRecoveryBeforePersist: commandEffects.resetRecoveryBeforePersist,
         resetRecoveryAfterPersist: commandEffects.resetRecoveryAfterPersist,
-        resetStoppedRuntimeBeforePersist: commandEffects.resetStoppedRuntimeBeforePersist,
         clearContinuationBeforePersist: commandEffects.clearContinuationBeforePersist,
+        clearActiveAccountingBeforePersist: commandEffects.clearActiveAccountingBeforePersist,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
-        stopStatusRefresh: false,
-        refreshUi: true,
       };
       if (current && goalsEquivalent(current, nextGoal)) {
         return { ...shared, persist: "skip", nextGoal };
@@ -287,7 +318,6 @@ export function planGoalTransition(
 }
 
 export interface GoalMemoryEffectHandlers {
-  resetStoppedRuntime: () => void;
   clearContinuation: () => void;
   clearActiveAccounting: () => void;
   resetRecovery: () => void;
@@ -298,9 +328,6 @@ export function applyGoalMemoryEffects(
   plan: GoalMemoryEffectPlan,
   handlers: GoalMemoryEffectHandlers,
 ): void {
-  if (plan.resetStoppedRuntime) {
-    handlers.resetStoppedRuntime();
-  }
   if (plan.clearContinuation) {
     handlers.clearContinuation();
   }
@@ -323,7 +350,7 @@ export interface GoalTransitionPostPersistHandlers {
 export function applyGoalTransitionPostPersistEffects(
   plan: Pick<
     GoalTransitionEffectPlan,
-    "resetRecoveryAfterPersist" | "markContinuationQueued" | "nextGoal" | "persist"
+    "resetRecoveryAfterPersist" | "markContinuationQueued" | "nextGoal"
   >,
   handlers: GoalTransitionPostPersistHandlers,
 ): void {

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -222,6 +222,29 @@ function requireUnchangedUsage(current: ThreadGoal, nextGoal: ThreadGoal, kind: 
   }
 }
 
+function requireNonRewindingUpdatedAt(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
+  if (nextGoal.updatedAt < current.updatedAt) {
+    throw transitionInvariantError(kind, "updatedAt must not decrease");
+  }
+}
+
+function requireRuntimeAccountingChange(
+  current: ThreadGoal,
+  nextGoal: ThreadGoal,
+  kind: string,
+): void {
+  const usageIncreased =
+    nextGoal.usage.tokensUsed > current.usage.tokensUsed ||
+    nextGoal.usage.activeSeconds > current.usage.activeSeconds;
+  const statusChanged = current.status !== nextGoal.status;
+  if (!usageIncreased && !statusChanged) {
+    throw transitionInvariantError(
+      kind,
+      "runtime accounting must increase usage or change status",
+    );
+  }
+}
+
 function requireStatusHelperImmutableFields(
   current: ThreadGoal,
   nextGoal: ThreadGoal,
@@ -231,6 +254,7 @@ function requireStatusHelperImmutableFields(
   requireUnchangedTokenBudget(current, nextGoal, kind);
   requireUnchangedUsage(current, nextGoal, kind);
   requireUnchangedCreatedAt(current, nextGoal, kind);
+  requireNonRewindingUpdatedAt(current, nextGoal, kind);
 }
 
 function requireNonDecreasingUsage(current: ThreadGoal, nextGoal: ThreadGoal, kind: string): void {
@@ -327,7 +351,9 @@ function validateRuntimeAccounting(current: ThreadGoal | null, nextGoal: ThreadG
   requireUnchangedObjective(current, nextGoal, kind);
   requireUnchangedTokenBudget(current, nextGoal, kind);
   requireUnchangedCreatedAt(current, nextGoal, kind);
+  requireNonRewindingUpdatedAt(current, nextGoal, kind);
   requireNonDecreasingUsage(current, nextGoal, kind);
+  requireRuntimeAccountingChange(current, nextGoal, kind);
   if (nextGoal.status === "budgetLimited") {
     requireBudgetLimitedUsageAtOrOverBudget(nextGoal, kind);
   }
@@ -415,15 +441,6 @@ export function planGoalTransition(
     case "runtime_accounting": {
       const { nextGoal } = request;
       validateRuntimeAccounting(current, nextGoal);
-      if (current && goalsEquivalent(current, nextGoal)) {
-        return {
-          persist: "skip",
-          nextGoal,
-          source: "runtime",
-          beforePersist: [],
-          afterPersist: [],
-        };
-      }
       const beforePersist = memoryEffectsFromGoalChange(current, nextGoal);
       if (crossedBudgetTransition(current, nextGoal)) {
         return {

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -135,14 +135,18 @@ function crossedBudgetTransition(current: ThreadGoal | null, nextGoal: ThreadGoa
 }
 
 function commandAfterPersistEffects(
+  current: ThreadGoal | null,
   nextGoal: ThreadGoal,
   wasPausedBefore: boolean,
 ): GoalTransitionEffect[] {
+  const goalIdChanged = (current?.goalId ?? null) !== nextGoal.goalId;
   const effects: GoalTransitionEffect[] = [];
   if (nextGoal.status === "active") {
     effects.push({ type: "markContinuationQueued", goalId: nextGoal.goalId });
   }
-  if ((nextGoal.status === "active" && wasPausedBefore) || nextGoal.status === "paused") {
+  if (nextGoal.status === "paused") {
+    effects.push({ type: "resetRecovery" });
+  } else if (nextGoal.status === "active" && wasPausedBefore && !goalIdChanged) {
     effects.push({ type: "resetRecovery" });
   }
   return effects;
@@ -317,7 +321,9 @@ export function planGoalTransition(
       const { nextGoal, source } = request;
       const wasPausedBefore = current?.status === "paused";
       const afterPersist =
-        source === "command" ? commandAfterPersistEffects(nextGoal, wasPausedBefore) : [];
+        source === "command"
+          ? commandAfterPersistEffects(current, nextGoal, wasPausedBefore)
+          : [];
       if (current && goalsEquivalent(current, nextGoal)) {
         return {
           persist: "skip",

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -35,6 +35,7 @@ export interface GoalTransitionEffectPlan {
   markContinuationQueued: boolean;
   resetRecoveryBeforePersist: boolean;
   resetRecoveryAfterPersist: boolean;
+  resetStoppedRuntimeBeforePersist: boolean;
   clearContinuationBeforePersist: boolean;
   clearHostOverflowRecovery: boolean;
   recoveryPausedReason: string | null;
@@ -111,6 +112,7 @@ export function planGoalTransition(
         markContinuationQueued: false,
         resetRecoveryBeforePersist: false,
         resetRecoveryAfterPersist: false,
+        resetStoppedRuntimeBeforePersist: false,
         clearContinuationBeforePersist: false,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
@@ -137,6 +139,7 @@ export function planGoalTransition(
         markContinuationQueued: false,
         resetRecoveryBeforePersist: false,
         resetRecoveryAfterPersist: false,
+        resetStoppedRuntimeBeforePersist: true,
         clearContinuationBeforePersist: false,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
@@ -154,6 +157,7 @@ export function planGoalTransition(
         markContinuationQueued: false,
         resetRecoveryBeforePersist: true,
         resetRecoveryAfterPersist: false,
+        resetStoppedRuntimeBeforePersist: false,
         clearContinuationBeforePersist: true,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
@@ -170,6 +174,7 @@ export function planGoalTransition(
         markContinuationQueued: false,
         resetRecoveryBeforePersist: false,
         resetRecoveryAfterPersist: false,
+        resetStoppedRuntimeBeforePersist: false,
         clearContinuationBeforePersist: false,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
@@ -186,6 +191,7 @@ export function planGoalTransition(
         markContinuationQueued: false,
         resetRecoveryBeforePersist: false,
         resetRecoveryAfterPersist: false,
+        resetStoppedRuntimeBeforePersist: false,
         clearContinuationBeforePersist: true,
         clearHostOverflowRecovery: true,
         recoveryPausedReason: request.recoveryReason,
@@ -204,12 +210,14 @@ export function planGoalTransition(
               resetRecoveryBeforePersist: false,
               resetRecoveryAfterPersist:
                 (nextGoal.status === "active" && wasPausedBefore) || nextGoal.status === "paused",
+              resetStoppedRuntimeBeforePersist: false,
               clearContinuationBeforePersist: false,
             }
           : {
               markContinuationQueued: false,
               resetRecoveryBeforePersist: false,
               resetRecoveryAfterPersist: false,
+              resetStoppedRuntimeBeforePersist: false,
               clearContinuationBeforePersist: false,
             };
 
@@ -221,6 +229,7 @@ export function planGoalTransition(
         markContinuationQueued: commandEffects.markContinuationQueued,
         resetRecoveryBeforePersist: commandEffects.resetRecoveryBeforePersist,
         resetRecoveryAfterPersist: commandEffects.resetRecoveryAfterPersist,
+        resetStoppedRuntimeBeforePersist: commandEffects.resetStoppedRuntimeBeforePersist,
         clearContinuationBeforePersist: commandEffects.clearContinuationBeforePersist,
         clearHostOverflowRecovery: false,
         recoveryPausedReason: null,
@@ -249,7 +258,6 @@ export function applyGoalMemoryEffects(
 ): void {
   if (plan.resetStoppedRuntime) {
     handlers.resetStoppedRuntime();
-    return;
   }
   if (plan.clearContinuation) {
     handlers.clearContinuation();
@@ -262,5 +270,25 @@ export function applyGoalMemoryEffects(
   }
   if (plan.clearBudgetWarning) {
     handlers.clearBudgetWarning();
+  }
+}
+
+export interface GoalTransitionPostPersistHandlers {
+  resetRecoveryAfterPersist: () => void;
+  markContinuationQueued: (goalId: string) => void;
+}
+
+export function applyGoalTransitionPostPersistEffects(
+  plan: Pick<
+    GoalTransitionEffectPlan,
+    "resetRecoveryAfterPersist" | "markContinuationQueued" | "nextGoal"
+  >,
+  handlers: GoalTransitionPostPersistHandlers,
+): void {
+  if (plan.resetRecoveryAfterPersist) {
+    handlers.resetRecoveryAfterPersist();
+  }
+  if (plan.markContinuationQueued && plan.nextGoal) {
+    handlers.markContinuationQueued(plan.nextGoal.goalId);
   }
 }

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -43,14 +43,14 @@ export type GoalTransitionPlan = {
   afterPersist: GoalTransitionEffect[];
 };
 
-export interface GoalMemoryEffectPlan {
+interface GoalMemoryEffectPlan {
   clearContinuation: boolean;
   clearActiveAccounting: boolean;
   resetRecovery: boolean;
   clearBudgetWarning: boolean;
 }
 
-export function planMemoryEffectsOnGoalChange(
+function planMemoryEffectsOnGoalChange(
   previous: ThreadGoal | null,
   next: ThreadGoal,
 ): GoalMemoryEffectPlan {
@@ -144,7 +144,7 @@ function commandAfterPersistEffects(
   if (nextGoal.status === "active") {
     effects.push({ type: "markContinuationQueued", goalId: nextGoal.goalId });
   }
-  if (nextGoal.status === "paused") {
+  if (nextGoal.status === "paused" && !goalIdChanged) {
     effects.push({ type: "resetRecovery" });
   } else if (nextGoal.status === "active" && wasPausedBefore && !goalIdChanged) {
     effects.push({ type: "resetRecovery" });

--- a/src/goal-transition.ts
+++ b/src/goal-transition.ts
@@ -1,0 +1,266 @@
+import { goalsEquivalent } from "./state.js";
+import type { GoalEntrySource, ThreadGoal } from "./types.js";
+
+export type GoalTransitionRequest =
+  | {
+      kind: "set";
+      nextGoal: ThreadGoal;
+      source: GoalEntrySource;
+      /** Command /goal resume: goal was paused immediately before this transition. */
+      wasPausedBefore?: boolean;
+    }
+  | { kind: "clear"; source: GoalEntrySource }
+  | { kind: "abort_pause"; nextGoal: ThreadGoal }
+  | { kind: "resume_active"; nextGoal: ThreadGoal }
+  | { kind: "recovery_pause"; nextGoal: ThreadGoal }
+  | {
+      kind: "recovery_shutdown_pause";
+      nextGoal: ThreadGoal;
+      recoveryReason: string;
+    };
+
+export interface GoalMemoryEffectPlan {
+  resetStoppedRuntime: boolean;
+  clearContinuation: boolean;
+  clearActiveAccounting: boolean;
+  resetRecovery: boolean;
+  clearBudgetWarning: boolean;
+}
+
+export interface GoalTransitionEffectPlan {
+  memory: GoalMemoryEffectPlan;
+  persist: "set" | "clear" | "skip";
+  nextGoal: ThreadGoal | null;
+  source: GoalEntrySource;
+  markContinuationQueued: boolean;
+  resetRecoveryBeforePersist: boolean;
+  resetRecoveryAfterPersist: boolean;
+  clearContinuationBeforePersist: boolean;
+  clearHostOverflowRecovery: boolean;
+  recoveryPausedReason: string | null;
+  stopStatusRefresh: boolean;
+  refreshUi: boolean;
+}
+
+export function planMemoryEffectsOnGoalChange(
+  previous: ThreadGoal | null,
+  next: ThreadGoal,
+): GoalMemoryEffectPlan {
+  const goalIdChanged = (previous?.goalId ?? null) !== next.goalId;
+
+  let resetStoppedRuntime = false;
+  let clearContinuation = false;
+  let clearActiveAccounting = false;
+  let resetRecovery = false;
+  let clearBudgetWarning = false;
+
+  if (goalIdChanged) {
+    resetStoppedRuntime = true;
+    clearBudgetWarning = true;
+  }
+  if (next.status === "complete") {
+    resetStoppedRuntime = true;
+  } else if (next.status === "paused") {
+    clearContinuation = true;
+    clearActiveAccounting = true;
+  } else if (next.status === "budgetLimited") {
+    clearContinuation = true;
+    clearActiveAccounting = true;
+    resetRecovery = true;
+  }
+  if (next.status !== "budgetLimited") {
+    clearBudgetWarning = true;
+  }
+
+  return {
+    resetStoppedRuntime,
+    clearContinuation,
+    clearActiveAccounting,
+    resetRecovery,
+    clearBudgetWarning,
+  };
+}
+
+function mergeMemoryPlans(...plans: readonly GoalMemoryEffectPlan[]): GoalMemoryEffectPlan {
+  return {
+    resetStoppedRuntime: plans.some((plan) => plan.resetStoppedRuntime),
+    clearContinuation: plans.some((plan) => plan.clearContinuation),
+    clearActiveAccounting: plans.some((plan) => plan.clearActiveAccounting),
+    resetRecovery: plans.some((plan) => plan.resetRecovery),
+    clearBudgetWarning: plans.some((plan) => plan.clearBudgetWarning),
+  };
+}
+
+export function planGoalTransition(
+  current: ThreadGoal | null,
+  request: GoalTransitionRequest,
+): GoalTransitionEffectPlan | null {
+  switch (request.kind) {
+    case "clear": {
+      return {
+        memory: {
+          resetStoppedRuntime: true,
+          clearContinuation: true,
+          clearActiveAccounting: true,
+          resetRecovery: true,
+          clearBudgetWarning: true,
+        },
+        persist: "clear",
+        nextGoal: null,
+        source: request.source,
+        markContinuationQueued: false,
+        resetRecoveryBeforePersist: false,
+        resetRecoveryAfterPersist: false,
+        clearContinuationBeforePersist: false,
+        clearHostOverflowRecovery: false,
+        recoveryPausedReason: null,
+        stopStatusRefresh: true,
+        refreshUi: true,
+      };
+    }
+    case "abort_pause": {
+      const { nextGoal } = request;
+      return {
+        memory: mergeMemoryPlans(
+          {
+            resetStoppedRuntime: true,
+            clearContinuation: true,
+            clearActiveAccounting: true,
+            resetRecovery: true,
+            clearBudgetWarning: true,
+          },
+          planMemoryEffectsOnGoalChange(current, nextGoal),
+        ),
+        persist: current && goalsEquivalent(current, nextGoal) ? "skip" : "set",
+        nextGoal,
+        source: "runtime",
+        markContinuationQueued: false,
+        resetRecoveryBeforePersist: false,
+        resetRecoveryAfterPersist: false,
+        clearContinuationBeforePersist: false,
+        clearHostOverflowRecovery: false,
+        recoveryPausedReason: null,
+        stopStatusRefresh: false,
+        refreshUi: true,
+      };
+    }
+    case "resume_active": {
+      const { nextGoal } = request;
+      return {
+        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
+        persist: current && goalsEquivalent(current, nextGoal) ? "skip" : "set",
+        nextGoal,
+        source: "runtime",
+        markContinuationQueued: false,
+        resetRecoveryBeforePersist: true,
+        resetRecoveryAfterPersist: false,
+        clearContinuationBeforePersist: true,
+        clearHostOverflowRecovery: false,
+        recoveryPausedReason: null,
+        stopStatusRefresh: false,
+        refreshUi: true,
+      };
+    }
+    case "recovery_pause": {
+      return {
+        memory: planMemoryEffectsOnGoalChange(current, request.nextGoal),
+        persist: current && goalsEquivalent(current, request.nextGoal) ? "skip" : "set",
+        nextGoal: request.nextGoal,
+        source: "runtime",
+        markContinuationQueued: false,
+        resetRecoveryBeforePersist: false,
+        resetRecoveryAfterPersist: false,
+        clearContinuationBeforePersist: false,
+        clearHostOverflowRecovery: false,
+        recoveryPausedReason: null,
+        stopStatusRefresh: false,
+        refreshUi: false,
+      };
+    }
+    case "recovery_shutdown_pause": {
+      return {
+        memory: planMemoryEffectsOnGoalChange(current, request.nextGoal),
+        persist: current && goalsEquivalent(current, request.nextGoal) ? "skip" : "set",
+        nextGoal: request.nextGoal,
+        source: "runtime",
+        markContinuationQueued: false,
+        resetRecoveryBeforePersist: false,
+        resetRecoveryAfterPersist: false,
+        clearContinuationBeforePersist: true,
+        clearHostOverflowRecovery: true,
+        recoveryPausedReason: request.recoveryReason,
+        stopStatusRefresh: false,
+        refreshUi: true,
+      };
+    }
+    case "set": {
+      const { nextGoal, source, wasPausedBefore = false } = request;
+      const persist =
+        current && goalsEquivalent(current, nextGoal) ? ("skip" as const) : ("set" as const);
+      const commandEffects =
+        source === "command"
+          ? {
+              markContinuationQueued: nextGoal.status === "active",
+              resetRecoveryBeforePersist: false,
+              resetRecoveryAfterPersist:
+                (nextGoal.status === "active" && wasPausedBefore) || nextGoal.status === "paused",
+              clearContinuationBeforePersist: false,
+            }
+          : {
+              markContinuationQueued: false,
+              resetRecoveryBeforePersist: false,
+              resetRecoveryAfterPersist: false,
+              clearContinuationBeforePersist: false,
+            };
+
+      return {
+        memory: planMemoryEffectsOnGoalChange(current, nextGoal),
+        persist,
+        nextGoal,
+        source,
+        markContinuationQueued: commandEffects.markContinuationQueued,
+        resetRecoveryBeforePersist: commandEffects.resetRecoveryBeforePersist,
+        resetRecoveryAfterPersist: commandEffects.resetRecoveryAfterPersist,
+        clearContinuationBeforePersist: commandEffects.clearContinuationBeforePersist,
+        clearHostOverflowRecovery: false,
+        recoveryPausedReason: null,
+        stopStatusRefresh: false,
+        refreshUi: true,
+      };
+    }
+    default: {
+      const _exhaustive: never = request;
+      throw new Error(`Unhandled goal transition request: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+export interface GoalMemoryEffectHandlers {
+  resetStoppedRuntime: () => void;
+  clearContinuation: () => void;
+  clearActiveAccounting: () => void;
+  resetRecovery: () => void;
+  clearBudgetWarning: () => void;
+}
+
+export function applyGoalMemoryEffects(
+  plan: GoalMemoryEffectPlan,
+  handlers: GoalMemoryEffectHandlers,
+): void {
+  if (plan.resetStoppedRuntime) {
+    handlers.resetStoppedRuntime();
+    return;
+  }
+  if (plan.clearContinuation) {
+    handlers.clearContinuation();
+  }
+  if (plan.clearActiveAccounting) {
+    handlers.clearActiveAccounting();
+  }
+  if (plan.resetRecovery) {
+    handlers.resetRecovery();
+  }
+  if (plan.clearBudgetWarning) {
+    handlers.clearBudgetWarning();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import {
   applyGoalMemoryEffects,
   applyGoalTransitionPostPersistEffects,
   planGoalTransition,
-  planMemoryEffectsOnGoalChange,
   type GoalTransitionRequest,
 } from "./goal-transition.js";
 import {
@@ -156,12 +155,6 @@ export default function (pi: ExtensionAPI): void {
     }
   };
 
-  const clearStoppedRuntimeState = (): void => {
-    clearContinuationState();
-    clearActiveAccounting();
-    resetErrorRecovery();
-  };
-
   const syncStatusRefresh = (): void => {
     if (goal?.status === "active" && statusContext && !statusRefreshTimer) {
       statusRefreshTimer = setInterval(() => {
@@ -226,18 +219,12 @@ export default function (pi: ExtensionAPI): void {
     extensionQueuedGoalWorkMessageIdForRuntime(message, continuationGoalIdFromRuntimePrompt);
 
   const goalMemoryHandlers = {
-    resetStoppedRuntime: clearStoppedRuntimeState,
     clearContinuation: clearContinuationState,
     clearActiveAccounting,
     resetRecovery: resetErrorRecovery,
     clearBudgetWarning: () => {
       accounting.budgetWarningSentFor = null;
     },
-  };
-
-  const setGoalInMemory = (nextGoal: ThreadGoal): void => {
-    applyGoalMemoryEffects(planMemoryEffectsOnGoalChange(goal, nextGoal), goalMemoryHandlers);
-    goal = nextGoal;
   };
 
   const applyGoalTransition = (
@@ -249,11 +236,11 @@ export default function (pi: ExtensionAPI): void {
     if (plan.resetRecoveryBeforePersist) {
       resetErrorRecovery();
     }
-    if (plan.resetStoppedRuntimeBeforePersist) {
-      clearStoppedRuntimeState();
-    }
     if (plan.clearContinuationBeforePersist) {
       clearContinuationState();
+    }
+    if (plan.clearActiveAccountingBeforePersist) {
+      clearActiveAccounting();
     }
     if (plan.clearHostOverflowRecovery) {
       clearActiveHostOverflowRecovery(recoveryState);
@@ -268,11 +255,9 @@ export default function (pi: ExtensionAPI): void {
       goal = null;
       lastPersistedGoal = null;
       lastRuntimePersistAt = null;
-      if (plan.stopStatusRefresh) {
-        stopStatusRefresh();
-      }
+      stopStatusRefresh();
       pi.appendEntry(CUSTOM_ENTRY_TYPE, clearEntry(clearedGoalId, plan.source));
-      if (plan.refreshUi && ctx) {
+      if (ctx) {
         refreshUi(ctx);
       }
       return true;
@@ -285,7 +270,16 @@ export default function (pi: ExtensionAPI): void {
           continuationQueuedFor = goalId;
         },
       });
-      if (plan.refreshUi && ctx) {
+      if (ctx) {
+        refreshUi(ctx);
+      }
+      return false;
+    }
+
+    if (plan.persist === "defer") {
+      applyGoalMemoryEffects(plan.memory, goalMemoryHandlers);
+      goal = plan.nextGoal;
+      if (ctx) {
         refreshUi(ctx);
       }
       return false;
@@ -301,7 +295,7 @@ export default function (pi: ExtensionAPI): void {
         continuationQueuedFor = goalId;
       },
     });
-    if (plan.refreshUi && ctx) {
+    if (ctx) {
       refreshUi(ctx);
     }
 
@@ -388,10 +382,10 @@ export default function (pi: ExtensionAPI): void {
 
   const goalAccounting = createGoalAccounting({
     getGoal: () => goal,
-    setGoal: setGoalInMemory,
     getAccounting: () => accounting,
-    flushGoalPersistence,
-    refreshUi,
+    applyRuntimeAccountingTransition(ctx, nextGoal, crossedBudget) {
+      applyGoalTransition({ kind: "runtime_accounting", nextGoal, crossedBudget }, ctx);
+    },
     sendMessage: pi.sendMessage.bind(pi),
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,9 +245,6 @@ export default function (pi: ExtensionAPI): void {
     ctx: StatusContext | null,
   ): boolean => {
     const plan = planGoalTransition(goal, request);
-    if (!plan) {
-      return false;
-    }
 
     if (plan.resetRecoveryBeforePersist) {
       resetErrorRecovery();
@@ -468,12 +465,15 @@ export default function (pi: ExtensionAPI): void {
     getGoal: () => goal,
     getRecoveryState: () => recoveryState,
     clearContinuationState,
-    pauseGoalForRecovery(ctx, activeGoal) {
+    pauseGoalForRecovery(ctx, activeGoal, recoveryReason) {
       const result = updateGoalStatus(activeGoal, "paused");
       if (!result.ok || !result.goal) {
         return;
       }
-      applyGoalTransition({ kind: "recovery_pause", nextGoal: result.goal }, ctx);
+      applyGoalTransition(
+        { kind: "recovery_pause", nextGoal: result.goal, recoveryReason },
+        ctx,
+      );
     },
     refreshUi,
     maybeContinue,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,7 @@ import {
 import { compactContinuationPrompt, continuationGoalIdFromPrompt } from "./prompts.js";
 import { isCommandResumeQueuedGoalMessage } from "./queued-goal-messages.js";
 import {
-  applyGoalMemoryEffects,
-  applyGoalTransitionPostPersistEffects,
+  applyGoalTransitionEffects,
   planGoalTransition,
   type GoalTransitionRequest,
 } from "./goal-transition.js";
@@ -218,13 +217,23 @@ export default function (pi: ExtensionAPI): void {
   }): string | null =>
     extensionQueuedGoalWorkMessageIdForRuntime(message, continuationGoalIdFromRuntimePrompt);
 
-  const goalMemoryHandlers = {
+  const transitionEffectHandlers = {
     clearContinuation: clearContinuationState,
     clearActiveAccounting,
     resetRecovery: resetErrorRecovery,
     clearBudgetWarning: () => {
       accounting.budgetWarningSentFor = null;
     },
+    clearHostOverflowRecovery: () => {
+      clearActiveHostOverflowRecovery(recoveryState);
+    },
+    setRecoveryPausedAttention: (reason: string) => {
+      setRecoveryPausedAttention(recoveryState, reason);
+    },
+    markContinuationQueued: (goalId: string) => {
+      continuationQueuedFor = goalId;
+    },
+    stopStatusRefresh,
   };
 
   const applyGoalTransition = (
@@ -233,30 +242,15 @@ export default function (pi: ExtensionAPI): void {
   ): boolean => {
     const plan = planGoalTransition(goal, request);
 
-    if (plan.resetRecoveryBeforePersist) {
-      resetErrorRecovery();
-    }
-    if (plan.clearContinuationBeforePersist) {
-      clearContinuationState();
-    }
-    if (plan.clearActiveAccountingBeforePersist) {
-      clearActiveAccounting();
-    }
-    if (plan.clearHostOverflowRecovery) {
-      clearActiveHostOverflowRecovery(recoveryState);
-    }
-    if (plan.recoveryPausedReason) {
-      setRecoveryPausedAttention(recoveryState, plan.recoveryPausedReason);
-    }
+    applyGoalTransitionEffects(plan.beforePersist, transitionEffectHandlers);
 
     if (plan.persist === "clear") {
       const clearedGoalId = goal?.goalId ?? null;
-      applyGoalMemoryEffects(plan.memory, goalMemoryHandlers);
       goal = null;
       lastPersistedGoal = null;
       lastRuntimePersistAt = null;
-      stopStatusRefresh();
       pi.appendEntry(CUSTOM_ENTRY_TYPE, clearEntry(clearedGoalId, plan.source));
+      applyGoalTransitionEffects(plan.afterPersist, transitionEffectHandlers);
       if (ctx) {
         refreshUi(ctx);
       }
@@ -264,12 +258,7 @@ export default function (pi: ExtensionAPI): void {
     }
 
     if (plan.persist === "skip") {
-      applyGoalTransitionPostPersistEffects(plan, {
-        resetRecoveryAfterPersist: resetErrorRecovery,
-        markContinuationQueued: (goalId) => {
-          continuationQueuedFor = goalId;
-        },
-      });
+      applyGoalTransitionEffects(plan.afterPersist, transitionEffectHandlers);
       if (ctx) {
         refreshUi(ctx);
       }
@@ -277,7 +266,6 @@ export default function (pi: ExtensionAPI): void {
     }
 
     if (plan.persist === "defer") {
-      applyGoalMemoryEffects(plan.memory, goalMemoryHandlers);
       goal = plan.nextGoal;
       if (ctx) {
         refreshUi(ctx);
@@ -285,16 +273,9 @@ export default function (pi: ExtensionAPI): void {
       return false;
     }
 
-    applyGoalMemoryEffects(plan.memory, goalMemoryHandlers);
     goal = plan.nextGoal;
     const persisted = flushGoalPersistence(plan.source);
-
-    applyGoalTransitionPostPersistEffects(plan, {
-      resetRecoveryAfterPersist: resetErrorRecovery,
-      markContinuationQueued: (goalId) => {
-        continuationQueuedFor = goalId;
-      },
-    });
+    applyGoalTransitionEffects(plan.afterPersist, transitionEffectHandlers);
     if (ctx) {
       refreshUi(ctx);
     }
@@ -383,8 +364,8 @@ export default function (pi: ExtensionAPI): void {
   const goalAccounting = createGoalAccounting({
     getGoal: () => goal,
     getAccounting: () => accounting,
-    applyRuntimeAccountingTransition(ctx, nextGoal, crossedBudget) {
-      applyGoalTransition({ kind: "runtime_accounting", nextGoal, crossedBudget }, ctx);
+    applyRuntimeAccountingTransition(ctx, nextGoal) {
+      applyGoalTransition({ kind: "runtime_accounting", nextGoal }, ctx);
     },
     sendMessage: pi.sendMessage.bind(pi),
   });
@@ -533,12 +514,7 @@ export default function (pi: ExtensionAPI): void {
     getGoal: () => goalForDisplay(),
     getGoalStartTurnStrategy: () => goalStartTurnStrategy(recoveryState.phase),
     setGoal(nextGoal, source, ctx) {
-      applyGoalTransition({
-        kind: "set",
-        nextGoal,
-        source,
-        wasPausedBefore: goal?.status === "paused",
-      }, ctx);
+      applyGoalTransition({ kind: "set", nextGoal, source }, ctx);
     },
     clearGoal(source, ctx) {
       applyGoalTransition({ kind: "clear", source }, ctx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,7 +331,12 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
 
-    applyGoalTransition({ kind: "resume_active", nextGoal: result.goal }, ctx);
+    if (result.goal.status === "active") {
+      applyGoalTransition({ kind: "resume_active", nextGoal: result.goal }, ctx);
+      return;
+    }
+
+    applyGoalTransition({ kind: "set", nextGoal: result.goal, source: "runtime" }, ctx);
   };
 
   const persistHostOverflowUserReset = (needsReset: boolean): void => {
@@ -566,13 +571,15 @@ export default function (pi: ExtensionAPI): void {
   pi.on("session_start", async (event, ctx) => {
     reloadFromSession(ctx);
     goalAccounting.beginAccounting();
-    if (event.reason === "resume" && goal?.status === "paused" && ctx.hasUI) {
-      const shouldResume = await ctx.ui.confirm("Resume paused goal?", `Goal: ${goal.objective}`);
+    const pausedGoal = goal?.status === "paused" ? goal : null;
+    if (event.reason === "resume" && pausedGoal && ctx.hasUI) {
+      const shouldResume = await ctx.ui.confirm("Resume paused goal?", `Goal: ${pausedGoal.objective}`);
       if (shouldResume) {
         resumePausedGoal(ctx);
         goalAccounting.beginAccounting();
-        if (goal) {
-          pi.sendUserMessage(compactContinuationPrompt(goal), { deliverAs: "followUp" });
+        const resumedGoal = goal;
+        if (resumedGoal?.status === "active") {
+          pi.sendUserMessage(compactContinuationPrompt(resumedGoal), { deliverAs: "followUp" });
         }
         return;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,12 @@ import {
 import { compactContinuationPrompt, continuationGoalIdFromPrompt } from "./prompts.js";
 import { isCommandResumeQueuedGoalMessage } from "./queued-goal-messages.js";
 import {
+  applyGoalMemoryEffects,
+  planGoalTransition,
+  planMemoryEffectsOnGoalChange,
+  type GoalTransitionRequest,
+} from "./goal-transition.js";
+import {
   applyQueuedGoalProviderContextRewrites,
   extensionQueuedGoalWorkMessageId,
   extensionQueuedGoalWorkMessageIdForRuntime,
@@ -218,30 +224,78 @@ export default function (pi: ExtensionAPI): void {
   }): string | null =>
     extensionQueuedGoalWorkMessageIdForRuntime(message, continuationGoalIdFromRuntimePrompt);
 
-  const applyGoalSideEffects = (nextGoal: ThreadGoal): void => {
-    const previousGoalId = goal?.goalId ?? null;
-    if (previousGoalId !== nextGoal.goalId) {
+  const goalMemoryHandlers = {
+    resetStoppedRuntime: clearStoppedRuntimeState,
+    clearContinuation: clearContinuationState,
+    clearActiveAccounting,
+    resetRecovery: resetErrorRecovery,
+    clearBudgetWarning: () => {
       accounting.budgetWarningSentFor = null;
-      clearStoppedRuntimeState();
-    }
-    if (nextGoal.status === "complete") {
-      clearStoppedRuntimeState();
-    } else if (nextGoal.status === "paused") {
-      clearContinuationState();
-      clearActiveAccounting();
-    } else if (nextGoal.status === "budgetLimited") {
-      clearContinuationState();
-      clearActiveAccounting();
-      resetErrorRecovery();
-    }
-    if (nextGoal.status !== "budgetLimited") {
-      accounting.budgetWarningSentFor = null;
-    }
+    },
   };
 
   const setGoalInMemory = (nextGoal: ThreadGoal): void => {
-    applyGoalSideEffects(nextGoal);
+    applyGoalMemoryEffects(planMemoryEffectsOnGoalChange(goal, nextGoal), goalMemoryHandlers);
     goal = nextGoal;
+  };
+
+  const applyGoalTransition = (
+    request: GoalTransitionRequest,
+    ctx: StatusContext | null,
+  ): boolean => {
+    const plan = planGoalTransition(goal, request);
+    if (!plan) {
+      return false;
+    }
+
+    if (plan.resetRecoveryBeforePersist) {
+      resetErrorRecovery();
+    }
+    if (plan.clearContinuationBeforePersist) {
+      clearContinuationState();
+    }
+    if (plan.clearHostOverflowRecovery) {
+      clearActiveHostOverflowRecovery(recoveryState);
+    }
+    if (plan.recoveryPausedReason) {
+      setRecoveryPausedAttention(recoveryState, plan.recoveryPausedReason);
+    }
+
+    if (plan.persist === "clear") {
+      const clearedGoalId = goal?.goalId ?? null;
+      applyGoalMemoryEffects(plan.memory, goalMemoryHandlers);
+      goal = null;
+      lastPersistedGoal = null;
+      lastRuntimePersistAt = null;
+      if (plan.stopStatusRefresh) {
+        stopStatusRefresh();
+      }
+      pi.appendEntry(CUSTOM_ENTRY_TYPE, clearEntry(clearedGoalId, plan.source));
+      if (plan.refreshUi && ctx) {
+        refreshUi(ctx);
+      }
+      return true;
+    }
+
+    if (plan.persist === "skip") {
+      return false;
+    }
+
+    applyGoalMemoryEffects(plan.memory, goalMemoryHandlers);
+    goal = plan.nextGoal;
+    const persisted = flushGoalPersistence(plan.source);
+
+    if (plan.resetRecoveryAfterPersist) {
+      resetErrorRecovery();
+    }
+    if (plan.markContinuationQueued && plan.nextGoal) {
+      continuationQueuedFor = plan.nextGoal.goalId;
+    }
+    if (plan.refreshUi && ctx) {
+      refreshUi(ctx);
+    }
+
+    return persisted;
   };
 
   const flushGoalPersistence = (source: GoalEntrySource): boolean => {
@@ -269,25 +323,6 @@ export default function (pi: ExtensionAPI): void {
     flushGoalPersistence(source);
   };
 
-  const persistGoal = (nextGoal: ThreadGoal, source: GoalEntrySource): boolean => {
-    if (goal && goalsEquivalent(goal, nextGoal)) {
-      return false;
-    }
-
-    setGoalInMemory(nextGoal);
-    return flushGoalPersistence(source);
-  };
-
-  const persistClear = (source: GoalEntrySource): void => {
-    const clearedGoalId = goal?.goalId ?? null;
-    goal = null;
-    lastPersistedGoal = null;
-    lastRuntimePersistAt = null;
-    clearStoppedRuntimeState();
-    stopStatusRefresh();
-    pi.appendEntry(CUSTOM_ENTRY_TYPE, clearEntry(clearedGoalId, source));
-  };
-
   const pauseForAbort = (ctx: ExtensionContext): void => {
     if (!goal || goal.status !== "active") {
       return;
@@ -298,9 +333,7 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
 
-    clearStoppedRuntimeState();
-    persistGoal(result.goal, "runtime");
-    refreshUi(ctx);
+    applyGoalTransition({ kind: "abort_pause", nextGoal: result.goal }, ctx);
   };
 
   const resumePausedGoal = (ctx: ExtensionContext): void => {
@@ -313,10 +346,7 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
 
-    resetErrorRecovery();
-    clearContinuationState();
-    persistGoal(result.goal, "runtime");
-    refreshUi(ctx);
+    applyGoalTransition({ kind: "resume_active", nextGoal: result.goal }, ctx);
   };
 
   const persistHostOverflowUserReset = (needsReset: boolean): void => {
@@ -364,8 +394,7 @@ export default function (pi: ExtensionAPI): void {
     if (goal && goalsEquivalent(goal, result.goal)) {
       return result;
     }
-    persistGoal(result.goal, source);
-    refreshUi(ctx);
+    applyGoalTransition({ kind: "set", nextGoal: result.goal, source }, ctx);
     return result;
   };
 
@@ -431,7 +460,7 @@ export default function (pi: ExtensionAPI): void {
       if (!result.ok || !result.goal) {
         return;
       }
-      persistGoal(result.goal, "runtime");
+      applyGoalTransition({ kind: "recovery_pause", nextGoal: result.goal }, ctx);
     },
     refreshUi,
     maybeContinue,
@@ -452,11 +481,14 @@ export default function (pi: ExtensionAPI): void {
       return;
     }
 
-    clearContinuationState();
-    clearActiveHostOverflowRecovery(recoveryState);
-    setRecoveryPausedAttention(recoveryState, reason);
-    persistGoal(result.goal, "runtime");
-    refreshUi(ctx);
+    applyGoalTransition(
+      {
+        kind: "recovery_shutdown_pause",
+        nextGoal: result.goal,
+        recoveryReason: reason,
+      },
+      ctx,
+    );
   };
 
   const beginOverflowRecoveryAttention = (ctx: ExtensionContext): void => {
@@ -485,8 +517,7 @@ export default function (pi: ExtensionAPI): void {
   registerGoalTools(pi, {
     getGoal: () => goalForDisplay(),
     setGoal(nextGoal, source, ctx) {
-      persistGoal(nextGoal, source);
-      refreshUi(ctx);
+      applyGoalTransition({ kind: "set", nextGoal, source }, ctx);
     },
     completeGoal,
   });
@@ -495,23 +526,15 @@ export default function (pi: ExtensionAPI): void {
     getGoal: () => goalForDisplay(),
     getGoalStartTurnStrategy: () => goalStartTurnStrategy(recoveryState.phase),
     setGoal(nextGoal, source, ctx) {
-      const wasPaused = goal?.status === "paused";
-      persistGoal(nextGoal, source);
-      if (source === "command") {
-        if (nextGoal.status === "active") {
-          if (wasPaused) {
-            resetErrorRecovery();
-          }
-          continuationQueuedFor = nextGoal.goalId;
-        } else if (nextGoal.status === "paused") {
-          resetErrorRecovery();
-        }
-      }
-      refreshUi(ctx);
+      applyGoalTransition({
+        kind: "set",
+        nextGoal,
+        source,
+        wasPausedBefore: goal?.status === "paused",
+      }, ctx);
     },
     clearGoal(source, ctx) {
-      persistClear(source);
-      refreshUi(ctx);
+      applyGoalTransition({ kind: "clear", source }, ctx);
     },
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { compactContinuationPrompt, continuationGoalIdFromPrompt } from "./promp
 import { isCommandResumeQueuedGoalMessage } from "./queued-goal-messages.js";
 import {
   applyGoalMemoryEffects,
+  applyGoalTransitionPostPersistEffects,
   planGoalTransition,
   planMemoryEffectsOnGoalChange,
   type GoalTransitionRequest,
@@ -251,6 +252,9 @@ export default function (pi: ExtensionAPI): void {
     if (plan.resetRecoveryBeforePersist) {
       resetErrorRecovery();
     }
+    if (plan.resetStoppedRuntimeBeforePersist) {
+      clearStoppedRuntimeState();
+    }
     if (plan.clearContinuationBeforePersist) {
       clearContinuationState();
     }
@@ -278,6 +282,15 @@ export default function (pi: ExtensionAPI): void {
     }
 
     if (plan.persist === "skip") {
+      applyGoalTransitionPostPersistEffects(plan, {
+        resetRecoveryAfterPersist: resetErrorRecovery,
+        markContinuationQueued: (goalId) => {
+          continuationQueuedFor = goalId;
+        },
+      });
+      if (plan.refreshUi && ctx) {
+        refreshUi(ctx);
+      }
       return false;
     }
 
@@ -285,12 +298,12 @@ export default function (pi: ExtensionAPI): void {
     goal = plan.nextGoal;
     const persisted = flushGoalPersistence(plan.source);
 
-    if (plan.resetRecoveryAfterPersist) {
-      resetErrorRecovery();
-    }
-    if (plan.markContinuationQueued && plan.nextGoal) {
-      continuationQueuedFor = plan.nextGoal.goalId;
-    }
+    applyGoalTransitionPostPersistEffects(plan, {
+      resetRecoveryAfterPersist: resetErrorRecovery,
+      markContinuationQueued: (goalId) => {
+        continuationQueuedFor = goalId;
+      },
+    });
     if (plan.refreshUi && ctx) {
       refreshUi(ctx);
     }

--- a/src/recovery-runtime.ts
+++ b/src/recovery-runtime.ts
@@ -8,7 +8,6 @@ import {
   planRecoveryForAssistantError,
   planRecoveryForSilentContextOverflow,
   requireHostOverflowUserReset,
-  setRecoveryPausedAttention,
   setRecoveryPendingAttention,
   type GoalRecoveryMachineState,
   type RecoveryAction,
@@ -20,7 +19,11 @@ interface RecoveryRuntimeDeps {
   getGoal: () => ThreadGoal | null;
   getRecoveryState: () => GoalRecoveryMachineState;
   clearContinuationState: () => void;
-  pauseGoalForRecovery: (ctx: ExtensionContext, pausedGoal: ThreadGoal) => void;
+  pauseGoalForRecovery: (
+    ctx: ExtensionContext,
+    pausedGoal: ThreadGoal,
+    recoveryReason: string,
+  ) => void;
   refreshUi: (ctx: ExtensionContext) => void;
   maybeContinue: (ctx: ExtensionContext) => void;
 }
@@ -32,10 +35,7 @@ export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
       return;
     }
 
-    deps.clearContinuationState();
-    deps.pauseGoalForRecovery(ctx, goal);
-    setRecoveryPausedAttention(deps.getRecoveryState(), reason);
-    deps.refreshUi(ctx);
+    deps.pauseGoalForRecovery(ctx, goal, reason);
   };
 
   const applyRecoveryAction = (action: RecoveryAction, ctx: ExtensionContext): void => {

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mock, test } from "node:test";
 
 import { formatFooterStatus } from "../src/format.js";
-import { isGoalCustomEntry } from "../src/state.js";
+import { isGoalCustomEntry, setEntry } from "../src/state.js";
 import { CUSTOM_ENTRY_TYPE } from "../src/types.js";
 import {
   assistantMessage,
@@ -57,6 +57,36 @@ test("a new user-driven agent start leaves a paused goal paused", async () => {
 
   assert.equal(harness.snapshot().goal?.status, "paused");
   assert.equal(harness.snapshot().goal?.usage.tokensUsed, 10);
+});
+
+test("session resume over-budget paused goal stays budgetLimited without follow-up turn", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runTool("create_goal", { objective: "ship it", token_budget: 10 });
+  await harness.runCommand("pause");
+  const paused = harness.snapshot().goal;
+  assert.ok(paused);
+  assert.equal(paused.status, "paused");
+
+  harness.entries.push({
+    type: "custom",
+    id: "entry-over-budget-paused",
+    parentId: null,
+    timestamp: new Date(0).toISOString(),
+    customType: CUSTOM_ENTRY_TYPE,
+    data: setEntry(
+      {
+        ...paused,
+        usage: { tokensUsed: 10, activeSeconds: paused.usage.activeSeconds },
+      },
+      "runtime",
+    ),
+  });
+  harness.sentUserMessages.length = 0;
+
+  await harness.emit("session_start", { type: "session_start", reason: "resume" });
+
+  assert.equal(harness.snapshot().goal?.status, "budgetLimited");
+  assert.equal(harness.sentUserMessages.length, 0);
 });
 
 test("session resume prompt can reactivate a paused goal", async () => {

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -7,7 +7,7 @@ import {
   type GoalTransitionEffect,
   type GoalTransitionPlan,
 } from "../src/goal-transition.js";
-import type { ThreadGoal } from "../src/types.js";
+import type { GoalStatus, ThreadGoal } from "../src/types.js";
 import { cloneGoal, createThreadGoal } from "../src/state.js";
 
 function effectTypes(effects: readonly GoalTransitionEffect[]): string[] {
@@ -397,19 +397,14 @@ test("planGoalTransition command skip applies post-persist effects only", () => 
   assert.deepEqual(effectTypes(plan.afterPersist), ["resetRecovery"]);
 });
 
-test("planGoalTransition abort pause clears primitives before persist when persistence skips", () => {
+test("planGoalTransition abort pause rejects invalid paused-to-paused shape", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
-  const plan = planGoalTransition(paused, { kind: "abort_pause", nextGoal: paused });
 
-  assertDisjointPrimitivePlan(plan, "abort pause skip");
-  assert.equal(plan.persist, "skip");
-  assert.deepEqual(effectTypes(plan.beforePersist), [
-    "clearContinuation",
-    "clearActiveAccounting",
-    "resetRecovery",
-  ]);
-  assert.deepEqual(plan.afterPersist, []);
+  assert.throws(
+    () => planGoalTransition(paused, { kind: "abort_pause", nextGoal: paused }),
+    /Invalid abort_pause transition: current status must be active/,
+  );
 });
 
 test("planGoalTransition runtime accounting defers persistence for active usage updates", () => {
@@ -465,4 +460,161 @@ test("planGoalTransition skip plans have empty beforePersist when unchanged", ()
   assert.equal(plan.persist, "skip");
   assert.deepEqual(plan.beforePersist, []);
   assert.deepEqual(plan.afterPersist, []);
+});
+
+const ALL_STATUSES: GoalStatus[] = ["active", "paused", "budgetLimited", "complete"];
+
+function goalAtStatus(base: ThreadGoal, status: GoalStatus): ThreadGoal {
+  return { ...cloneGoal(base), status };
+}
+
+function statusSpecificRequest(
+  kind:
+    | "abort_pause"
+    | "resume_active"
+    | "recovery_pause"
+    | "recovery_shutdown_pause"
+    | "runtime_accounting",
+  nextGoal: ThreadGoal,
+):
+  | { kind: "abort_pause"; nextGoal: ThreadGoal }
+  | { kind: "resume_active"; nextGoal: ThreadGoal }
+  | { kind: "recovery_pause"; nextGoal: ThreadGoal; recoveryReason: string }
+  | { kind: "recovery_shutdown_pause"; nextGoal: ThreadGoal; recoveryReason: string }
+  | { kind: "runtime_accounting"; nextGoal: ThreadGoal } {
+  switch (kind) {
+    case "abort_pause":
+      return { kind, nextGoal };
+    case "resume_active":
+      return { kind, nextGoal };
+    case "recovery_pause":
+      return { kind, nextGoal, recoveryReason: "context_length_exceeded" };
+    case "recovery_shutdown_pause":
+      return { kind, nextGoal, recoveryReason: "shutdown" };
+    case "runtime_accounting":
+      return { kind, nextGoal };
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`Unhandled status-specific kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+function isValidStatusSpecificTransition(
+  kind:
+    | "abort_pause"
+    | "resume_active"
+    | "recovery_pause"
+    | "recovery_shutdown_pause"
+    | "runtime_accounting",
+  currentStatus: GoalStatus | null,
+  nextStatus: GoalStatus,
+  sameGoalId: boolean,
+): boolean {
+  if (currentStatus === null || !sameGoalId) {
+    return false;
+  }
+  switch (kind) {
+    case "abort_pause":
+    case "recovery_pause":
+    case "recovery_shutdown_pause":
+      return currentStatus === "active" && nextStatus === "paused";
+    case "resume_active":
+      return currentStatus === "paused" && nextStatus === "active";
+    case "runtime_accounting":
+      return (
+        (currentStatus === "active" || currentStatus === "budgetLimited") &&
+        (nextStatus === "active" || nextStatus === "budgetLimited")
+      );
+    default: {
+      const _exhaustive: never = kind;
+      throw new Error(`Unhandled status-specific kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+const STATUS_SPECIFIC_VARIANTS = [
+  "abort_pause",
+  "resume_active",
+  "recovery_pause",
+  "recovery_shutdown_pause",
+  "runtime_accounting",
+] as const;
+
+for (const kind of STATUS_SPECIFIC_VARIANTS) {
+  for (const currentStatus of ALL_STATUSES) {
+    for (const nextStatus of ALL_STATUSES) {
+      const valid = isValidStatusSpecificTransition(kind, currentStatus, nextStatus, true);
+      test(
+        `planGoalTransition ${kind} status matrix ${currentStatus}->${nextStatus} ${
+          valid ? "plans" : "rejects"
+        }`,
+        () => {
+          const base = createThreadGoal("ship it", kind === "runtime_accounting" ? 10 : undefined);
+          const current = goalAtStatus(base, currentStatus);
+          const next = goalAtStatus(base, nextStatus);
+          const request = statusSpecificRequest(kind, next);
+
+          if (!valid) {
+            assert.throws(() => planGoalTransition(current, request), new RegExp(`Invalid ${kind} transition:`));
+            return;
+          }
+
+          const plan = planGoalTransition(current, request);
+          assertDisjointPrimitivePlan(plan, `${kind} ${currentStatus}->${nextStatus}`);
+        },
+      );
+    }
+  }
+
+  test(`planGoalTransition ${kind} rejects null current`, () => {
+    const next = createThreadGoal("ship it");
+    const request = statusSpecificRequest(kind, next);
+    assert.throws(
+      () => planGoalTransition(null, request),
+      new RegExp(`Invalid ${kind} transition: current goal is required`),
+    );
+  });
+
+  test(`planGoalTransition ${kind} rejects different goal id`, () => {
+    const currentBase = createThreadGoal("current objective");
+    const nextBase = createThreadGoal("next objective");
+    const shape =
+      kind === "resume_active"
+        ? { current: "paused" as const, next: "active" as const }
+        : kind === "runtime_accounting"
+          ? { current: "active" as const, next: "active" as const }
+          : { current: "active" as const, next: "paused" as const };
+    const current = goalAtStatus(currentBase, shape.current);
+    const next = goalAtStatus(nextBase, shape.next);
+
+    assert.throws(
+      () => planGoalTransition(current, statusSpecificRequest(kind, next)),
+      new RegExp(`Invalid ${kind} transition: goalId mismatch`),
+    );
+  });
+}
+
+test("planGoalTransition runtime accounting rejects complete next goal", () => {
+  const goal = createThreadGoal("ship it");
+  const complete = { ...cloneGoal(goal), status: "complete" as const };
+
+  assert.throws(
+    () =>
+      planGoalTransition(goal, {
+        kind: "runtime_accounting",
+        nextGoal: complete,
+      }),
+    /Invalid runtime_accounting transition: next status must be active or budgetLimited/,
+  );
+});
+
+test("planGoalTransition resume_active rejects unchanged paused shape", () => {
+  const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+
+  assert.throws(
+    () => planGoalTransition(paused, { kind: "resume_active", nextGoal: paused }),
+    /Invalid resume_active transition: next status must be active/,
+  );
 });

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -9,21 +9,22 @@ import {
 } from "../src/goal-transition.js";
 import { cloneGoal, createThreadGoal } from "../src/state.js";
 
-test("planMemoryEffectsOnGoalChange clears stopped runtime when goal id changes", () => {
+test("planMemoryEffectsOnGoalChange clears stopped runtime primitives when goal id changes", () => {
   const previous = createThreadGoal("first");
   const next = createThreadGoal("second");
 
   const plan = planMemoryEffectsOnGoalChange(previous, next);
-  assert.equal(plan.resetStoppedRuntime, true);
+  assert.equal(plan.clearContinuation, true);
+  assert.equal(plan.clearActiveAccounting, true);
+  assert.equal(plan.resetRecovery, true);
   assert.equal(plan.clearBudgetWarning, true);
 });
 
-test("planMemoryEffectsOnGoalChange pauses clear continuation and accounting without full reset", () => {
+test("planMemoryEffectsOnGoalChange pauses clear continuation and accounting without recovery reset", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
 
   const plan = planMemoryEffectsOnGoalChange(goal, paused);
-  assert.equal(plan.resetStoppedRuntime, false);
   assert.equal(plan.clearContinuation, true);
   assert.equal(plan.clearActiveAccounting, true);
   assert.equal(plan.resetRecovery, false);
@@ -45,25 +46,30 @@ test("planGoalTransition command set marks continuation and defers recovery rese
   assert.equal(plan.resetRecoveryBeforePersist, false);
 });
 
-test("planGoalTransition abort pause resets stopped runtime before paused memory effects", () => {
+test("planGoalTransition abort pause clears stopped runtime primitives before paused memory effects", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
 
   const plan = planGoalTransition(goal, { kind: "abort_pause", nextGoal: paused });
   assert.equal(plan.persist, "set");
-  assert.equal(plan.memory.resetStoppedRuntime, true);
+  assert.equal(plan.clearContinuationBeforePersist, true);
+  assert.equal(plan.clearActiveAccountingBeforePersist, true);
+  assert.equal(plan.resetRecoveryBeforePersist, true);
+  assert.equal(plan.memory.clearContinuation, true);
+  assert.equal(plan.memory.resetRecovery, true);
 });
 
-test("planGoalTransition clear stops status refresh and persists clear", () => {
+test("planGoalTransition clear persists clear with full memory reset", () => {
   const goal = createThreadGoal("ship it");
   const plan = planGoalTransition(goal, { kind: "clear", source: "command" });
 
   assert.equal(plan.persist, "clear");
-  assert.equal(plan.stopStatusRefresh, true);
   assert.equal(plan.nextGoal, null);
+  assert.equal(plan.memory.clearContinuation, true);
+  assert.equal(plan.memory.resetRecovery, true);
 });
 
-test("planGoalTransition recovery pause owns continuation clear, reason, and refresh", () => {
+test("planGoalTransition recovery pause owns continuation clear and reason", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
   const plan = planGoalTransition(goal, {
@@ -75,7 +81,6 @@ test("planGoalTransition recovery pause owns continuation clear, reason, and ref
   assert.equal(plan.persist, "set");
   assert.equal(plan.clearContinuationBeforePersist, true);
   assert.equal(plan.recoveryPausedReason, "context_length_exceeded");
-  assert.equal(plan.refreshUi, true);
   assert.equal(plan.memory.clearContinuation, true);
 });
 
@@ -97,16 +102,12 @@ test("applyGoalMemoryEffects invokes every handler when all flags are true", () 
   const calls: string[] = [];
   applyGoalMemoryEffects(
     {
-      resetStoppedRuntime: true,
       clearContinuation: true,
       clearActiveAccounting: true,
       resetRecovery: true,
       clearBudgetWarning: true,
     },
     {
-      resetStoppedRuntime: () => {
-        calls.push("resetStoppedRuntime");
-      },
       clearContinuation: () => {
         calls.push("clearContinuation");
       },
@@ -123,7 +124,6 @@ test("applyGoalMemoryEffects invokes every handler when all flags are true", () 
   );
 
   assert.deepEqual(calls, [
-    "resetStoppedRuntime",
     "clearContinuation",
     "clearActiveAccounting",
     "resetRecovery",
@@ -158,12 +158,64 @@ test("applyGoalTransitionPostPersistEffects applies skip-plan command side effec
   ]);
 });
 
-test("planGoalTransition abort pause clears stopped runtime before persist when persistence skips", () => {
+test("planGoalTransition abort pause clears stopped runtime primitives before persist when persistence skips", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
   const plan = planGoalTransition(paused, { kind: "abort_pause", nextGoal: paused });
 
   assert.equal(plan.persist, "skip");
   assert.equal("memory" in plan, false);
-  assert.equal(plan.resetStoppedRuntimeBeforePersist, true);
+  assert.equal(plan.clearContinuationBeforePersist, true);
+  assert.equal(plan.clearActiveAccountingBeforePersist, true);
+  assert.equal(plan.resetRecoveryBeforePersist, true);
+});
+
+test("planGoalTransition runtime accounting defers persistence for ordinary usage updates", () => {
+  const goal = createThreadGoal("ship it");
+  const next = {
+    ...cloneGoal(goal),
+    usage: { tokensUsed: 5, activeSeconds: 3 },
+    updatedAt: goal.updatedAt + 1,
+  };
+
+  const plan = planGoalTransition(goal, {
+    kind: "runtime_accounting",
+    nextGoal: next,
+    crossedBudget: false,
+  });
+
+  assert.equal(plan.persist, "defer");
+  assert.equal(plan.memory.clearBudgetWarning, true);
+});
+
+test("planGoalTransition runtime accounting persists immediately when budget is crossed", () => {
+  const goal = createThreadGoal("ship it", 10);
+  const limited = {
+    ...cloneGoal(goal),
+    status: "budgetLimited" as const,
+    usage: { tokensUsed: 10, activeSeconds: 1 },
+    updatedAt: goal.updatedAt + 1,
+  };
+
+  const plan = planGoalTransition(goal, {
+    kind: "runtime_accounting",
+    nextGoal: limited,
+    crossedBudget: true,
+  });
+
+  assert.equal(plan.persist, "set");
+  assert.equal(plan.memory.clearContinuation, true);
+  assert.equal(plan.memory.resetRecovery, true);
+});
+
+test("planGoalTransition skip plans cannot carry memory", () => {
+  const goal = createThreadGoal("ship it");
+  const plan = planGoalTransition(goal, {
+    kind: "runtime_accounting",
+    nextGoal: goal,
+    crossedBudget: false,
+  });
+
+  assert.equal(plan.persist, "skip");
+  assert.equal("memory" in plan, false);
 });

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -4,10 +4,10 @@ import { test } from "node:test";
 import {
   applyGoalTransitionEffects,
   planGoalTransition,
-  planMemoryEffectsOnGoalChange,
   type GoalTransitionEffect,
   type GoalTransitionPlan,
 } from "../src/goal-transition.js";
+import type { ThreadGoal } from "../src/types.js";
 import { cloneGoal, createThreadGoal } from "../src/state.js";
 
 function effectTypes(effects: readonly GoalTransitionEffect[]): string[] {
@@ -36,25 +36,160 @@ function assertDisjointPrimitivePlan(plan: GoalTransitionPlan, label: string): v
   assertNoDuplicateEffectTypes(combined, `${label} combined`);
 }
 
-test("planMemoryEffectsOnGoalChange clears stopped runtime primitives when goal id changes", () => {
+type CommandSetTableCase = {
+  label: string;
+  build: () => { current: ThreadGoal; next: ThreadGoal };
+  persist: GoalTransitionPlan["persist"];
+  before: string[];
+  after: string[];
+};
+
+const commandSetTable: CommandSetTableCase[] = [
+  {
+    label: "active skip unchanged",
+    build: () => {
+      const goal = createThreadGoal("ship it");
+      return { current: goal, next: goal };
+    },
+    persist: "skip",
+    before: [],
+    after: ["markContinuationQueued"],
+  },
+  {
+    label: "paused skip unchanged",
+    build: () => {
+      const goal = createThreadGoal("ship it");
+      const paused = { ...cloneGoal(goal), status: "paused" as const };
+      return { current: paused, next: paused };
+    },
+    persist: "skip",
+    before: [],
+    after: ["resetRecovery"],
+  },
+  {
+    label: "active to same paused",
+    build: () => {
+      const goal = createThreadGoal("ship it");
+      const paused = { ...cloneGoal(goal), status: "paused" as const };
+      return { current: goal, next: paused };
+    },
+    persist: "set",
+    before: ["clearContinuation", "clearActiveAccounting", "clearBudgetWarning"],
+    after: ["resetRecovery"],
+  },
+  {
+    label: "active to different paused",
+    build: () => {
+      const current = createThreadGoal("old objective");
+      const next = { ...createThreadGoal("new objective"), status: "paused" as const };
+      return { current, next };
+    },
+    persist: "set",
+    before: [
+      "clearContinuation",
+      "clearActiveAccounting",
+      "resetRecovery",
+      "clearBudgetWarning",
+    ],
+    after: [],
+  },
+  {
+    label: "paused to same active",
+    build: () => {
+      const goal = createThreadGoal("ship it");
+      const paused = { ...cloneGoal(goal), status: "paused" as const };
+      const active = { ...cloneGoal(goal), status: "active" as const };
+      return { current: paused, next: active };
+    },
+    persist: "set",
+    before: ["clearBudgetWarning"],
+    after: ["markContinuationQueued", "resetRecovery"],
+  },
+  {
+    label: "paused to different active",
+    build: () => {
+      const paused = { ...createThreadGoal("old objective"), status: "paused" as const };
+      const next = createThreadGoal("new objective");
+      return { current: paused, next };
+    },
+    persist: "set",
+    before: [
+      "clearContinuation",
+      "clearActiveAccounting",
+      "resetRecovery",
+      "clearBudgetWarning",
+    ],
+    after: ["markContinuationQueued"],
+  },
+  {
+    label: "active to different active",
+    build: () => {
+      const current = createThreadGoal("old objective");
+      const next = createThreadGoal("new objective");
+      return { current, next };
+    },
+    persist: "set",
+    before: [
+      "clearContinuation",
+      "clearActiveAccounting",
+      "resetRecovery",
+      "clearBudgetWarning",
+    ],
+    after: ["markContinuationQueued"],
+  },
+  {
+    label: "paused to different paused",
+    build: () => {
+      const current = { ...createThreadGoal("old objective"), status: "paused" as const };
+      const next = { ...createThreadGoal("new objective"), status: "paused" as const };
+      return { current, next };
+    },
+    persist: "set",
+    before: [
+      "clearContinuation",
+      "clearActiveAccounting",
+      "resetRecovery",
+      "clearBudgetWarning",
+    ],
+    after: [],
+  },
+];
+
+for (const tableCase of commandSetTable) {
+  test(`planGoalTransition command set table: ${tableCase.label}`, () => {
+    const { current, next } = tableCase.build();
+    const plan = planGoalTransition(current, {
+      kind: "set",
+      nextGoal: next,
+      source: "command",
+    });
+
+    assertDisjointPrimitivePlan(plan, tableCase.label);
+    assert.equal(plan.persist, tableCase.persist);
+    assert.deepEqual(effectTypes(plan.beforePersist), tableCase.before);
+    assert.deepEqual(effectTypes(plan.afterPersist), tableCase.after);
+  });
+}
+
+test("planGoalTransition command set with goal id change clears runtime memory before persist", () => {
   const previous = createThreadGoal("first");
   const next = createThreadGoal("second");
 
-  const plan = planMemoryEffectsOnGoalChange(previous, next);
-  assert.equal(plan.clearContinuation, true);
-  assert.equal(plan.clearActiveAccounting, true);
-  assert.equal(plan.resetRecovery, true);
-  assert.equal(plan.clearBudgetWarning, true);
-});
+  const plan = planGoalTransition(previous, {
+    kind: "set",
+    nextGoal: next,
+    source: "command",
+  });
 
-test("planMemoryEffectsOnGoalChange pauses clear continuation and accounting without recovery reset", () => {
-  const goal = createThreadGoal("ship it");
-  const paused = { ...cloneGoal(goal), status: "paused" as const };
-
-  const plan = planMemoryEffectsOnGoalChange(goal, paused);
-  assert.equal(plan.clearContinuation, true);
-  assert.equal(plan.clearActiveAccounting, true);
-  assert.equal(plan.resetRecovery, false);
+  assertDisjointPrimitivePlan(plan, "command goal id change");
+  assert.equal(plan.persist, "set");
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearActiveAccounting",
+    "resetRecovery",
+    "clearBudgetWarning",
+  ]);
+  assert.deepEqual(effectTypes(plan.afterPersist), ["markContinuationQueued"]);
 });
 
 test("planGoalTransition command set replacing paused goal resets recovery only before persist", () => {

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -468,6 +468,45 @@ function goalAtStatus(base: ThreadGoal, status: GoalStatus): ThreadGoal {
   return { ...cloneGoal(base), status };
 }
 
+function runtimeAccountingMatrixNext(current: ThreadGoal, nextStatus: GoalStatus): ThreadGoal {
+  if (nextStatus === "active") {
+    const next = cloneGoal(current);
+    next.status = "active";
+    next.updatedAt = current.updatedAt + 1;
+    if (next.usage.tokensUsed <= current.usage.tokensUsed) {
+      next.usage = {
+        tokensUsed: current.usage.tokensUsed + 1,
+        activeSeconds: current.usage.activeSeconds,
+      };
+    }
+    return next;
+  }
+
+  const budget = current.tokenBudget ?? 10;
+  return {
+    ...cloneGoal(current),
+    status: "budgetLimited",
+    usage: {
+      tokensUsed: Math.max(current.usage.tokensUsed + 1, budget),
+      activeSeconds: current.usage.activeSeconds,
+    },
+    updatedAt: current.updatedAt + 1,
+  };
+}
+
+function statusSpecificMatrixNext(
+  base: ThreadGoal,
+  kind: (typeof STATUS_SPECIFIC_VARIANTS)[number],
+  currentStatus: GoalStatus,
+  nextStatus: GoalStatus,
+): ThreadGoal {
+  const current = goalAtStatus(base, currentStatus);
+  if (kind === "runtime_accounting") {
+    return runtimeAccountingMatrixNext(current, nextStatus);
+  }
+  return goalAtStatus(base, nextStatus);
+}
+
 function statusSpecificRequest(
   kind:
     | "abort_pause"
@@ -522,6 +561,15 @@ function isValidStatusSpecificTransition(
     case "resume_active":
       return currentStatus === "paused" && nextStatus === "active";
     case "runtime_accounting":
+      if (currentStatus === "paused" || currentStatus === "complete") {
+        return false;
+      }
+      if (nextStatus === "paused" || nextStatus === "complete") {
+        return false;
+      }
+      if (currentStatus === "budgetLimited" && nextStatus === "active") {
+        return false;
+      }
       return (
         (currentStatus === "active" || currentStatus === "budgetLimited") &&
         (nextStatus === "active" || nextStatus === "budgetLimited")
@@ -552,7 +600,10 @@ for (const kind of STATUS_SPECIFIC_VARIANTS) {
         () => {
           const base = createThreadGoal("ship it", kind === "runtime_accounting" ? 10 : undefined);
           const current = goalAtStatus(base, currentStatus);
-          const next = goalAtStatus(base, nextStatus);
+          const next =
+            valid && kind === "runtime_accounting"
+              ? statusSpecificMatrixNext(base, kind, currentStatus, nextStatus)
+              : goalAtStatus(base, nextStatus);
           const request = statusSpecificRequest(kind, next);
 
           if (!valid) {
@@ -616,5 +667,173 @@ test("planGoalTransition resume_active rejects unchanged paused shape", () => {
   assert.throws(
     () => planGoalTransition(paused, { kind: "resume_active", nextGoal: paused }),
     /Invalid resume_active transition: next status must be active/,
+  );
+});
+
+const STATUS_HELPER_PAUSE_KINDS = [
+  "abort_pause",
+  "recovery_pause",
+  "recovery_shutdown_pause",
+] as const;
+
+function legalActiveToPausedNext(current: ThreadGoal): ThreadGoal {
+  return { ...cloneGoal(current), status: "paused", updatedAt: current.updatedAt + 1 };
+}
+
+function legalPausedToActiveNext(current: ThreadGoal): ThreadGoal {
+  return { ...cloneGoal(current), status: "active", updatedAt: current.updatedAt + 1 };
+}
+
+function legalRuntimeAccountingNext(current: ThreadGoal): ThreadGoal {
+  return {
+    ...cloneGoal(current),
+    usage: {
+      tokensUsed: current.usage.tokensUsed + 1,
+      activeSeconds: current.usage.activeSeconds,
+    },
+    updatedAt: current.updatedAt + 1,
+  };
+}
+
+for (const kind of STATUS_HELPER_PAUSE_KINDS) {
+  for (const field of ["objective", "tokenBudget", "usage", "createdAt"] as const) {
+    test(`planGoalTransition ${kind} rejects malformed same-id ${field} mutation`, () => {
+      const current = createThreadGoal("ship it", 10);
+      const next = legalActiveToPausedNext(current);
+      switch (field) {
+        case "objective":
+          next.objective = "mutated objective";
+          break;
+        case "tokenBudget":
+          next.tokenBudget = 99;
+          break;
+        case "usage":
+          next.usage = { tokensUsed: 99, activeSeconds: 99 };
+          break;
+        case "createdAt":
+          next.createdAt = current.createdAt + 1;
+          break;
+        default: {
+          const _exhaustive: never = field;
+          throw new Error(`Unhandled field: ${String(_exhaustive)}`);
+        }
+      }
+
+      assert.throws(
+        () => planGoalTransition(current, statusSpecificRequest(kind, next)),
+        new RegExp(`Invalid ${kind} transition:`),
+      );
+    });
+  }
+}
+
+for (const field of ["objective", "tokenBudget", "usage", "createdAt"] as const) {
+  test(`planGoalTransition resume_active rejects malformed same-id ${field} mutation`, () => {
+    const current = { ...createThreadGoal("ship it", 10), status: "paused" as const };
+    const next = legalPausedToActiveNext(current);
+    switch (field) {
+      case "objective":
+        next.objective = "mutated objective";
+        break;
+      case "tokenBudget":
+        next.tokenBudget = 99;
+        break;
+      case "usage":
+        next.usage = { tokensUsed: 99, activeSeconds: 99 };
+        break;
+      case "createdAt":
+        next.createdAt = current.createdAt + 1;
+        break;
+      default: {
+        const _exhaustive: never = field;
+        throw new Error(`Unhandled field: ${String(_exhaustive)}`);
+      }
+    }
+
+    assert.throws(
+      () => planGoalTransition(current, { kind: "resume_active", nextGoal: next }),
+      /Invalid resume_active transition:/,
+    );
+  });
+}
+
+for (const field of ["objective", "tokenBudget", "createdAt"] as const) {
+  test(`planGoalTransition runtime_accounting rejects malformed same-id ${field} mutation`, () => {
+    const current = createThreadGoal("ship it", 10);
+    const next = legalRuntimeAccountingNext(current);
+    switch (field) {
+      case "objective":
+        next.objective = "mutated objective";
+        break;
+      case "tokenBudget":
+        next.tokenBudget = 99;
+        break;
+      case "createdAt":
+        next.createdAt = current.createdAt + 1;
+        break;
+      default: {
+        const _exhaustive: never = field;
+        throw new Error(`Unhandled field: ${String(_exhaustive)}`);
+      }
+    }
+
+    assert.throws(
+      () =>
+        planGoalTransition(current, {
+          kind: "runtime_accounting",
+          nextGoal: next,
+        }),
+      /Invalid runtime_accounting transition:/,
+    );
+  });
+}
+
+test("planGoalTransition runtime_accounting rejects usage decrease", () => {
+  const current = {
+    ...createThreadGoal("ship it", 10),
+    usage: { tokensUsed: 5, activeSeconds: 2 },
+  };
+  const next = {
+    ...cloneGoal(current),
+    usage: { tokensUsed: 4, activeSeconds: 2 },
+    updatedAt: current.updatedAt + 1,
+  };
+
+  assert.throws(
+    () => planGoalTransition(current, { kind: "runtime_accounting", nextGoal: next }),
+    /Invalid runtime_accounting transition: usage\.tokensUsed must not decrease/,
+  );
+});
+
+test("planGoalTransition runtime_accounting rejects under-budget budgetLimited next", () => {
+  const current = createThreadGoal("ship it", 10);
+  const next = {
+    ...cloneGoal(current),
+    status: "budgetLimited" as const,
+    usage: { tokensUsed: 5, activeSeconds: 0 },
+    updatedAt: current.updatedAt + 1,
+  };
+
+  assert.throws(
+    () => planGoalTransition(current, { kind: "runtime_accounting", nextGoal: next }),
+    /Invalid runtime_accounting transition: usage\.tokensUsed must be at or above tokenBudget/,
+  );
+});
+
+test("planGoalTransition runtime_accounting rejects budgetLimited to active", () => {
+  const current = {
+    ...createThreadGoal("ship it", 10),
+    status: "budgetLimited" as const,
+    usage: { tokensUsed: 10, activeSeconds: 0 },
+  };
+  const next = {
+    ...cloneGoal(current),
+    status: "active" as const,
+    updatedAt: current.updatedAt + 1,
+  };
+
+  assert.throws(
+    () => planGoalTransition(current, { kind: "runtime_accounting", nextGoal: next }),
+    /Invalid runtime_accounting transition: budgetLimited goals cannot transition to active/,
   );
 });

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  applyGoalMemoryEffects,
+  applyGoalTransitionPostPersistEffects,
   planGoalTransition,
   planMemoryEffectsOnGoalChange,
 } from "../src/goal-transition.js";
@@ -61,4 +63,79 @@ test("planGoalTransition clear stops status refresh and persists clear", () => {
   assert.equal(plan.persist, "clear");
   assert.equal(plan.stopStatusRefresh, true);
   assert.equal(plan.nextGoal, null);
+});
+
+test("applyGoalMemoryEffects invokes every handler when all flags are true", () => {
+  const calls: string[] = [];
+  applyGoalMemoryEffects(
+    {
+      resetStoppedRuntime: true,
+      clearContinuation: true,
+      clearActiveAccounting: true,
+      resetRecovery: true,
+      clearBudgetWarning: true,
+    },
+    {
+      resetStoppedRuntime: () => {
+        calls.push("resetStoppedRuntime");
+      },
+      clearContinuation: () => {
+        calls.push("clearContinuation");
+      },
+      clearActiveAccounting: () => {
+        calls.push("clearActiveAccounting");
+      },
+      resetRecovery: () => {
+        calls.push("resetRecovery");
+      },
+      clearBudgetWarning: () => {
+        calls.push("clearBudgetWarning");
+      },
+    },
+  );
+
+  assert.deepEqual(calls, [
+    "resetStoppedRuntime",
+    "clearContinuation",
+    "clearActiveAccounting",
+    "resetRecovery",
+    "clearBudgetWarning",
+  ]);
+});
+
+test("applyGoalTransitionPostPersistEffects applies skip-plan command side effects", () => {
+  const goal = createThreadGoal("ship it");
+  const plan = planGoalTransition(goal, {
+    kind: "set",
+    nextGoal: goal,
+    source: "command",
+    wasPausedBefore: true,
+  });
+  assert.ok(plan);
+  assert.equal(plan.persist, "skip");
+
+  const calls: string[] = [];
+  applyGoalTransitionPostPersistEffects(plan, {
+    resetRecoveryAfterPersist: () => {
+      calls.push("resetRecoveryAfterPersist");
+    },
+    markContinuationQueued: (goalId) => {
+      calls.push(`markContinuationQueued:${goalId}`);
+    },
+  });
+
+  assert.deepEqual(calls, [
+    "resetRecoveryAfterPersist",
+    `markContinuationQueued:${goal.goalId}`,
+  ]);
+});
+
+test("planGoalTransition abort pause clears stopped runtime before persist when persistence skips", () => {
+  const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+  const plan = planGoalTransition(paused, { kind: "abort_pause", nextGoal: paused });
+
+  assert.ok(plan);
+  assert.equal(plan.persist, "skip");
+  assert.equal(plan.resetStoppedRuntimeBeforePersist, true);
 });

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -38,8 +38,8 @@ test("planGoalTransition command set marks continuation and defers recovery rese
     wasPausedBefore: true,
   });
 
-  assert.ok(plan);
   assert.equal(plan.persist, "skip");
+  assert.equal("memory" in plan, false);
   assert.equal(plan.markContinuationQueued, true);
   assert.equal(plan.resetRecoveryAfterPersist, true);
   assert.equal(plan.resetRecoveryBeforePersist, false);
@@ -50,19 +50,47 @@ test("planGoalTransition abort pause resets stopped runtime before paused memory
   const paused = { ...cloneGoal(goal), status: "paused" as const };
 
   const plan = planGoalTransition(goal, { kind: "abort_pause", nextGoal: paused });
-  assert.ok(plan);
-  assert.equal(plan.memory.resetStoppedRuntime, true);
   assert.equal(plan.persist, "set");
+  assert.equal(plan.memory.resetStoppedRuntime, true);
 });
 
 test("planGoalTransition clear stops status refresh and persists clear", () => {
   const goal = createThreadGoal("ship it");
   const plan = planGoalTransition(goal, { kind: "clear", source: "command" });
 
-  assert.ok(plan);
   assert.equal(plan.persist, "clear");
   assert.equal(plan.stopStatusRefresh, true);
   assert.equal(plan.nextGoal, null);
+});
+
+test("planGoalTransition recovery pause owns continuation clear, reason, and refresh", () => {
+  const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+  const plan = planGoalTransition(goal, {
+    kind: "recovery_pause",
+    nextGoal: paused,
+    recoveryReason: "context_length_exceeded",
+  });
+
+  assert.equal(plan.persist, "set");
+  assert.equal(plan.clearContinuationBeforePersist, true);
+  assert.equal(plan.recoveryPausedReason, "context_length_exceeded");
+  assert.equal(plan.refreshUi, true);
+  assert.equal(plan.memory.clearContinuation, true);
+});
+
+test("planGoalTransition recovery shutdown pause clears host overflow recovery", () => {
+  const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+  const plan = planGoalTransition(goal, {
+    kind: "recovery_shutdown_pause",
+    nextGoal: paused,
+    recoveryReason: "shutdown",
+  });
+
+  assert.equal(plan.persist, "set");
+  assert.equal(plan.clearHostOverflowRecovery, true);
+  assert.equal(plan.recoveryPausedReason, "shutdown");
 });
 
 test("applyGoalMemoryEffects invokes every handler when all flags are true", () => {
@@ -111,8 +139,8 @@ test("applyGoalTransitionPostPersistEffects applies skip-plan command side effec
     source: "command",
     wasPausedBefore: true,
   });
-  assert.ok(plan);
   assert.equal(plan.persist, "skip");
+  assert.equal("memory" in plan, false);
 
   const calls: string[] = [];
   applyGoalTransitionPostPersistEffects(plan, {
@@ -135,7 +163,7 @@ test("planGoalTransition abort pause clears stopped runtime before persist when 
   const paused = { ...cloneGoal(goal), status: "paused" as const };
   const plan = planGoalTransition(paused, { kind: "abort_pause", nextGoal: paused });
 
-  assert.ok(plan);
   assert.equal(plan.persist, "skip");
+  assert.equal("memory" in plan, false);
   assert.equal(plan.resetStoppedRuntimeBeforePersist, true);
 });

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -57,6 +57,48 @@ test("planMemoryEffectsOnGoalChange pauses clear continuation and accounting wit
   assert.equal(plan.resetRecovery, false);
 });
 
+test("planGoalTransition command set replacing paused goal resets recovery only before persist", () => {
+  const paused = createThreadGoal("old objective");
+  const pausedCurrent = { ...cloneGoal(paused), status: "paused" as const };
+  const nextActive = createThreadGoal("new objective");
+
+  const plan = planGoalTransition(pausedCurrent, {
+    kind: "set",
+    nextGoal: nextActive,
+    source: "command",
+  });
+
+  assertDisjointPrimitivePlan(plan, "command paused replacement");
+  assert.equal(plan.persist, "set");
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearActiveAccounting",
+    "resetRecovery",
+    "clearBudgetWarning",
+  ]);
+  assert.deepEqual(effectTypes(plan.afterPersist), ["markContinuationQueued"]);
+});
+
+test("planGoalTransition command pause schedules reset recovery after persist", () => {
+  const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+
+  const plan = planGoalTransition(goal, {
+    kind: "set",
+    nextGoal: paused,
+    source: "command",
+  });
+
+  assertDisjointPrimitivePlan(plan, "command pause");
+  assert.equal(plan.persist, "set");
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearActiveAccounting",
+    "clearBudgetWarning",
+  ]);
+  assert.deepEqual(effectTypes(plan.afterPersist), ["resetRecovery"]);
+});
+
 test("planGoalTransition command resume schedules reset and continuation after persist", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -2,12 +2,39 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
-  applyGoalMemoryEffects,
-  applyGoalTransitionPostPersistEffects,
+  applyGoalTransitionEffects,
   planGoalTransition,
   planMemoryEffectsOnGoalChange,
+  type GoalTransitionEffect,
+  type GoalTransitionPlan,
 } from "../src/goal-transition.js";
 import { cloneGoal, createThreadGoal } from "../src/state.js";
+
+function effectTypes(effects: readonly GoalTransitionEffect[]): string[] {
+  return effects.map((effect) => effect.type);
+}
+
+function assertNoDuplicateEffectTypes(
+  effects: readonly GoalTransitionEffect[],
+  label: string,
+): void {
+  const seen = new Set<string>();
+  for (const effect of effects) {
+    assert.equal(
+      seen.has(effect.type),
+      false,
+      `${label}: duplicate effect type ${effect.type}`,
+    );
+    seen.add(effect.type);
+  }
+}
+
+function assertDisjointPrimitivePlan(plan: GoalTransitionPlan, label: string): void {
+  assertNoDuplicateEffectTypes(plan.beforePersist, `${label} beforePersist`);
+  assertNoDuplicateEffectTypes(plan.afterPersist, `${label} afterPersist`);
+  const combined = [...plan.beforePersist, ...plan.afterPersist];
+  assertNoDuplicateEffectTypes(combined, `${label} combined`);
+}
 
 test("planMemoryEffectsOnGoalChange clears stopped runtime primitives when goal id changes", () => {
   const previous = createThreadGoal("first");
@@ -30,46 +57,71 @@ test("planMemoryEffectsOnGoalChange pauses clear continuation and accounting wit
   assert.equal(plan.resetRecovery, false);
 });
 
-test("planGoalTransition command set marks continuation and defers recovery reset until after persist", () => {
+test("planGoalTransition command resume schedules reset and continuation after persist", () => {
   const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+  const active = { ...cloneGoal(goal), status: "active" as const };
+
+  const plan = planGoalTransition(paused, {
+    kind: "set",
+    nextGoal: active,
+    source: "command",
+  });
+
+  assertDisjointPrimitivePlan(plan, "command resume");
+  assert.equal(plan.persist, "set");
+  assert.deepEqual(effectTypes(plan.beforePersist), ["clearBudgetWarning"]);
+  assert.deepEqual(effectTypes(plan.afterPersist), ["markContinuationQueued", "resetRecovery"]);
+});
+
+test("planGoalTransition command set skip marks continuation for unchanged active goal", () => {
+  const goal = createThreadGoal("ship it");
+
   const plan = planGoalTransition(goal, {
     kind: "set",
     nextGoal: goal,
     source: "command",
-    wasPausedBefore: true,
   });
 
+  assertDisjointPrimitivePlan(plan, "command active skip");
   assert.equal(plan.persist, "skip");
-  assert.equal("memory" in plan, false);
-  assert.equal(plan.markContinuationQueued, true);
-  assert.equal(plan.resetRecoveryAfterPersist, true);
-  assert.equal(plan.resetRecoveryBeforePersist, false);
+  assert.deepEqual(plan.beforePersist, []);
+  assert.deepEqual(effectTypes(plan.afterPersist), ["markContinuationQueued"]);
 });
 
-test("planGoalTransition abort pause clears stopped runtime primitives before paused memory effects", () => {
+test("planGoalTransition abort pause uses disjoint primitive schedule", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
 
   const plan = planGoalTransition(goal, { kind: "abort_pause", nextGoal: paused });
+  assertDisjointPrimitivePlan(plan, "abort pause set");
   assert.equal(plan.persist, "set");
-  assert.equal(plan.clearContinuationBeforePersist, true);
-  assert.equal(plan.clearActiveAccountingBeforePersist, true);
-  assert.equal(plan.resetRecoveryBeforePersist, true);
-  assert.equal(plan.memory.clearContinuation, true);
-  assert.equal(plan.memory.resetRecovery, true);
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearActiveAccounting",
+    "resetRecovery",
+    "clearBudgetWarning",
+  ]);
+  assert.deepEqual(plan.afterPersist, []);
 });
 
 test("planGoalTransition clear persists clear with full memory reset", () => {
   const goal = createThreadGoal("ship it");
   const plan = planGoalTransition(goal, { kind: "clear", source: "command" });
 
+  assertDisjointPrimitivePlan(plan, "clear");
   assert.equal(plan.persist, "clear");
   assert.equal(plan.nextGoal, null);
-  assert.equal(plan.memory.clearContinuation, true);
-  assert.equal(plan.memory.resetRecovery, true);
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearActiveAccounting",
+    "resetRecovery",
+    "clearBudgetWarning",
+  ]);
+  assert.deepEqual(effectTypes(plan.afterPersist), ["stopStatusRefresh"]);
 });
 
-test("planGoalTransition recovery pause owns continuation clear and reason", () => {
+test("planGoalTransition recovery pause owns continuation clear and reason without duplicates", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
   const plan = planGoalTransition(goal, {
@@ -78,10 +130,14 @@ test("planGoalTransition recovery pause owns continuation clear and reason", () 
     recoveryReason: "context_length_exceeded",
   });
 
+  assertDisjointPrimitivePlan(plan, "recovery pause");
   assert.equal(plan.persist, "set");
-  assert.equal(plan.clearContinuationBeforePersist, true);
-  assert.equal(plan.recoveryPausedReason, "context_length_exceeded");
-  assert.equal(plan.memory.clearContinuation, true);
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "setRecoveryPausedAttention",
+    "clearActiveAccounting",
+    "clearBudgetWarning",
+  ]);
 });
 
 test("planGoalTransition recovery shutdown pause clears host overflow recovery", () => {
@@ -93,20 +149,26 @@ test("planGoalTransition recovery shutdown pause clears host overflow recovery",
     recoveryReason: "shutdown",
   });
 
+  assertDisjointPrimitivePlan(plan, "recovery shutdown pause");
   assert.equal(plan.persist, "set");
-  assert.equal(plan.clearHostOverflowRecovery, true);
-  assert.equal(plan.recoveryPausedReason, "shutdown");
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearHostOverflowRecovery",
+    "setRecoveryPausedAttention",
+    "clearActiveAccounting",
+    "clearBudgetWarning",
+  ]);
 });
 
-test("applyGoalMemoryEffects invokes every handler when all flags are true", () => {
+test("applyGoalTransitionEffects invokes handlers in effect order", () => {
   const calls: string[] = [];
-  applyGoalMemoryEffects(
-    {
-      clearContinuation: true,
-      clearActiveAccounting: true,
-      resetRecovery: true,
-      clearBudgetWarning: true,
-    },
+  applyGoalTransitionEffects(
+    [
+      { type: "clearContinuation" },
+      { type: "clearActiveAccounting" },
+      { type: "resetRecovery" },
+      { type: "clearBudgetWarning" },
+    ],
     {
       clearContinuation: () => {
         calls.push("clearContinuation");
@@ -120,6 +182,18 @@ test("applyGoalMemoryEffects invokes every handler when all flags are true", () 
       clearBudgetWarning: () => {
         calls.push("clearBudgetWarning");
       },
+      clearHostOverflowRecovery: () => {
+        calls.push("clearHostOverflowRecovery");
+      },
+      setRecoveryPausedAttention: () => {
+        calls.push("setRecoveryPausedAttention");
+      },
+      markContinuationQueued: (goalId) => {
+        calls.push(`markContinuationQueued:${goalId}`);
+      },
+      stopStatusRefresh: () => {
+        calls.push("stopStatusRefresh");
+      },
     },
   );
 
@@ -131,46 +205,37 @@ test("applyGoalMemoryEffects invokes every handler when all flags are true", () 
   ]);
 });
 
-test("applyGoalTransitionPostPersistEffects applies skip-plan command side effects", () => {
+test("planGoalTransition command skip applies post-persist effects only", () => {
   const goal = createThreadGoal("ship it");
-  const plan = planGoalTransition(goal, {
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+  const plan = planGoalTransition(paused, {
     kind: "set",
-    nextGoal: goal,
+    nextGoal: paused,
     source: "command",
-    wasPausedBefore: true,
   });
+
+  assertDisjointPrimitivePlan(plan, "command paused skip");
   assert.equal(plan.persist, "skip");
-  assert.equal("memory" in plan, false);
-
-  const calls: string[] = [];
-  applyGoalTransitionPostPersistEffects(plan, {
-    resetRecoveryAfterPersist: () => {
-      calls.push("resetRecoveryAfterPersist");
-    },
-    markContinuationQueued: (goalId) => {
-      calls.push(`markContinuationQueued:${goalId}`);
-    },
-  });
-
-  assert.deepEqual(calls, [
-    "resetRecoveryAfterPersist",
-    `markContinuationQueued:${goal.goalId}`,
-  ]);
+  assert.deepEqual(plan.beforePersist, []);
+  assert.deepEqual(effectTypes(plan.afterPersist), ["resetRecovery"]);
 });
 
-test("planGoalTransition abort pause clears stopped runtime primitives before persist when persistence skips", () => {
+test("planGoalTransition abort pause clears primitives before persist when persistence skips", () => {
   const goal = createThreadGoal("ship it");
   const paused = { ...cloneGoal(goal), status: "paused" as const };
   const plan = planGoalTransition(paused, { kind: "abort_pause", nextGoal: paused });
 
+  assertDisjointPrimitivePlan(plan, "abort pause skip");
   assert.equal(plan.persist, "skip");
-  assert.equal("memory" in plan, false);
-  assert.equal(plan.clearContinuationBeforePersist, true);
-  assert.equal(plan.clearActiveAccountingBeforePersist, true);
-  assert.equal(plan.resetRecoveryBeforePersist, true);
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearActiveAccounting",
+    "resetRecovery",
+  ]);
+  assert.deepEqual(plan.afterPersist, []);
 });
 
-test("planGoalTransition runtime accounting defers persistence for ordinary usage updates", () => {
+test("planGoalTransition runtime accounting defers persistence for active usage updates", () => {
   const goal = createThreadGoal("ship it");
   const next = {
     ...cloneGoal(goal),
@@ -181,11 +246,12 @@ test("planGoalTransition runtime accounting defers persistence for ordinary usag
   const plan = planGoalTransition(goal, {
     kind: "runtime_accounting",
     nextGoal: next,
-    crossedBudget: false,
   });
 
+  assertDisjointPrimitivePlan(plan, "runtime defer");
   assert.equal(plan.persist, "defer");
-  assert.equal(plan.memory.clearBudgetWarning, true);
+  assert.deepEqual(effectTypes(plan.beforePersist), ["clearBudgetWarning"]);
+  assert.deepEqual(plan.afterPersist, []);
 });
 
 test("planGoalTransition runtime accounting persists immediately when budget is crossed", () => {
@@ -200,22 +266,26 @@ test("planGoalTransition runtime accounting persists immediately when budget is 
   const plan = planGoalTransition(goal, {
     kind: "runtime_accounting",
     nextGoal: limited,
-    crossedBudget: true,
   });
 
+  assertDisjointPrimitivePlan(plan, "runtime budget cross");
   assert.equal(plan.persist, "set");
-  assert.equal(plan.memory.clearContinuation, true);
-  assert.equal(plan.memory.resetRecovery, true);
+  assert.deepEqual(effectTypes(plan.beforePersist), [
+    "clearContinuation",
+    "clearActiveAccounting",
+    "resetRecovery",
+  ]);
 });
 
-test("planGoalTransition skip plans cannot carry memory", () => {
+test("planGoalTransition skip plans have empty beforePersist when unchanged", () => {
   const goal = createThreadGoal("ship it");
   const plan = planGoalTransition(goal, {
     kind: "runtime_accounting",
     nextGoal: goal,
-    crossedBudget: false,
   });
 
+  assertDisjointPrimitivePlan(plan, "runtime skip");
   assert.equal(plan.persist, "skip");
-  assert.equal("memory" in plan, false);
+  assert.deepEqual(plan.beforePersist, []);
+  assert.deepEqual(plan.afterPersist, []);
 });

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -449,17 +449,27 @@ test("planGoalTransition runtime accounting persists immediately when budget is 
   ]);
 });
 
-test("planGoalTransition skip plans have empty beforePersist when unchanged", () => {
+test("planGoalTransition runtime accounting rejects unchanged payload", () => {
   const goal = createThreadGoal("ship it");
-  const plan = planGoalTransition(goal, {
-    kind: "runtime_accounting",
-    nextGoal: goal,
-  });
 
-  assertDisjointPrimitivePlan(plan, "runtime skip");
-  assert.equal(plan.persist, "skip");
-  assert.deepEqual(plan.beforePersist, []);
-  assert.deepEqual(plan.afterPersist, []);
+  assert.throws(
+    () =>
+      planGoalTransition(goal, {
+        kind: "runtime_accounting",
+        nextGoal: goal,
+      }),
+    /Invalid runtime_accounting transition: runtime accounting must increase usage or change status/,
+  );
+});
+
+test("planGoalTransition runtime accounting rejects timestamp-only payload", () => {
+  const goal = createThreadGoal("ship it", 10);
+  const next = { ...cloneGoal(goal), updatedAt: goal.updatedAt + 1 };
+
+  assert.throws(
+    () => planGoalTransition(goal, { kind: "runtime_accounting", nextGoal: next }),
+    /Invalid runtime_accounting transition: runtime accounting must increase usage or change status/,
+  );
 });
 
 const ALL_STATUSES: GoalStatus[] = ["active", "paused", "budgetLimited", "complete"];
@@ -837,3 +847,34 @@ test("planGoalTransition runtime_accounting rejects budgetLimited to active", ()
     /Invalid runtime_accounting transition: budgetLimited goals cannot transition to active/,
   );
 });
+
+const STATUS_SPECIFIC_UPDATED_AT_KINDS = [
+  "abort_pause",
+  "resume_active",
+  "recovery_pause",
+  "recovery_shutdown_pause",
+  "runtime_accounting",
+] as const;
+
+for (const kind of STATUS_SPECIFIC_UPDATED_AT_KINDS) {
+  test(`planGoalTransition ${kind} rejects updatedAt rewind`, () => {
+    const current =
+      kind === "resume_active"
+        ? { ...createThreadGoal("ship it", 10), status: "paused" as const }
+        : kind === "runtime_accounting"
+          ? createThreadGoal("ship it", 10)
+          : createThreadGoal("ship it", 10);
+    const next =
+      kind === "abort_pause" || kind === "recovery_pause" || kind === "recovery_shutdown_pause"
+        ? legalActiveToPausedNext(current)
+        : kind === "resume_active"
+          ? legalPausedToActiveNext(current)
+          : legalRuntimeAccountingNext(current);
+    next.updatedAt = current.updatedAt - 1;
+
+    assert.throws(
+      () => planGoalTransition(current, statusSpecificRequest(kind, next)),
+      /updatedAt must not decrease/,
+    );
+  });
+}

--- a/test/goal-transition.test.ts
+++ b/test/goal-transition.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  planGoalTransition,
+  planMemoryEffectsOnGoalChange,
+} from "../src/goal-transition.js";
+import { cloneGoal, createThreadGoal } from "../src/state.js";
+
+test("planMemoryEffectsOnGoalChange clears stopped runtime when goal id changes", () => {
+  const previous = createThreadGoal("first");
+  const next = createThreadGoal("second");
+
+  const plan = planMemoryEffectsOnGoalChange(previous, next);
+  assert.equal(plan.resetStoppedRuntime, true);
+  assert.equal(plan.clearBudgetWarning, true);
+});
+
+test("planMemoryEffectsOnGoalChange pauses clear continuation and accounting without full reset", () => {
+  const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+
+  const plan = planMemoryEffectsOnGoalChange(goal, paused);
+  assert.equal(plan.resetStoppedRuntime, false);
+  assert.equal(plan.clearContinuation, true);
+  assert.equal(plan.clearActiveAccounting, true);
+  assert.equal(plan.resetRecovery, false);
+});
+
+test("planGoalTransition command set marks continuation and defers recovery reset until after persist", () => {
+  const goal = createThreadGoal("ship it");
+  const plan = planGoalTransition(goal, {
+    kind: "set",
+    nextGoal: goal,
+    source: "command",
+    wasPausedBefore: true,
+  });
+
+  assert.ok(plan);
+  assert.equal(plan.persist, "skip");
+  assert.equal(plan.markContinuationQueued, true);
+  assert.equal(plan.resetRecoveryAfterPersist, true);
+  assert.equal(plan.resetRecoveryBeforePersist, false);
+});
+
+test("planGoalTransition abort pause resets stopped runtime before paused memory effects", () => {
+  const goal = createThreadGoal("ship it");
+  const paused = { ...cloneGoal(goal), status: "paused" as const };
+
+  const plan = planGoalTransition(goal, { kind: "abort_pause", nextGoal: paused });
+  assert.ok(plan);
+  assert.equal(plan.memory.resetStoppedRuntime, true);
+  assert.equal(plan.persist, "set");
+});
+
+test("planGoalTransition clear stops status refresh and persists clear", () => {
+  const goal = createThreadGoal("ship it");
+  const plan = planGoalTransition(goal, { kind: "clear", source: "command" });
+
+  assert.ok(plan);
+  assert.equal(plan.persist, "clear");
+  assert.equal(plan.stopStatusRefresh, true);
+  assert.equal(plan.nextGoal, null);
+});

--- a/test/recovery-runtime.test.ts
+++ b/test/recovery-runtime.test.ts
@@ -3,7 +3,10 @@ import test from "node:test";
 
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
-import { createGoalRecoveryMachine } from "../src/recovery-machine.js";
+import {
+  createGoalRecoveryMachine,
+  setRecoveryPausedAttention,
+} from "../src/recovery-machine.js";
 import { createGoalRecoveryRuntime } from "../src/recovery-runtime.js";
 import { recoveryPhaseNeedsUserStartTurn } from "../src/recovery-phase.js";
 import { CONTEXT_OVERFLOW_SIGNATURE } from "../src/recovery.js";
@@ -32,7 +35,9 @@ function createRecoveryTestRuntime(goal: ThreadGoal | null = activeGoal) {
     getGoal: () => goal,
     getRecoveryState: () => recoveryState,
     clearContinuationState: () => {},
-    pauseGoalForRecovery: () => {},
+    pauseGoalForRecovery: (_ctx, _goal, reason) => {
+      setRecoveryPausedAttention(recoveryState, reason);
+    },
     refreshUi: () => {
       refreshCount += 1;
     },
@@ -158,6 +163,45 @@ test("overflow compaction attempts survive intervening transient errors before p
   assert.equal(harness.continueCount, 0);
   assert.equal(harness.recoveryState.counters.compactionAttempts, 2);
   assert.match(harness.recoveryState.attention ?? "", /\/goal resume/);
+});
+
+test("recovery pause delegates reason without clearing continuation in recovery runtime", () => {
+  let continuationCleared = false;
+  let pauseReason: string | null = null;
+  let refreshCount = 0;
+  const recoveryState = createGoalRecoveryMachine();
+
+  const runtime = createGoalRecoveryRuntime({
+    getGoal: () => activeGoal,
+    getRecoveryState: () => recoveryState,
+    clearContinuationState: () => {
+      continuationCleared = true;
+    },
+    pauseGoalForRecovery: (_ctx, _goal, reason) => {
+      pauseReason = reason;
+    },
+    refreshUi: () => {
+      refreshCount += 1;
+    },
+    maybeContinue: () => {},
+  });
+
+  const ctx = { ui: { setStatus() {} } } as unknown as ExtensionContext;
+
+  runtime.handlePersistentAssistantError(
+    { role: "assistant", stopReason: "error", errorMessage: "context_length_exceeded" },
+    ctx,
+  );
+  runtime.onSessionCompact();
+  continuationCleared = false;
+  runtime.handlePersistentAssistantError(
+    { role: "assistant", stopReason: "error", errorMessage: "context_length_exceeded" },
+    ctx,
+  );
+
+  assert.equal(continuationCleared, false);
+  assert.match(pauseReason ?? "", /context window recovery failed/);
+  assert.equal(refreshCount, 0);
 });
 
 test("session compact after pending transient error preserves attention without continuing", () => {


### PR DESCRIPTION
## Summary

- Add `src/goal-transition.ts` with pure transition planning (`planGoalTransition`) and shared effect application.
- Route command/tool/runtime abort/resume/recovery goal changes through `applyGoalTransition` in `src/index.ts` instead of duplicating cleanup at each call site.
- Add focused planner unit tests in `test/goal-transition.test.ts`.
- Review round 1: apply all planned memory handlers; `persist: "skip"` still runs post-persist command/runtime side effects; abort pause restores pre-persist stopped-runtime cleanup.
- Review round 2: `recovery_pause` carries `recoveryReason` and owns continuation clear, paused attention, and UI refresh; `GoalTransitionEffectPlan` is a discriminated union so skip plans cannot carry dead memory effects; removed dead nullable planner branch.
- Review round 3: replace composite `resetStoppedRuntime` flags with primitive memory/pre-persist fields; remove dead `refreshUi`/`persist` plan fields; route coalesced runtime usage through `runtime_accounting` + `persist: "defer"` on the same transition executor.
- Review round 4: replace overlapping flag/memory bags with disjoint `beforePersist`/`afterPersist` primitive effect schedules; derive paused-before and budget-cross facts inside the planner; tighten tests to reachable contracts with duplicate-free effect assertions.
- Review round 5: command `set` after-persist `resetRecovery` only for same-goal pause/resume; paused-goal replacement relies on goal-id-change beforePersist reset; add paused-replacement and command-pause planner tests.
- Review round 6: same-goal command pause also gates after-persist `resetRecovery` on unchanged goal id; privatize memory planner internals; add command-set table tests for duplicate-free schedules across type-valid `set` shapes.
- Review round 7: validate status-specific transition requests at the planner boundary (active→paused abort/recovery, paused→active resume, active/budgetLimited runtime accounting); reject null current, goalId mismatch, and impossible status pairs before planning; add exhaustive status-matrix planner tests.
- Review round 8: require immutable objective/tokenBudget/usage/createdAt for pause/resume/recovery helpers; tighten `runtime_accounting` to active→active, active→budgetLimited, and budgetLimited→budgetLimited with non-decreasing usage and budget-consistent limited status; reject `budgetLimited→active` and malformed same-id payloads; add matrix/mutation tests.
- Review round 9: route over-budget paused session resume through generic `set` instead of `resume_active`; only send session-resume continuation when the goal ends `active`; reject `updatedAt` rewinds on status helpers and runtime accounting; reject timestamp-only runtime accounting (require usage increase or legal status change); remove dead `runtime_accounting` skip plan.

Closes #22

## Test plan

- [x] `npm run verify` (382 tests)
- [x] `npx tsc --noEmit --noUnusedLocals --noUnusedParameters --pretty false`
- [x] `git diff --check` / `git show --check`

Made with [Cursor](https://cursor.com)