### PR TITLE
fix: preserve active goal continuation cache stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Aligns the budget-limit steering prompt with the public `budgetLimited` status spelling.
 - Documents that default-branch source installs may include unreleased changes beyond the latest npm/tagged release.
 - Adds a copy-pasteable interactive Cursor Composer 2.5 `/goal` smoke test and documents that `pi -p '/goal ...'` is not a reliable slash-command smoke path.
+- Stops refreshing the latest active hidden goal continuation during provider-context rewriting, preserving prompt-cache stability while still superseding older continuations.
 
 ## 0.1.16 - 2026-05-28
 

--- a/src/queued-goal-work.ts
+++ b/src/queued-goal-work.ts
@@ -1,9 +1,4 @@
-import {
-  compactContinuationPrompt,
-  continuationGoalIdFromPrompt,
-  continuationPrompt,
-  supersededContinuationMessage,
-} from "./prompts.js";
+import { continuationGoalIdFromPrompt, supersededContinuationMessage } from "./prompts.js";
 import {
   isActiveGoalQueuedDetails,
   type QueuedGoalContextCarrier,
@@ -50,22 +45,11 @@ interface StaleQueuedGoalUserMessage extends QueuedGoalUserMessage {
   content: QueuedGoalTextPart[];
 }
 
-interface RefreshedActiveQueuedGoalCustomMessage extends QueuedGoalCustomMessage {
-  content: string;
-  display: false;
-}
-
-interface RefreshedActiveQueuedGoalUserMessage extends QueuedGoalUserMessage {
-  content: QueuedGoalTextPart[];
-}
-
 type RewrittenQueuedGoalWorkMessage =
   | SupersededQueuedGoalCustomMessage
   | SupersededQueuedGoalUserMessage
   | StaleQueuedGoalCustomMessage
-  | StaleQueuedGoalUserMessage
-  | RefreshedActiveQueuedGoalCustomMessage
-  | RefreshedActiveQueuedGoalUserMessage;
+  | StaleQueuedGoalUserMessage;
 
 type ProviderContextRewrite<TMessage extends QueuedGoalContextInput> =
   TMessage & RewrittenQueuedGoalWorkMessage;
@@ -164,20 +148,6 @@ function supersededContinuationContextMessage(
   };
 }
 
