### PR TITLE
chore: post-0.1.15 codebase audit remediation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 dist/
 .scratchpad.md
 .DS_Store
+.debug/
 
 # CueLoop local/runtime state (do not commit)
 .cueloop/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# pi-codex-goal — agent notes
+
+Pi extension: Codex-style `/goal` command and `get_goal` / `create_goal` / `update_goal` tools. State lives in pi session custom entries.
+
+## Verify before finishing
+
+```sh
+npm run verify
+```
+
+Runs `tsc --noEmit` and the full Node test suite (`test/*.test.ts`).
+
+## Layout
+
+| Area | Modules |
+|------|---------|
+| Wiring | `src/index.ts`, `goal-runtime-controller.ts` |
+| User / model API | `commands.ts`, `tools.ts` |
+| Runtime events | `goal-runtime-event-handlers.ts`, `goal-runtime-*-handlers.ts` |
+| Transitions | `goal-transition.ts`, `goal-transition-effects.ts`, `goal-state-controller.ts` |
+| Stale continuations | `stale-queued-work-*.ts` |
+| Recovery | `recovery*.ts` |
+| Domain | `state.ts`, `types.ts`, `goal-persistence.ts` |
+
+Structural audit: `docs/CODEBASE_AUDIT.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Adds `docs/CODEBASE_AUDIT.md` with a 2026-05-28 structural health report and remediation record.
+- Adds project `AGENTS.md` and documents `npm run verify` in the README Development section.
+- Extracts stale queued-work reducer lifecycle default tables into `stale-queued-work-reducer-defaults.ts`.
+- Ignores local `.debug/` Cursor SDK event artifacts in `.gitignore`.
+
 ## 0.1.15 - 2026-05-27
 
 - Refactors the goal runtime monolith into focused modules for clearer lifecycle ownership, event handling, and continuation orchestration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+## 0.1.16 - 2026-05-28
+
 - Adds `docs/CODEBASE_AUDIT.md` with a 2026-05-28 structural health report and remediation record.
 - Adds project `AGENTS.md` and documents `npm run verify` in the README Development section.
 - Extracts stale queued-work reducer lifecycle default tables into `stale-queued-work-reducer-defaults.ts`.
 - Ignores local `.debug/` Cursor SDK event artifacts in `.gitignore`.
+- Updates the local pi development baseline to `@earendil-works/*` `0.77.0`, keeps pi runtime packages as optional wildcard peers, and leaves no pi/Node upper-bound metadata that would block future pi releases at install time.
 
 ## 0.1.15 - 2026-05-27
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pi install npm:pi-codex-goal
 Install a pinned npm version:
 
 ```sh
-pi install npm:pi-codex-goal@0.1.15
+pi install npm:pi-codex-goal@<version>
 ```
 
 Install from GitHub:
@@ -33,7 +33,7 @@ pi install https://github.com/fitchmultz/pi-codex-goal
 Install a pinned GitHub release:
 
 ```sh
-pi install https://github.com/fitchmultz/pi-codex-goal@v0.1.15
+pi install https://github.com/fitchmultz/pi-codex-goal@v<version>
 ```
 
 For local development from this repository:
@@ -53,7 +53,7 @@ Validate types and tests before committing or opening a PR:
 npm run verify
 ```
 
-Project agent notes and module map: [AGENTS.md](AGENTS.md).  
+Project agent notes and module map: [AGENTS.md](AGENTS.md).
 Latest structural audit: [docs/CODEBASE_AUDIT.md](docs/CODEBASE_AUDIT.md).
 
 ## User Commands

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ npm install
 pi install .
 ```
 
+Compatibility note: this package is tested against the current pi release during each package update, and pi-bundled runtime packages are declared as optional wildcard peers. That keeps installs forward-open for future pi releases: npm peer ranges should not block users from trying a newer pi, though runtime behavior is only verified against the tested baseline until a follow-up package release confirms it.
+
 ## Development
 
 Validate types and tests before committing or opening a PR:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ npm install
 pi install .
 ```
 
+## Development
+
+Validate types and tests before committing or opening a PR:
+
+```sh
+npm run verify
+```
+
+Project agent notes and module map: [AGENTS.md](AGENTS.md).  
+Latest structural audit: [docs/CODEBASE_AUDIT.md](docs/CODEBASE_AUDIT.md).
+
 ## User Commands
 
 ```text

--- a/docs/CODEBASE_AUDIT.md
+++ b/docs/CODEBASE_AUDIT.md
@@ -1,0 +1,125 @@
+# Codebase Audit — pi-codex-goal
+
+**Date:** 2026-05-28  
+**Scope:** Full repository (`src/`, `test/`, package metadata, operability)  
+**Baseline:** `0.1.15` on `main` after runtime refactor and 0.1.15 release audit remediation (`347b8bd`)
+
+## Executive summary
+
+The package is in **good structural health**. Core behavior is split across focused runtime modules (controller, event handlers, transitions, recovery, stale queued-work state machine, persistence). TypeScript is strict, the test suite is broad (284 tests), and `npm run verify` passes.
+
+This audit found **no critical or high-severity structural defects**. Remaining items were operability/documentation gaps and one maintainability split (stale queued-work default transition tables). Those are addressed on branch `chore/post-0.1.15-codebase-audit`.
+
+## Scope
+
+| Area | Examined |
+|------|----------|
+| Entry | `src/index.ts` → `goal-runtime-controller.ts` |
+| Commands / tools | `commands.ts`, `tools.ts` |
+| Domain state | `state.ts`, `types.ts`, `goal-persistence.ts` |
+| Runtime lifecycle | `goal-runtime-*`, `goal-state-controller.ts`, `goal-transition*.ts` |
+| Continuation / queue | `continuation-scheduler.ts`, `queued-goal-*.ts`, `prompts.ts` |
+| Stale work FSM | `stale-queued-work-*.ts` |
+| Recovery | `recovery*.ts` |
+| Tests | 24 files under `test/`, harness in `test/support/` |
+| Config | `package.json`, `tsconfig.json`, `.gitignore` |
+
+## Findings by category
+
+### Architecture and boundaries
+
+```text
+[🔵 Low] [Architecture] src/state.ts (~377 lines)
+- Problem: Combines validation, mutations, session reconstruction, and equivalence helpers in one module.
+- Impact: Slightly higher cognitive load when changing persistence vs. command semantics.
+- Blast radius: All goal CRUD, persistence replay, and tool handlers.
+- Fix: Acceptable for now; split only if reconstruction or validation grows further. No behavior change required.
+```
+
+```text
+[🔵 Low] [Architecture] src/stale-queued-work-reducer.ts (~420 lines after defaults extraction)
+- Problem: Reducer mixed lifecycle default tables with transition logic (pre-audit).
+- Impact: Harder to scan exceptional transitions vs. table-driven defaults.
+- Blast radius: Stale continuation abort/cleanup across all runtime paths.
+- Fix: Extracted `stale-queued-work-reducer-defaults.ts` (this PR).
+```
+
+**Positive patterns (evidence):**
+
+- `goal-runtime-event-handlers.ts` composes four handler modules with narrowed `goal-runtime-event-handler-types.ts` ports.
+- `goal-transition.ts` plans transitions; `goal-transition-effects.ts` applies side effects once.
+- `stale-queued-work-reducer.ts` uses per-lifecycle default tables and explicit handlers for non-default events.
+
+### Complexity and maintainability
+
+No `TODO`/`FIXME`, no `any`, no `@ts-expect-error`, no `eslint-disable` in `src/`. Exhaustive `switch`/`never` guards are used consistently in reducers and effect applicators.
+
+### Testing and verification
+
+| Signal | Value |
+|--------|-------|
+| Tests | 284 passing (`npm test`) |
+| Typecheck | Strict + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` |
+| Local gate | `npm run verify` |
+
+Coverage is **integration-heavy** via `test/support/runtime-harness.ts` and scenario tests — appropriate for an extension that wires pi session events. Dedicated unit tests exist for transitions, stale queued-work reducer tables, recovery classification, and persistence coalescing.
+
+**Gap (acceptable):** No isolated unit file for `continuation-scheduler.ts` or `goal-runtime-status.ts`; behavior is covered by `test/continuation.test.ts` and footer/command scenarios.
+
+### Configuration and operability
+
+```text
+[🟡 Medium] [Operability] README.md (pre-audit)
+- Problem: No documented local verification command for contributors/agents.
+- Impact: Harder to discover the canonical CI-equivalent check.
+- Blast radius: Contributors, agent sessions, release prep.
+- Fix: Development section + project `AGENTS.md` (this PR).
+```
+
+```text
+[🔵 Low] [Operability] .gitignore
+- Problem: Local `.debug/` (Cursor SDK event dumps) was not ignored.
+- Impact: Risk of accidental commit of session debug artifacts.
+- Fix: Ignore `.debug/` (this PR).
+```
+
+## Metrics / notable patterns
+
+| Metric | Value |
+|--------|-------|
+| `src/*.ts` modules | 38 |
+| Largest modules (lines) | `stale-queued-work-reducer.ts` ~420, `state.ts` ~377, `queued-goal-work.ts` ~383 |
+| Test files | 24 |
+| Peer baseline | `@earendil-works/*` 0.76.0 |
+
+Dependency graph is acyclic: handlers → controller ports → state/persistence/recovery; stale-work subsystems do not import runtime handlers.
+
+## Remediation roadmap
+
+### Quick wins (done on audit branch)
+
+- [x] Extract stale queued-work reducer default tables
+- [x] Document `npm run verify` in README and `AGENTS.md`
+- [x] Ignore `.debug/` in `.gitignore`
+- [x] Publish this audit in `docs/CODEBASE_AUDIT.md`
+
+### Short-term (optional, not blocking)
+
+- Add a one-line “Contributing” link from README to `docs/CODEBASE_AUDIT.md` if the doc grows follow-up sections.
+
+### Deeper refactors (only if scope expands)
+
+- Split `state.ts` into `goal-domain.ts` + `goal-session-reconstruction.ts` if either half exceeds ~250 lines or gains new concerns.
+
+## Assumptions and open questions
+
+- **Security:** Out of scope; no secrets in repo; objectives are XML-escaped in hidden prompts (`prompts.ts`).
+- **CI:** No GitHub Actions in-repo by project convention; local `npm run verify` is the gate.
+- **Performance:** Not profiled; hot paths are event-driven with coalesced persistence — no obvious anti-patterns for an extension.
+
+## Definition of done (audit)
+
+- [x] Main subsystems and entrypoints examined
+- [x] Findings prioritized with file evidence
+- [x] Structural risks separated from style noise
+- [x] Practical remediation roadmap with follow-up items executed on branch

--- a/docs/CODEBASE_AUDIT.md
+++ b/docs/CODEBASE_AUDIT.md
@@ -1,7 +1,7 @@
 # Codebase Audit — pi-codex-goal
 
-**Date:** 2026-05-28  
-**Scope:** Full repository (`src/`, `test/`, package metadata, operability)  
+**Date:** 2026-05-28
+**Scope:** Full repository (`src/`, `test/`, package metadata, operability)
 **Baseline:** `0.1.15` on `main` after runtime refactor and 0.1.15 release audit remediation (`347b8bd`)
 
 ## Executive summary
@@ -90,7 +90,7 @@ Coverage is **integration-heavy** via `test/support/runtime-harness.ts` and scen
 | `src/*.ts` modules | 38 |
 | Largest modules (lines) | `stale-queued-work-reducer.ts` ~420, `state.ts` ~377, `queued-goal-work.ts` ~383 |
 | Test files | 24 |
-| Peer baseline | `@earendil-works/*` 0.76.0 |
+| Pi dev baseline | `@earendil-works/*` 0.77.0 |
 
 Dependency graph is acyclic: handlers → controller ports → state/persistence/recovery; stale-work subsystems do not import runtime handlers.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-codex-goal",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "devDependencies": {
-        "@earendil-works/pi-ai": "0.76.0",
-        "@earendil-works/pi-coding-agent": "0.76.0",
+        "@earendil-works/pi-ai": "0.77.0",
+        "@earendil-works/pi-coding-agent": "0.77.0",
         "@types/node": "^25.9.1",
         "tsx": "^4.22.3",
-        "typebox": "1.1.38",
+        "typebox": "1.1.39",
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=22.19.0 <27"
+        "node": ">=22.19.0"
       },
       "peerDependencies": {
         "@earendil-works/pi-ai": "*",
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.76.0.tgz",
-      "integrity": "sha512-RO/L80iTxkK/nM2s5IVuirjH04UBsVzFfAT0qVcP/VwtDe9pjpqL+BVqb3XTyfitTD9tBo/hQuKmagN8Ep5qZA==",
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.77.0.tgz",
+      "integrity": "sha512-H21BrQDPf3ydaeBmS5maNDHxUGFMiKBF/n3WnE+OTWloIZSayeL+/NVEgG3aKQw8fZL6HAMYAGpUIVJgFuKtnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -541,17 +541,24 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.76.0.tgz",
-      "integrity": "sha512-vTnKbgw1rDQq2MD+vcWgyYvEPMV4mMb07tZZMS7FOvlS5t/jzIX9smC+k97YGpfl8dT+L9Uj+MYyvYSBXVaEHw==",
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.77.0.tgz",
+      "integrity": "sha512-huS+k+dhQRR9PlTK7crLfeSRUw3a96V6JYfP0ZH3Zkko/m10gsYk8dKQmwScSy5Dll516pXorz19BURfD6S2qQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.76.0",
-        "@earendil-works/pi-ai": "^0.76.0",
-        "@earendil-works/pi-tui": "^0.76.0",
+        "@earendil-works/pi-agent-core": "^0.77.0",
+        "@earendil-works/pi-ai": "^0.77.0",
+        "@earendil-works/pi-tui": "^0.77.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -574,7 +581,7 @@
         "node": ">=22.19.0"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard": "0.3.6"
+        "@mariozechner/clipboard": "0.3.9"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
@@ -1040,12 +1047,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.76.0.tgz",
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.77.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.76.0",
+        "@earendil-works/pi-ai": "^0.77.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1055,8 +1062,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.76.0.tgz",
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.77.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1079,8 +1086,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.76.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.76.0.tgz",
+      "version": "0.77.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.77.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1117,9 +1124,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
-      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1127,22 +1134,22 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
-        "@mariozechner/clipboard-darwin-universal": "0.3.6",
-        "@mariozechner/clipboard-darwin-x64": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
-      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
       "cpu": [
         "arm64"
       ],
@@ -1157,9 +1164,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
-      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1171,9 +1178,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
-      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
       "cpu": [
         "x64"
       ],
@@ -1188,13 +1195,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
-      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1205,13 +1215,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
-      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1222,13 +1235,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
-      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1239,13 +1255,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
-      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,13 +1275,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
-      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1273,9 +1295,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
-      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
       "cpu": [
         "arm64"
       ],
@@ -1290,9 +1312,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
-      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
       "cpu": [
         "x64"
       ],
@@ -3756,9 +3778,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.39.tgz",
+      "integrity": "sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "main": "src/index.ts",
   "files": [
     "src",
+    "docs",
+    "AGENTS.md",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Codex-style goal tracking and continuation for pi.",
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",
@@ -55,15 +55,15 @@
     }
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "0.76.0",
-    "@earendil-works/pi-coding-agent": "0.76.0",
+    "@earendil-works/pi-ai": "0.77.0",
+    "@earendil-works/pi-coding-agent": "0.77.0",
     "@types/node": "^25.9.1",
     "tsx": "^4.22.3",
-    "typebox": "1.1.38",
+    "typebox": "1.1.39",
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=22.19.0 <27"
+    "node": ">=22.19.0"
   },
-  "packageManager": "npm@11.0.0"
+  "packageManager": "npm@11.16.0"
 }

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -77,7 +77,7 @@ function isNonRetryableProviderLimitError(errorMessage: string): boolean {
 }
 
 /**
- * Mirrors Pi 0.76.0 host AgentSession._isRetryableError() classification for transient provider failures.
+ * Mirrors Pi 0.77.0 host AgentSession._isRetryableError() classification for transient provider failures.
  * Context overflow is not transient retryable because host compaction handles that path.
  * Terminal quota, billing, and provider-limit errors are not retryable even when they contain 429 or rate-limit wording.
  */

