### PR TITLE
fix: align budget-limit prompt status spelling

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -133,7 +133,7 @@ export function budgetLimitPrompt(goal: ThreadGoal): string {
     `- Tokens used: ${formatTokenValue(goal.usage.tokensUsed)}`,
     `- Token budget: ${formatOptionalTokenBudget(goal)}`,
     "",
-    "The system has marked the goal as budget_limited, so do not start new substantive work for this goal. Wrap up this turn soon: summarize useful progress, identify remaining work or blockers, and leave the user with a clear next step.",
+    "The system has marked the goal as budgetLimited, so do not start new substantive work for this goal. Wrap up this turn soon: summarize useful progress, identify remaining work or blockers, and leave the user with a clear next step.",
     "",
     `Do not call ${goalToolReference("update_goal")} unless the goal is actually complete.`,
     "",

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -58,6 +58,9 @@ test("continuation and budget-limit prompts reference exposed goal-completion to
   const continuation = continuationPrompt(created);
   const budget = budgetLimitPrompt(created);
 
+  assert.match(budget, /marked the goal as budgetLimited/);
+  assert.doesNotMatch(budget, /budget_limited/);
+
   for (const prompt of [continuation, budget]) {
     assert.match(prompt, /update_goal \(or the exposed namespaced equivalent, such as pi__update_goal\)/);
     assert.match(prompt, /pi__update_goal/);


### PR DESCRIPTION
## Summary
- Change the budget-limit steering prompt to use the public `budgetLimited` status spelling.
- Add prompt coverage that requires `budgetLimited` and rejects the stale `budget_limited` spelling.

Closes #15

## Behavior changes
- Model-facing budget-limit guidance now matches the runtime/tool/docs status spelling.

## Validation
- `git diff --check`
- `npm run verify` — `tsc --noEmit` and 284 Node tests passed
- Reviewer subagent: NO FINDINGS

## Risks/notes
- Low risk: prompt text spelling only, with exact regression coverage.