### PR TITLE
Align pi-codex-goal with Pi 0.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Updates the local pi development baseline to `@earendil-works/*` `0.76.0` and refreshes the npm lockfile.
+- Aligns recovery retry classification with Pi 0.76.0 so terminal quota, billing, and provider-limit errors do not stay pending for host retries even when they include `429` wording.
+- Validates the cutover with the existing typecheck/test suite plus package metadata and dry-run pack checks.
+
 ## 0.1.15 - 2026-05-27
 
 - Refactors the goal runtime monolith into focused modules for clearer lifecycle ownership, event handling, and continuation orchestration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.15",
       "license": "MIT",
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.75.5",
-        "@earendil-works/pi-coding-agent": "0.75.5",
+        "@earendil-works/pi-ai": "0.76.0",
+        "@earendil-works/pi-coding-agent": "0.76.0",
         "@types/node": "^25.9.1",
         "tsx": "^4.22.3",
         "typebox": "1.1.38",
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
-      "integrity": "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.76.0.tgz",
+      "integrity": "sha512-RO/L80iTxkK/nM2s5IVuirjH04UBsVzFfAT0qVcP/VwtDe9pjpqL+BVqb3XTyfitTD9tBo/hQuKmagN8Ep5qZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -542,16 +542,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.5.tgz",
-      "integrity": "sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.76.0.tgz",
+      "integrity": "sha512-vTnKbgw1rDQq2MD+vcWgyYvEPMV4mMb07tZZMS7FOvlS5t/jzIX9smC+k97YGpfl8dT+L9Uj+MYyvYSBXVaEHw==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.75.5",
-        "@earendil-works/pi-ai": "^0.75.5",
-        "@earendil-works/pi-tui": "^0.75.5",
+        "@earendil-works/pi-agent-core": "^0.76.0",
+        "@earendil-works/pi-ai": "^0.76.0",
+        "@earendil-works/pi-tui": "^0.76.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1040,12 +1040,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.76.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.5",
+        "@earendil-works/pi-ai": "^0.76.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1055,8 +1055,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.76.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1072,15 +1072,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.75.5",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.76.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     }
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.75.5",
-    "@earendil-works/pi-coding-agent": "0.75.5",
+    "@earendil-works/pi-ai": "0.76.0",
+    "@earendil-works/pi-coding-agent": "0.76.0",
     "@types/node": "^25.9.1",
     "tsx": "^4.22.3",
     "typebox": "1.1.38",

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -70,14 +70,25 @@ export function isContextOverflowError(errorMessage: string | undefined): boolea
   );
 }
 
+function isNonRetryableProviderLimitError(errorMessage: string): boolean {
+  return /GoUsageLimitError|FreeUsageLimitError|Monthly usage limit reached|available balance|insufficient_quota|out of budget|quota exceeded|billing/i.test(
+    errorMessage,
+  );
+}
+
 /**
- * Mirrors host AgentSession._isRetryableError() classification for transient provider failures.
+ * Mirrors Pi 0.76.0 host AgentSession._isRetryableError() classification for transient provider failures.
+ * Context overflow is not transient retryable because host compaction handles that path.
+ * Terminal quota, billing, and provider-limit errors are not retryable even when they contain 429 or rate-limit wording.
  */
 export function isRetryableTransientError(errorMessage: string | undefined): boolean {
   if (!errorMessage) {
     return false;
   }
   if (isContextOverflowError(errorMessage)) {
+    return false;
+  }
+  if (isNonRetryableProviderLimitError(errorMessage)) {
     return false;
   }
   return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(

--- a/test/recovery-errors.test.ts
+++ b/test/recovery-errors.test.ts
@@ -37,6 +37,25 @@ test("non-retryable provider errors pause active goals immediately", async () =>
   );
 });
 
+test("terminal provider-limit 429 errors pause active goals immediately", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  harness.sentMessages.length = 0;
+
+  await emitPersistentAssistantError(harness, 0, "insufficient_quota 429");
+
+  assert.equal(harness.snapshot().goal?.status, "paused");
+  assert.equal(harness.sentMessages.length, 0);
+  assert.equal(
+    harness.footerStatuses.at(-1),
+    formatFooterStatus(
+      harness.snapshot().goal,
+      recoveryAttentionMessage("non-retryable provider error (insufficient_quota 429)"),
+    ),
+  );
+  assert.doesNotMatch(harness.footerStatuses.at(-1) ?? "", /Goal recovery pending/);
+});
+
 test("non-retryable provider error pause does not cancel host compaction", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -87,11 +87,30 @@ test("isAssistantContextOverflow detects silent stop and zero-output length over
 });
 
 test("isRetryableTransientError mirrors host retry classification", () => {
+  assert.equal(isRetryableTransientError("HTTP 429 too many requests"), true);
   assert.equal(isRetryableTransientError("HTTP 500 internal server error"), true);
   assert.equal(isRetryableTransientError("HTTP 502 bad gateway"), true);
+  assert.equal(isRetryableTransientError("HTTP 503 service unavailable"), true);
   assert.equal(isRetryableTransientError("websocket closed"), true);
   assert.equal(isRetryableTransientError("context_length_exceeded"), false);
   assert.equal(isRetryableTransientError("invalid api key"), false);
+});
+
+const terminalProviderLimitErrors = [
+  "insufficient_quota 429",
+  "available balance",
+  "quota exceeded",
+  "billing",
+  "GoUsageLimitError",
+  "FreeUsageLimitError",
+  "Monthly usage limit reached",
+  "out of budget",
+] as const;
+
+test("terminal provider-limit errors are not retryable transient errors", () => {
+  for (const errorMessage of terminalProviderLimitErrors) {
+    assert.equal(isRetryableTransientError(errorMessage), false, errorMessage);
+  }
 });
 
 test("failure signatures canonicalize context overflow regardless of volatile token counts", () => {
@@ -381,4 +400,18 @@ test("non-retryable provider errors pause immediately", () => {
   if (action.type === "pause") {
     assert.match(action.reason, /non-retryable provider error/);
   }
+});
+
+test("terminal provider-limit errors pause immediately instead of pending host retry", () => {
+  const state = createGoalRecoveryMachine();
+  const action = planRecoveryForAssistantError(
+    state,
+    { role: "assistant", stopReason: "error", errorMessage: "insufficient_quota 429" },
+  );
+
+  assert.equal(action.type, "pause");
+  if (action.type === "pause") {
+    assert.equal(action.reason, "non-retryable provider error (insufficient_quota 429)");
+  }
+  assert.equal(state.counters.transientAttempts, 0);
 });


### PR DESCRIPTION
## Summary

- update local Pi dev baseline packages from `0.75.5` to `0.76.0`
- align recovery retry classification with Pi 0.76.0 terminal quota/billing/provider-limit behavior
- add regression coverage for non-retryable provider-limit `429` errors while preserving generic transient retry cases
- document the cutover under `Unreleased` without bumping the package version

## Verification

- `npm run verify`
  - typecheck passed
  - 284 tests passed, 0 failed
- `npm ls @earendil-works/pi-coding-agent @earendil-works/pi-ai @earendil-works/pi-agent-core @earendil-works/pi-tui typebox --depth=1`
  - Pi packages resolve to 0.76.0
- `npm pack --dry-run --json`
  - `pi-codex-goal@0.1.15`
  - `entryCount: 40`
  - `bundled: []`
- `git diff --check`