--- a/src/stale-queued-work-reducer-defaults.ts
+++ b/src/stale-queued-work-reducer-defaults.ts
@@ -1,0 +1,68 @@
+import type { StaleQueuedWorkEvent } from "./stale-queued-work-types.js";
+
+export type EventDefaultAction = "emptyPlan" | "noPlan" | "handled";
+export type LifecycleEventDefaults = Record<StaleQueuedWorkEvent["type"], EventDefaultAction>;
+
+export const IDLE_EVENT_DEFAULTS = {
+  runnableWorkStarted: "handled",
+  staleWorkStarted: "handled",
+  contextAbort: "noPlan",
+  userInputClearAbort: "emptyPlan",
+  extensionContinuationClearAbort: "emptyPlan",
+  beforeAgentStartClearAbort: "emptyPlan",
+  turnStart: "emptyPlan",
+  toolExecutionEnd: "emptyPlan",
+  sessionBeforeCompact: "emptyPlan",
+  sessionCompact: "emptyPlan",
+  turnEnd: "emptyPlan",
+  agentEnd: "emptyPlan",
+  sessionShutdown: "emptyPlan",
+} as const satisfies LifecycleEventDefaults;
+
+export const OBSERVING_TURN_EVENT_DEFAULTS = {
+  runnableWorkStarted: "handled",
+  staleWorkStarted: "handled",
+  contextAbort: "handled",
+  userInputClearAbort: "emptyPlan",
+  extensionContinuationClearAbort: "emptyPlan",
+  beforeAgentStartClearAbort: "emptyPlan",
+  turnStart: "handled",
+  toolExecutionEnd: "emptyPlan",
+  sessionBeforeCompact: "emptyPlan",
+  sessionCompact: "emptyPlan",
+  turnEnd: "handled",
+  agentEnd: "handled",
+  sessionShutdown: "handled",
+} as const satisfies LifecycleEventDefaults;
+
+export const ABORTING_TURN_EVENT_DEFAULTS = {
+  runnableWorkStarted: "emptyPlan",
+  staleWorkStarted: "emptyPlan",
+  contextAbort: "handled",
+  userInputClearAbort: "handled",
+  extensionContinuationClearAbort: "handled",
+  beforeAgentStartClearAbort: "handled",
+  turnStart: "handled",
+  toolExecutionEnd: "handled",
+  sessionBeforeCompact: "handled",
+  sessionCompact: "handled",
+  turnEnd: "handled",
+  agentEnd: "handled",
+  sessionShutdown: "handled",
+} as const satisfies LifecycleEventDefaults;
+
+export const AWAITING_TERMINAL_CLEANUP_EVENT_DEFAULTS = {
+  runnableWorkStarted: "handled",
+  staleWorkStarted: "handled",
+  contextAbort: "noPlan",
+  userInputClearAbort: "emptyPlan",
+  extensionContinuationClearAbort: "emptyPlan",
+  beforeAgentStartClearAbort: "emptyPlan",
+  turnStart: "emptyPlan",
+  toolExecutionEnd: "emptyPlan",
+  sessionBeforeCompact: "emptyPlan",
+  sessionCompact: "emptyPlan",
+  turnEnd: "handled",
+  agentEnd: "handled",
+  sessionShutdown: "handled",
+} as const satisfies LifecycleEventDefaults;