-function continuationPromptForProviderContext(
-  goal: ThreadGoal,
-  message: Pick<QueuedGoalWorkSourceMessage, "details">,
-): string {
-  if (isActiveGoalQueuedDetails(message.details)) {
-    const kind = message.details.kind;
-    if (kind === "command_start" || kind === "command_resume") {
-      return continuationPrompt(goal);
-    }
-  }
-
-  return compactContinuationPrompt(goal);
-}
-
 function dedupeActiveGoalContinuations<TMessage extends QueuedGoalContextInput>(
   messages: readonly TMessage[],
   goal: ThreadGoal,
@@ -220,43 +190,6 @@ function dedupeActiveGoalContinuations<TMessage extends QueuedGoalContextInput>(
     const rewritten = supersededContinuationContextMessage(source, activeGoalId);
     nextMessages[index] = mergeProviderContextMessage(message, rewritten);
     changed = true;
-  }
-
-  const latestMessage = nextMessages[latestIndex];
-  if (!latestMessage) {
-    return { messages: nextMessages, changed };
-  }
-  const latestCarrier = toQueuedGoalContextCarrier(latestMessage);
-  if (!latestCarrier) {
-    return { messages: nextMessages, changed };
-  }
-  const latestSource = toQueuedGoalWorkSource(latestCarrier);
-  if (!latestSource) {
-    return { messages: nextMessages, changed };
-  }
-
-  const refreshedContent = continuationPromptForProviderContext(goal, latestSource);
-  if (latestSource.role === "custom") {
-    if (latestMessage.content !== refreshedContent) {
-      const refreshed: RefreshedActiveQueuedGoalCustomMessage = {
-        ...latestSource,
-        content: refreshedContent,
-        display: false,
-      };
-      nextMessages[latestIndex] = mergeProviderContextMessage(latestMessage, refreshed);
-      changed = true;
-    }
-  } else {
-    const refreshedUserContent: QueuedGoalTextPart[] = [{ type: "text", text: refreshedContent }];
-    const currentContent = textContentFromMessageContent(latestMessage.content);
-    if (currentContent !== refreshedContent) {
-      const refreshed: RefreshedActiveQueuedGoalUserMessage = {
-        ...latestSource,
-        content: refreshedUserContent,
-      };
-      nextMessages[latestIndex] = mergeProviderContextMessage(latestMessage, refreshed);
-      changed = true;
-    }
   }
 
   return { messages: nextMessages, changed };

--- a/test/provider-context.test.ts
+++ b/test/provider-context.test.ts
@@ -18,7 +18,7 @@ import {
   requireProviderContextResult,
 } from "./support/runtime-harness.js";
 
-test("provider context dedupes many active continuations to one refreshed prompt", async () => {
+test("provider context dedupes many active continuations without refreshing the latest prompt", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");
   const goal = harness.snapshot().goal;
@@ -64,8 +64,8 @@ test("provider context dedupes many active continuations to one refreshed prompt
   assert.match(String(providerContextMessageAt(result, 1).content), /Superseded hidden goal continuation bookkeeping/);
 
   const latestContent = String(providerContextMessageAt(result, 2).content);
-  assert.match(latestContent, /Tokens used: 0/);
-  assert.match(latestContent, /Time spent pursuing goal: 0s/);
+  assert.match(latestContent, /Tokens used: 99/);
+  assert.match(latestContent, /Time spent pursuing goal: 42s/);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
   assert.doesNotMatch(latestContent, /<untrusted_objective>/);
 });
@@ -125,7 +125,7 @@ test("active provider-context dedupe preserves historical user marker mixed with
   assert.match(String(userContentFromUnknown(providerContextMessageAt(result, 1).content)[0]?.text), /<untrusted_objective>/);
 
   const latestContent = String(providerContextMessageAt(result, 2).content);
-  assert.match(latestContent, /Tokens used: 0/);
+  assert.match(latestContent, /Tokens used: 99/);
   assert.doesNotMatch(latestContent, /<untrusted_objective>/);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
 });
@@ -204,7 +204,7 @@ test("active goal provider-context dedupe preserves pasted marker input mixed wi
   assert.match(String(providerContextMessageAt(result, 0).content), /Superseded hidden goal continuation bookkeeping/);
 
   const latestContent = String(providerContextMessageAt(result, 2).content);
-  assert.match(latestContent, /Tokens used: 0/);
+  assert.match(latestContent, /Tokens used: 99/);
   assert.doesNotMatch(latestContent, /<untrusted_objective>/);
   assert.equal(continuationGoalIdFromPrompt(latestContent), goal.goalId);
 });

--- a/test/queued-goal-work.test.ts
+++ b/test/queued-goal-work.test.ts
@@ -70,7 +70,7 @@ test("applyQueuedGoalProviderContextRewrites rewrites stale custom and user queu
   assert.match(String(userContentFromUnknown(userResult.messages[0]?.content)[0]?.text), /queued hidden goal continuation was stale/);
 });
 
-test("applyQueuedGoalProviderContextRewrites supersedes older custom continuations and refreshes the latest", () => {
+test("applyQueuedGoalProviderContextRewrites supersedes older custom continuations without refreshing the latest", () => {
   const older = goalCustomContextMessage({
     content: continuationPrompt(activeGoal),
     details: { kind: "continuation", goalId: activeGoal.goalId },
@@ -98,7 +98,7 @@ test("applyQueuedGoalProviderContextRewrites supersedes older custom continuatio
     kind: "superseded_continuation",
     goalId: activeGoal.goalId,
   });
-  assert.match(String(messages[1]?.content), /Tokens used: 0/);
+  assert.match(String(messages[1]?.content), /Tokens used: 99/);
 });
 
 test("applyQueuedGoalProviderContextRewrites marks stale continuations for completed goals", () => {


### PR DESCRIPTION
## Summary
- Stop rewriting the latest active hidden goal continuation during provider-context dedupe.
- Keep superseding older active continuations and keep stale-goal cancellation rewrites intact.
- Update provider-context tests so the latest continuation keeps its original dynamic budget text instead of being refreshed every context build.

Closes #35

## Behavior changes
- Hidden active goal continuations keep stable prompt content once queued, improving provider prompt-cache prefix stability.
- Models can still call `get_goal` when they need current usage/status; older active continuations are still compacted to bookkeeping markers.

## Validation
- `git diff --check`
- `npm run verify` — `tsc --noEmit` and 284 Node tests passed
- `npm pack --dry-run --json`
- DeepSeek real smoke: `pi --model deepseek/deepseek-v4-pro --no-session --mode json -p 'Reply exactly: PI_DEEPSEEK_OK'` succeeded; repeat call showed prompt-cache reuse (second run usage: input 10, cacheRead 27008)
- Reviewer subagent: NO FINDINGS

## Risks/notes
- This fixes the extension-controlled cache-instability source identified in provider-context rewriting. It does not claim to control unrelated provider-side cache behavior.