--- a/src/stale-queued-work-reducer.ts
+++ b/src/stale-queued-work-reducer.ts
@@ -1,4 +1,11 @@
 import {
+  ABORTING_TURN_EVENT_DEFAULTS,
+  AWAITING_TERMINAL_CLEANUP_EVENT_DEFAULTS,
+  IDLE_EVENT_DEFAULTS,
+  OBSERVING_TURN_EVENT_DEFAULTS,
+  type LifecycleEventDefaults,
+} from "./stale-queued-work-reducer-defaults.js";
+import {
   consumeAbortingAgentEnd,
   consumePendingStaleAgentEnd,
   dropActiveObligations,
@@ -215,73 +222,6 @@ function finishActiveAbortingLifecycle(
     : { kind: "idle" };
   return transition(nextState, skipClearAccountingRefreshPlan());
 }
-
-type EventDefaultAction = "emptyPlan" | "noPlan" | "handled";
-type LifecycleEventDefaults = Record<StaleQueuedWorkEvent["type"], EventDefaultAction>;
-
-const IDLE_EVENT_DEFAULTS = {
-  runnableWorkStarted: "handled",
-  staleWorkStarted: "handled",
-  contextAbort: "noPlan",
-  userInputClearAbort: "emptyPlan",
-  extensionContinuationClearAbort: "emptyPlan",
-  beforeAgentStartClearAbort: "emptyPlan",
-  turnStart: "emptyPlan",
-  toolExecutionEnd: "emptyPlan",
-  sessionBeforeCompact: "emptyPlan",
-  sessionCompact: "emptyPlan",
-  turnEnd: "emptyPlan",
-  agentEnd: "emptyPlan",
-  sessionShutdown: "emptyPlan",
-} as const satisfies LifecycleEventDefaults;
-
-const OBSERVING_TURN_EVENT_DEFAULTS = {
-  runnableWorkStarted: "handled",
-  staleWorkStarted: "handled",
-  contextAbort: "handled",
-  userInputClearAbort: "emptyPlan",
-  extensionContinuationClearAbort: "emptyPlan",
-  beforeAgentStartClearAbort: "emptyPlan",
-  turnStart: "handled",
-  toolExecutionEnd: "emptyPlan",
-  sessionBeforeCompact: "emptyPlan",
-  sessionCompact: "emptyPlan",
-  turnEnd: "handled",
-  agentEnd: "handled",
-  sessionShutdown: "handled",
-} as const satisfies LifecycleEventDefaults;
-
-const ABORTING_TURN_EVENT_DEFAULTS = {
-  runnableWorkStarted: "emptyPlan",
-  staleWorkStarted: "emptyPlan",
-  contextAbort: "handled",
-  userInputClearAbort: "handled",
-  extensionContinuationClearAbort: "handled",
-  beforeAgentStartClearAbort: "handled",
-  turnStart: "handled",
-  toolExecutionEnd: "handled",
-  sessionBeforeCompact: "handled",
-  sessionCompact: "handled",
-  turnEnd: "handled",
-  agentEnd: "handled",
-  sessionShutdown: "handled",
-} as const satisfies LifecycleEventDefaults;
-
-const AWAITING_TERMINAL_CLEANUP_EVENT_DEFAULTS = {
-  runnableWorkStarted: "handled",
-  staleWorkStarted: "handled",
-  contextAbort: "noPlan",
-  userInputClearAbort: "emptyPlan",
-  extensionContinuationClearAbort: "emptyPlan",
-  beforeAgentStartClearAbort: "emptyPlan",
-  turnStart: "emptyPlan",
-  toolExecutionEnd: "emptyPlan",
-  sessionBeforeCompact: "emptyPlan",
-  sessionCompact: "emptyPlan",
-  turnEnd: "handled",
-  agentEnd: "handled",
-  sessionShutdown: "handled",
-} as const satisfies LifecycleEventDefaults;
 
 function applyDefaultTransition(
   state: StaleQueuedWorkState,


### PR DESCRIPTION
## Summary

- Adds [docs/CODEBASE_AUDIT.md](docs/CODEBASE_AUDIT.md) — evidence-backed structural health report for `0.1.15` (no critical/high findings; operability and one maintainability split addressed here).
- Adds [AGENTS.md](AGENTS.md) and a README **Development** section documenting `npm run verify`.
- Extracts stale queued-work lifecycle default tables into `src/stale-queued-work-reducer-defaults.ts`.
- Ignores local `.debug/` Cursor SDK event dumps.

## Test plan

- [x] `npm run verify` (typecheck + 284 tests)


Made with [Cursor](https://cursor.com)