### PR TITLE
Add Crabbox platform smoke release gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@ npm-debug.log*
 *.tsbuildinfo
 coverage/
 dist/
+.artifacts/
+.platform-smoke-runs/
 .scratchpad.md
 .DS_Store
 .debug/
+.crabbox/
 
 # CueLoop local/runtime state (do not commit)
 .cueloop/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,18 @@ Pi extension: Codex-style `/goal` command and `get_goal` / `create_goal` / `upda
 npm run verify
 ```
 
-Runs `tsc --noEmit` and the full Node test suite (`test/*.test.ts`).
+Runs `tsc --noEmit`, the platform-smoke harness checks, and the full Node test suite (`test/*.test.ts`).
+
+For release-sensitive changes, also use the local Crabbox platform gate documented in `docs/platform-smoke.md`:
+
+```sh
+npm run check:platform-smoke
+npm run smoke:platform:all
+```
+
+`smoke:platform:all` runs `smoke:platform:doctor` before any target suite starts.
+
+The required gate runs the full suite plus a real model-backed goal-tool smoke on macOS, Ubuntu Linux, and native Windows. The default smoke model is `zai/glm-5.1`; override with `PLATFORM_SMOKE_MODEL` when needed.
 
 ## Layout
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.1.21 - 2026-06-01
+
+- Add a Crabbox-backed release gate for macOS, Ubuntu Linux, and native Windows.
+- Prove releases through packed package install, `pi install`, `pi list`, and a real model-backed goal runtime smoke on every required platform.
+- Add `check:platform-smoke` to the normal verification path and make `smoke:platform:all` run doctor before any target suite.
+- Strengthen platform doctor checks for Crabbox providers, Windows Parallels template/snapshot readiness, repository hygiene, package contents, auth presence, artifact redaction, and lease cleanup evidence.
+
 ## 0.1.20 - 2026-05-31
 
 - Defer active-goal continuations queued by `session_compact` until the compaction event has unwound, avoiding nested prompt/auto-compaction races in Pi’s compaction lifecycle.

--- a/README.md
+++ b/README.md
@@ -68,28 +68,34 @@ Validate types and tests before committing or opening a PR:
 npm run verify
 ```
 
+Cross-platform release-sensitive changes should also pass the local Crabbox platform smoke gate:
+
+```sh
+npm run check:platform-smoke
+npm run smoke:platform:all
+```
+
+`smoke:platform:all` runs the doctor before any target suite.
+
+That gate runs `npm run verify`, packs the package, installs the packed package into a clean pi project, checks `pi list`, and runs a real model-backed goal-tool smoke on macOS, Ubuntu Linux, and native Windows. The runtime smoke defaults to `zai/glm-5.1`; override it with `PLATFORM_SMOKE_MODEL` and configure forwarded auth env vars with `PLATFORM_SMOKE_AUTH_ENV`. Setup and artifact details: [docs/platform-smoke.md](docs/platform-smoke.md).
+
 Project agent notes and module map: [AGENTS.md](AGENTS.md).
 Latest structural audit: [docs/CODEBASE_AUDIT.md](docs/CODEBASE_AUDIT.md).
 
-## Smoke test with Cursor Composer 2.5
+## Interactive smoke test
 
 This smoke test exercises the interactive `/goal` command, hidden continuation, bridged goal tools, filesystem verification, and final `update_goal` completion.
 
 Prerequisites:
 
-- Pi can authenticate to Cursor, for example through a Cursor User API Key.
-- Cursor Composer 2.5 is available:
-
-```sh
-pi --list-models cursor 2>&1 | rg 'composer-2[.-]5'
-```
+- Pi can authenticate to any capable model available in your local setup.
 
 Start pi from this repository:
 
 ```sh
 rm -f /tmp/pi-codex-goal-slash-smoke.txt
 rm -rf /tmp/pi-codex-goal-slash-smoke-session
-pi --model cursor/composer-2-5 --cursor-no-fast \
+pi --model <model-id> \
   --session-dir /tmp/pi-codex-goal-slash-smoke-session
 ```
 
@@ -136,7 +142,7 @@ This intentionally matches Codex TUI behavior: token budgets are set through the
 
 Completed goals are terminal for automatic transitions: pause, resume, and hidden continuations do not reopen them. To recover from premature completion, use `/goal <objective>` to replace the goal or `/goal clear` before starting again.
 
-In bridged MCP environments such as `pi-cursor-sdk`, pi may expose these tools under namespaced MCP names like `pi__get_goal`, `pi__create_goal`, and `pi__update_goal`. Prompt guidance tells models to call whichever goal-tool name is actually exposed in the current run, not display or transcript labels.
+In bridged MCP environments, pi may expose these tools under namespaced MCP names like `pi__get_goal`, `pi__create_goal`, and `pi__update_goal`. Prompt guidance tells models to call whichever goal-tool name is actually exposed in the current run, not display or transcript labels.
 
 ## Behavior
 

--- a/docs/CODEBASE_AUDIT.md
+++ b/docs/CODEBASE_AUDIT.md
@@ -78,7 +78,7 @@ Coverage is **integration-heavy** via `test/support/runtime-harness.ts` and scen
 
 ```text
 [🔵 Low] [Operability] .gitignore
-- Problem: Local `.debug/` (Cursor SDK event dumps) was not ignored.
+- Problem: Local `.debug/` runtime/debug artifacts were not ignored.
 - Impact: Risk of accidental commit of session debug artifacts.
 - Fix: Ignore `.debug/` (this PR).
 ```

--- a/docs/platform-smoke.md
+++ b/docs/platform-smoke.md
@@ -1,0 +1,138 @@
+# Platform smoke testing
+
+`pi-codex-goal` uses a Crabbox-backed local platform smoke gate to prove the package on macOS, Ubuntu Linux, and native Windows before release-sensitive changes ship.
+
+This setup reuses the portable Crabbox platform-testing lessons without copying provider-specific smoke flows from another project. The gate includes a real model-backed pi run so release checks catch platform-specific extension failures before completion is claimed.
+
+## Required gate
+
+Run the cheap harness checks first, then the required full gate:
+
+```sh
+npm run check:platform-smoke
+npm run smoke:platform:all
+```
+
+`smoke:platform:all` runs `smoke:platform:doctor` before any target suite starts. Use `smoke:platform:doctor` directly when diagnosing local setup without spending model tokens.
+
+Per-target commands are for diagnosis:
+
+```sh
+npm run smoke:platform:macos
+npm run smoke:platform:ubuntu
+npm run smoke:platform:windows-native
+```
+
+## Targets
+
+| Target | Crabbox provider | Shell contract |
+| --- | --- | --- |
+| `macos` | `ssh` static localhost | POSIX shell on macOS |
+| `ubuntu` | `local-container` | POSIX shell in an Ubuntu Node container |
+| `windows-native` | `parallels` | native Windows PowerShell |
+
+## Required environment
+
+Install Crabbox with Homebrew so `crabbox` is on `PATH`. Use `PLATFORM_SMOKE_CRABBOX=/path/to/crabbox` only when testing a non-default binary.
+
+```sh
+PLATFORM_SMOKE_MAC_HOST=localhost
+PLATFORM_SMOKE_MAC_USER="$USER"
+PLATFORM_SMOKE_MAC_WORK_ROOT="/Users/$USER/crabbox/pi-codex-goal"
+PLATFORM_SMOKE_UBUNTU_IMAGE="cimg/node:24.16"
+
+PLATFORM_SMOKE_WINDOWS_VM="pi-extension-windows-template"
+PLATFORM_SMOKE_WINDOWS_SNAPSHOT="crabbox-ready"
+PLATFORM_SMOKE_WINDOWS_USER="<windows-ssh-user>"
+PLATFORM_SMOKE_WINDOWS_WORK_ROOT="C:\\crabbox\\pi-codex-goal"
+
+# Real runtime smoke defaults.
+PLATFORM_SMOKE_MODEL="zai/glm-5.1"
+PLATFORM_SMOKE_AUTH_ENV="ZAI_API_KEY,Z_AI_API_KEY"
+```
+
+Use `PLATFORM_SMOKE_MODEL` to run the real runtime smoke against another provider/model, and `PLATFORM_SMOKE_AUTH_ENV` to tell Crabbox which auth variables to forward to each target.
+
+The doctor fails when any required platform setup is missing. It verifies the Crabbox binary/version, `ssh`, `local-container`, and `parallels` provider availability, provider-specific readiness, Docker, macOS SSH, Windows source VM/snapshot state, artifact-root writability, forbidden source/package artifacts, and model auth presence. It also fails when the real runtime smoke suite is required and none of the configured model auth environment variables is present.
+
+For Windows, `pi-extension-windows-template` must be stopped and `crabbox-ready` must be a known-good power-off snapshot. If a reusable Windows tool is missing, update the template and refresh/promote `crabbox-ready`; do not add one-off installers to per-run smoke scripts.
+
+## What the suites prove
+
+Each required target runs `platform-build` and `goal-runtime-smoke`.
+
+### `platform-build`
+
+1. Verify Node major version is at least the configured validation baseline.
+2. Run `npm ci` in the synced checkout.
+3. Run `npm run verify`, the repo's local CI command.
+4. Run `npm pack`.
+5. Create a clean target-local pi project.
+6. Install the packed tarball into that project with `npm install --no-save`.
+7. Run `pi install -l ./node_modules/pi-codex-goal` from the clean project.
+8. Run `pi list` and assert `pi-codex-goal` is registered from the packed install.
+9. Assert the smoke never used the source shortcut `pi -e .` or `pi --extension .`.
+
+### `goal-runtime-smoke`
+
+1. Re-pack and install the package into a clean target-local pi project.
+2. Run real `pi --model <model> -p <prompt>` against that packed install.
+3. Prompt the model to call the actual goal tools, create and verify a marker file, call `update_goal`, and confirm completion.
+4. Capture pi stdout/stderr and session JSONL.
+5. Assert the final marker, verified file, `pi-codex-goal` custom entries, and complete goal status.
+
+## Artifact contract
+
+Every target writes artifacts under:
+
+```text
+.artifacts/platform-smoke/<run-id>/<target>/<suite>/
+```
+
+Required files include:
+
+```text
+summary.json
+artifact-manifest.json
+target.json
+suite.json
+command.txt
+exit-code.txt
+crabbox.stdout.txt
+crabbox.stderr.txt
+crabbox.timing.json
+node-version.txt
+packed-tarball.txt
+packed-node-install.stdout.txt
+packed-node-install.stderr.txt
+pi-install.stdout.txt
+pi-install.stderr.txt
+pi-list.stdout.txt
+pi-list.stderr.txt
+assertions.json
+failures.md            # only when assertions fail
+```
+
+`goal-runtime-smoke` also writes `goal-runtime-result.json`, `pi-run.stdout.txt`, `pi-run.stderr.txt`, and `session.jsonl`.
+
+The suites record failures as artifacts before reporting failure so the host can inspect the real target evidence. Each target also writes a `lease-cleanup` artifact directory with `crabbox.stop.*` files; cleanup failure is a failing test result. Ubuntu and Windows runs also invoke Crabbox cleanup for stale direct-provider state after stopping the owned lease.
+
+## Lessons carried forward
+
+- Use Crabbox targets instead of a one-OS local script.
+- Keep platform-specific shell rendering explicit: POSIX for macOS/Ubuntu and PowerShell for native Windows.
+- Run the repository's existing validation command on every required target.
+- Test the packed package, not `pi -e .`.
+- Include a real model-backed pi run so release claims are not based on unit tests alone.
+- Make doctor fail before expensive or long target runs, and enforce doctor-before-all in the release entrypoint.
+- Preserve artifacts on failure and use `assertions.json` as the pass/fail source of truth.
+- Record lease stop evidence for every target and fail cleanup problems.
+- Treat missing platform setup as blocked, not skipped-ready.
+- Redact persisted artifacts and fail scans that find raw secret values.
+
+## Source of truth
+
+- Config: [`platform-smoke.config.mjs`](../platform-smoke.config.mjs)
+- CLI: [`scripts/platform-smoke.mjs`](../scripts/platform-smoke.mjs)
+- Target commands: [`scripts/platform-smoke/targets.mjs`](../scripts/platform-smoke/targets.mjs)
+- Windows suite body: [`scripts/platform-smoke/platform-build-windows.ps1`](../scripts/platform-smoke/platform-build-windows.ps1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-codex-goal",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "0.78.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "files": [
     "src",
     "docs",
+    "scripts",
     "AGENTS.md",
     "prompts",
+    "platform-smoke.config.mjs",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"
@@ -42,7 +44,14 @@
   "scripts": {
     "test": "node --import tsx --test test/*.test.ts",
     "typecheck": "tsc --noEmit",
-    "verify": "npm run typecheck && npm test"
+    "check:platform-smoke": "node --check scripts/platform-smoke.mjs && node --check scripts/platform-smoke/artifacts.mjs && node --check scripts/platform-smoke/crabbox-runner.mjs && node --check scripts/platform-smoke/doctor.mjs && node --check scripts/platform-smoke/goal-runtime-smoke.mjs && node --check scripts/platform-smoke/targets.mjs && node --import tsx --test test/platform-smoke.test.ts",
+    "verify": "npm run typecheck && npm run check:platform-smoke && npm test",
+    "smoke:platform": "node scripts/platform-smoke.mjs",
+    "smoke:platform:doctor": "node scripts/platform-smoke.mjs doctor",
+    "smoke:platform:macos": "node scripts/platform-smoke.mjs run --target macos",
+    "smoke:platform:ubuntu": "node scripts/platform-smoke.mjs run --target ubuntu",
+    "smoke:platform:windows-native": "node scripts/platform-smoke.mjs run --target windows-native",
+    "smoke:platform:all": "npm run smoke:platform:doctor && node scripts/platform-smoke.mjs run --target macos,ubuntu,windows-native"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Codex-style goal tracking and continuation for pi.",
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",

--- a/platform-smoke.config.mjs
+++ b/platform-smoke.config.mjs
@@ -1,0 +1,18 @@
+// Platform smoke configuration for pi-codex-goal.
+// Reuses the portable Crabbox cross-platform testing lessons while keeping
+// this package's smoke gate focused on build, verify, pack, and installed pi package behavior.
+
+export default {
+	packageName: "pi-codex-goal",
+	artifactRoot: ".artifacts/platform-smoke",
+	requiredTargets: ["macos", "ubuntu", "windows-native"],
+	requiredSuites: ["platform-build", "goal-runtime-smoke"],
+	defaultModel: "zai/glm-5.1",
+	defaultAuthEnv: ["ZAI_API_KEY", "Z_AI_API_KEY"],
+	requiredCrabbox: {
+		install: "Homebrew package or PLATFORM_SMOKE_CRABBOX override",
+		minVersion: "0.24.0",
+	},
+	ubuntuContainerImage: "cimg/node:24.16",
+	nodeValidationMajor: 24,
+};

--- a/scripts/platform-smoke.mjs
+++ b/scripts/platform-smoke.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const require = createRequire(import.meta.url);
+
+let config;
+try {
+	config = require(resolve(repoRoot, "platform-smoke.config.mjs"));
+	if (config.default) config = config.default;
+} catch (error) {
+	config = null;
+}
+
+function printHelp() {
+	console.log(`Usage: node scripts/platform-smoke.mjs <command> [options]
+
+Commands:
+  doctor                     Validate Crabbox and platform prerequisites; spends no model tokens
+  run --target <names>       Run one or more comma-separated targets concurrently
+
+Package scripts:
+  check:platform-smoke       Syntax-check harness scripts and run cheap harness invariant tests
+  smoke:platform:all         Runs doctor first, then the full macOS/Ubuntu/Windows matrix
+  run --suite <name>         Run one suite on all or specified targets
+
+Targets:
+  macos, ubuntu, windows-native
+
+Suites:
+  platform-build             npm ci, npm run verify, npm pack, packed pi install, pi list
+  goal-runtime-smoke         real model run through packed pi-codex-goal install
+
+Options:
+  --target <names>           Comma-separated target names
+  --suite <name>             Suite name; defaults to configured required suites
+  --help, -h                 Show this help
+
+Examples:
+  npm run check:platform-smoke
+  npm run smoke:platform:doctor
+  npm run smoke:platform:all
+  node scripts/platform-smoke.mjs doctor
+  node scripts/platform-smoke.mjs run --target macos
+  node scripts/platform-smoke.mjs run --target ubuntu --suite platform-build
+  node scripts/platform-smoke.mjs run --target macos,ubuntu,windows-native
+
+Environment:
+  PLATFORM_SMOKE_CRABBOX              Optional Crabbox binary override; defaults to crabbox on PATH
+  PLATFORM_SMOKE_MAC_HOST             macOS SSH host; default localhost
+  PLATFORM_SMOKE_MAC_USER             macOS SSH user; default $USER
+  PLATFORM_SMOKE_MAC_WORK_ROOT        macOS Crabbox work root
+  PLATFORM_SMOKE_UBUNTU_IMAGE         Ubuntu local-container image
+  PLATFORM_SMOKE_WINDOWS_VM           Parallels Windows template VM
+  PLATFORM_SMOKE_WINDOWS_SNAPSHOT     Parallels snapshot name
+  PLATFORM_SMOKE_WINDOWS_USER         Windows SSH user
+  PLATFORM_SMOKE_WINDOWS_WORK_ROOT    Windows work root, for example C:\\crabbox\\pi-codex-goal
+  PLATFORM_SMOKE_MODEL                Model for real runtime smoke; default zai/glm-5.1
+  PLATFORM_SMOKE_AUTH_ENV             Comma-separated auth env names to forward; default ZAI_API_KEY,Z_AI_API_KEY
+`);
+}
+
+function parseArgs(argv) {
+	const parsed = { command: null, target: null, suite: null, rest: [] };
+	for (let i = 2; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--help" || arg === "-h") {
+			parsed.command = "help";
+			return parsed;
+		}
+		if (arg === "doctor" || arg === "run") {
+			parsed.command = arg;
+			continue;
+		}
+		if (arg === "--target" && argv[i + 1]) {
+			parsed.target = argv[i + 1];
+			i += 1;
+			continue;
+		}
+		if (arg === "--suite" && argv[i + 1]) {
+			parsed.suite = argv[i + 1];
+			i += 1;
+			continue;
+		}
+		parsed.rest.push(arg);
+	}
+	return parsed;
+}
+
+function validateNames(kind, names, allowed) {
+	const invalid = names.filter((name) => !allowed.includes(name));
+	if (invalid.length > 0) throw new Error(`unknown ${kind}: ${invalid.join(", ")}`);
+}
+
+async function main() {
+	const args = parseArgs(process.argv);
+	if (!args.command || args.command === "help") {
+		printHelp();
+		process.exit(args.command === "help" ? 0 : 1);
+	}
+	if (!config) throw new Error("platform-smoke.config.mjs not found or invalid");
+
+	if (args.command === "doctor") {
+		const { runDoctor } = await import("./platform-smoke/doctor.mjs");
+		await runDoctor(config);
+		return;
+	}
+
+	if (args.command === "run") {
+		const { runTargetSuite, runTargetSuites } = await import("./platform-smoke/targets.mjs");
+		const targets = args.target ? args.target.split(",").map((name) => name.trim()).filter(Boolean) : config.requiredTargets;
+		const suites = args.suite ? [args.suite] : config.requiredSuites;
+		const supportedTargets = config.supportedTargets ?? config.requiredTargets;
+		validateNames("target", targets, supportedTargets);
+		validateNames("suite", suites, config.requiredSuites);
+		const runs = targets.map(async (targetName) => {
+			console.log(`\n=== Target: ${targetName} ===`);
+			const result = args.suite
+				? await runTargetSuite(config, targetName, suites[0])
+				: await runTargetSuites(config, targetName, suites);
+			return { targetName, result };
+		});
+		const results = await Promise.all(runs);
+		const failed = results.filter(({ result }) => !result.ok);
+		if (failed.length > 0) {
+			console.error(`\nPlatform smoke failed for ${failed.map(({ targetName }) => targetName).join(", ")}. See ${config.artifactRoot}.`);
+			process.exitCode = 1;
+		}
+		return;
+	}
+
+	throw new Error(`unknown command: ${args.command}`);
+}
+
+main().catch((error) => {
+	console.error(error.message);
+	process.exit(1);
+});

--- a/scripts/platform-smoke/artifacts.mjs
+++ b/scripts/platform-smoke/artifacts.mjs
@@ -1,0 +1,94 @@
+/** Artifact helpers for platform smoke suites. */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+export function createSuiteDir(artifactRoot, runId, targetName, suiteName) {
+	const dir = resolve(process.cwd(), artifactRoot, runId, targetName, suiteName);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+export function writeCommand(dir, command) {
+	writeFileSync(resolve(dir, "command.txt"), `${command}\n`);
+}
+
+export function writeExitCode(dir, code, signal) {
+	writeFileSync(resolve(dir, "exit-code.txt"), `code=${code}\nsignal=${signal ?? "none"}\n`);
+}
+
+export function writeSummary(dir, data) {
+	writeFileSync(resolve(dir, "summary.json"), JSON.stringify({ ...data, writtenAt: new Date().toISOString() }, null, 2));
+}
+
+export function writeManifest(dir, expectedFiles) {
+	const present = [];
+	function walk(current) {
+		for (const entry of readdirSync(current, { withFileTypes: true })) {
+			const path = resolve(current, entry.name);
+			if (entry.isDirectory()) walk(path);
+			else if (entry.isFile()) present.push(relative(dir, path));
+		}
+	}
+	if (existsSync(dir)) walk(dir);
+	const allPresent = [...new Set([...present, "artifact-manifest.json"])].sort();
+	const manifest = {
+		expected: expectedFiles,
+		present: allPresent,
+		missing: expectedFiles.filter((file) => !allPresent.includes(file)),
+		writtenAt: new Date().toISOString(),
+	};
+	writeFileSync(resolve(dir, "artifact-manifest.json"), JSON.stringify(manifest, null, 2));
+	return manifest;
+}
+
+export function collectSecretValues(envNames, env = process.env) {
+	return [...new Set(envNames.map((name) => env[name]).filter((value) => typeof value === "string" && value.length >= 8))];
+}
+
+export function redactSecrets(text, secretValues = []) {
+	let redacted = String(text ?? "");
+	for (const secret of secretValues) {
+		redacted = redacted.split(secret).join("[REDACTED_SECRET]");
+	}
+	return redacted;
+}
+
+export function scanForSecrets(text, secretValues = []) {
+	const content = String(text ?? "");
+	const violations = [];
+	for (const secret of secretValues) {
+		if (secret && content.includes(secret)) violations.push("raw forwarded secret value");
+	}
+	for (const [pattern, label] of [
+		[/bearer\s+[A-Za-z0-9\-._~+/]{20,}=*/gi, "bearer token"],
+		[/Authorization:\s*Bearer\s+[A-Za-z0-9\-._~+/]{20,}=*/gi, "authorization header"],
+		[/(?:api[_-]?key|access[_-]?token|refresh[_-]?token|cookie)\s*[:=]\s*["']?[A-Za-z0-9_./+\-=]{20,}/gi, "token-like field"],
+	]) {
+		if (pattern.test(content)) violations.push(label);
+	}
+	return [...new Set(violations)];
+}
+
+export function scanArtifactTextFiles(dir, secretValues = []) {
+	const findings = [];
+	function walk(current) {
+		for (const entry of readdirSync(current, { withFileTypes: true })) {
+			const path = resolve(current, entry.name);
+			if (entry.isDirectory()) {
+				walk(path);
+				continue;
+			}
+			if (!entry.isFile()) continue;
+			if (!/\.(?:txt|json|jsonl|md|log|ps1|mjs|js)$/i.test(entry.name)) continue;
+			try {
+				const text = readFileSync(path, "utf8");
+				for (const violation of scanForSecrets(text, secretValues)) findings.push({ file: relative(dir, path), violation });
+			} catch {
+				// Ignore unreadable or non-text files.
+			}
+		}
+	}
+	walk(dir);
+	return findings;
+}

--- a/scripts/platform-smoke/crabbox-runner.mjs
+++ b/scripts/platform-smoke/crabbox-runner.mjs
@@ -1,0 +1,139 @@
+/** Thin Crabbox CLI wrapper for cross-platform smoke tests. */
+
+import { spawn } from "node:child_process";
+
+function env(name) {
+	return process.env[name] ?? "";
+}
+
+export function crabboxBin() {
+	return process.env.PLATFORM_SMOKE_CRABBOX || "crabbox";
+}
+
+function packageSlug() {
+	return process.env.PLATFORM_SMOKE_PACKAGE_SLUG || "pi-codex-goal";
+}
+
+export function buildTargetBaseArgs(targetName) {
+	switch (targetName) {
+		case "macos": {
+			const user = env("PLATFORM_SMOKE_MAC_USER") || env("USER");
+			const host = env("PLATFORM_SMOKE_MAC_HOST") || "localhost";
+			const workRoot = env("PLATFORM_SMOKE_MAC_WORK_ROOT") || `/Users/${user}/crabbox/${packageSlug()}`;
+			return [
+				"--provider", "ssh",
+				"--target", "macos",
+				"--static-host", host,
+				"--static-user", user,
+				"--static-port", "22",
+				"--static-work-root", workRoot,
+			];
+		}
+		case "ubuntu": {
+			const image = env("PLATFORM_SMOKE_UBUNTU_IMAGE") || "cimg/node:24.16";
+			return [
+				"--provider", "local-container",
+				"--target", "linux",
+				"--local-container-image", image,
+			];
+		}
+		case "windows-native": {
+			const vm = env("PLATFORM_SMOKE_WINDOWS_VM") || "pi-extension-windows-template";
+			const snapshot = env("PLATFORM_SMOKE_WINDOWS_SNAPSHOT") || "crabbox-ready";
+			const user = env("PLATFORM_SMOKE_WINDOWS_USER") || env("USER");
+			const workRoot = env("PLATFORM_SMOKE_WINDOWS_WORK_ROOT") || `C:\\crabbox\\${packageSlug()}`;
+			return [
+				"--provider", "parallels",
+				"--target", "windows",
+				"--windows-mode", "normal",
+				"--parallels-source", vm,
+				"--parallels-source-snapshot", snapshot,
+				"--parallels-user", user,
+				"--parallels-work-root", workRoot,
+			];
+		}
+		default:
+			throw new Error(`unknown platform smoke target: ${targetName}`);
+	}
+}
+
+export function leaseIdFor(targetName, slug) {
+	if (targetName === "macos") return "static_localhost";
+	return slug;
+}
+
+function parseLeaseId(text) {
+	return text.match(/\bleased\s+(\S+)/)?.[1]
+		?? text.match(/\blease=(\S+)/)?.[1]
+		?? null;
+}
+
+export function execCrabbox(args, options = {}) {
+	return new Promise((resolvePromise) => {
+		const child = spawn(crabboxBin(), args, {
+			stdio: ["ignore", "pipe", "pipe"],
+			env: { ...process.env, CRABBOX_SYNC_GIT_SEED: "false", ...options.env },
+		});
+		const stdout = [];
+		const stderr = [];
+		let timeout;
+		let killTimeout;
+		if (options.timeout) {
+			timeout = setTimeout(() => {
+				stderr.push(Buffer.from(`\n[platform-smoke] crabbox timed out after ${options.timeout}ms\n`));
+				try { child.kill("SIGTERM"); } catch {}
+				killTimeout = setTimeout(() => {
+					try { child.kill("SIGKILL"); } catch {}
+				}, 10_000);
+			}, options.timeout);
+		}
+		child.stdout.on("data", (chunk) => stdout.push(chunk));
+		child.stderr.on("data", (chunk) => stderr.push(chunk));
+		child.on("error", (error) => {
+			if (timeout) clearTimeout(timeout);
+			if (killTimeout) clearTimeout(killTimeout);
+			resolvePromise({ stdout: Buffer.concat(stdout).toString(), stderr: `${Buffer.concat(stderr).toString()}${error.message}\n`, code: 1, signal: null });
+		});
+		child.on("close", (code, signal) => {
+			if (timeout) clearTimeout(timeout);
+			if (killTimeout) clearTimeout(killTimeout);
+			resolvePromise({ stdout: Buffer.concat(stdout).toString(), stderr: Buffer.concat(stderr).toString(), code: code ?? (signal ? 1 : 0), signal });
+		});
+	});
+}
+
+export async function warmupLease(targetName, slug) {
+	const args = ["warmup", ...buildTargetBaseArgs(targetName), "--slug", slug, "--keep"];
+	console.log(`  [crabbox] ${args.join(" ")}`);
+	const result = await execCrabbox(args, { timeout: 300_000 });
+	return {
+		...result,
+		ok: result.code === 0,
+		leaseId: parseLeaseId(`${result.stdout}\n${result.stderr}`) ?? leaseIdFor(targetName, slug),
+	};
+}
+
+export async function runOnLease(targetName, leaseId, command, options = {}) {
+	const args = ["run", ...buildTargetBaseArgs(targetName), "--id", leaseId];
+	for (const name of options.allowEnv ?? []) {
+		args.push("--allow-env", name);
+	}
+	if (options.sync === false) args.push("--no-sync");
+	else args.push("--fresh-sync");
+	args.push("--shell", command);
+	console.log(`  [crabbox] run ${targetName} ${options.sync === false ? "--no-sync" : "--fresh-sync"}`);
+	return execCrabbox(args, { timeout: options.timeout ?? 900_000 });
+}
+
+export async function stopLease(targetName, leaseId) {
+	const args = ["stop", ...buildTargetBaseArgs(targetName), "--id", leaseId];
+	console.log(`  [crabbox] ${args.join(" ")}`);
+	return execCrabbox(args, { timeout: 90_000 });
+}
+
+export async function cleanupStaleTargetState(targetName) {
+	if (targetName === "macos") return null;
+	const args = ["cleanup", ...buildTargetBaseArgs(targetName)];
+	console.log(`  [crabbox] ${args.join(" ")}`);
+	return execCrabbox(args, { timeout: 120_000 });
+}

--- a/scripts/platform-smoke/doctor.mjs
+++ b/scripts/platform-smoke/doctor.mjs
@@ -1,0 +1,299 @@
+/** Platform smoke doctor. Fails before target runs when Crabbox/platform setup is missing. */
+
+import { execFileSync, execSync } from "node:child_process";
+import { accessSync, constants, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { resolve } from "node:path";
+
+function env(name) {
+	return process.env[name] ?? "";
+}
+
+function ok(label) {
+	console.log(`  ✓ ${label}`);
+}
+
+function warn(label) {
+	console.log(`  ⚠ ${label}`);
+}
+
+function fail(label, failures) {
+	console.error(`  ✗ ${label}`);
+	failures.count += 1;
+}
+
+function silent(cmd, args, options = {}) {
+	try {
+		return execFileSync(cmd, args, { timeout: 20_000, stdio: "pipe", ...options }).toString().trim();
+	} catch {
+		return null;
+	}
+}
+
+function shell(command, options = {}) {
+	try {
+		return execSync(command, { timeout: 20_000, stdio: "pipe", ...options }).toString().trim();
+	} catch {
+		return null;
+	}
+}
+
+function hasCommand(name) {
+	return silent("which", [name]) !== null;
+}
+
+function commandPath(name) {
+	return silent("which", [name]);
+}
+
+function parseVersion(version) {
+	const match = String(version).match(/\d+(?:\.\d+){0,2}/);
+	return match ? match[0].split(".").map((part) => Number(part)) : null;
+}
+
+function versionAtLeast(actual, minimum) {
+	const parsedActual = parseVersion(actual);
+	const parsedMinimum = parseVersion(minimum);
+	if (!parsedActual || !parsedMinimum) return false;
+	for (let i = 0; i < Math.max(parsedActual.length, parsedMinimum.length); i += 1) {
+		const a = parsedActual[i] ?? 0;
+		const b = parsedMinimum[i] ?? 0;
+		if (a > b) return true;
+		if (a < b) return false;
+	}
+	return true;
+}
+
+function isForbiddenProjectPath(path) {
+	return /(^|\/)\.env(?:\..*)?$/.test(path)
+		|| /(^|\/)[^/]+\.tgz$/.test(path)
+		|| /(^|\/)\.artifacts(?:\/|$)/.test(path)
+		|| /(^|\/)\.crabbox(?:\/|$)/.test(path)
+		|| /(^|\/)\.debug(?:\/|$)/.test(path);
+}
+
+function npmPackFiles() {
+	const output = silent("npm", ["pack", "--dry-run", "--json"]);
+	if (!output) return null;
+	try {
+		const parsed = JSON.parse(output);
+		return parsed[0]?.files?.map((file) => file.path) ?? [];
+	} catch {
+		return null;
+	}
+}
+
+function checkForbiddenProjectFiles(failures) {
+	const tracked = shell("git ls-files")?.split(/\r?\n/).filter(Boolean) ?? [];
+	const trackedForbidden = tracked.filter(isForbiddenProjectPath);
+	if (trackedForbidden.length === 0) ok("tracked source files exclude forbidden local artifacts");
+	else fail(`forbidden tracked source path(s): ${trackedForbidden.join(", ")}`, failures);
+
+	const localForbidden = shell("find . -maxdepth 2 \\( -name '.env' -o -name '.env.*' -o -name '*.tgz' \\) -not -path './node_modules/*' 2>/dev/null")
+		?.split(/\r?\n/).filter(Boolean) ?? [];
+	if (localForbidden.length === 0) ok("no local .env or package tarball artifacts at repo top level");
+	else fail(`forbidden local artifact(s): ${localForbidden.join(", ")}`, failures);
+
+	const packFiles = npmPackFiles();
+	if (!packFiles) {
+		fail("could not inspect npm pack contents", failures);
+		return;
+	}
+	const packedForbidden = packFiles.filter(isForbiddenProjectPath);
+	if (packedForbidden.length === 0) ok("npm package excludes forbidden local artifacts");
+	else fail(`forbidden npm package path(s): ${packedForbidden.join(", ")}`, failures);
+}
+
+function crabboxProviders(cbox) {
+	const output = silent(cbox, ["providers"]);
+	if (!output) return [];
+	return output.split(/\r?\n/)
+		.filter((line) => /^\S/.test(line))
+		.map((line) => line.trim().split(/\s+/)[0])
+		.filter(Boolean);
+}
+
+function checkRequiredProviders(cbox, failures) {
+	const providers = crabboxProviders(cbox);
+	if (providers.length === 0) {
+		fail("could not read crabbox providers", failures);
+		return;
+	}
+	for (const provider of ["ssh", "local-container", "parallels"]) {
+		if (providers.includes(provider)) ok(`crabbox provider available: ${provider}`);
+		else fail(`crabbox provider missing: ${provider}`, failures);
+	}
+}
+
+function checkCrabboxProvider(cbox, args, label, failures) {
+	const output = silent(cbox, ["doctor", ...args, "--json"]);
+	if (!output) {
+		fail(`${label} crabbox doctor failed`, failures);
+		return;
+	}
+	try {
+		const parsed = JSON.parse(output);
+		if (parsed.ok) ok(`${label} provider OK`);
+		else fail(`${label} provider not ready: ${parsed.error ?? "unknown error"}`, failures);
+	} catch {
+		warn(`${label} provider returned non-JSON doctor output`);
+	}
+}
+
+export async function runDoctor(config) {
+	const failures = { count: 0 };
+	const packageName = config?.packageName ?? "pi-codex-goal";
+	const artifactRoot = config?.artifactRoot ?? ".artifacts/platform-smoke";
+	const nodeMajor = config?.nodeValidationMajor ?? 24;
+
+	console.log("\n── Platform smoke config ──");
+	ok(`package: ${packageName}`);
+	ok(`targets: ${(config?.requiredTargets ?? []).join(", ")}`);
+	ok(`suites: ${(config?.requiredSuites ?? []).join(", ")}`);
+
+	console.log("\n── Crabbox binary ──");
+	const cbox = env("PLATFORM_SMOKE_CRABBOX") || "crabbox";
+	const cboxPath = env("PLATFORM_SMOKE_CRABBOX") || commandPath("crabbox");
+	if (!cboxPath) {
+		fail("crabbox not found on PATH; install with Homebrew or set PLATFORM_SMOKE_CRABBOX", failures);
+	} else {
+		if (env("PLATFORM_SMOKE_CRABBOX")) {
+			try {
+				accessSync(cboxPath, constants.X_OK);
+				ok(`binary: ${cboxPath}`);
+			} catch {
+				fail(`${cboxPath} is not executable`, failures);
+			}
+		} else {
+			ok(`binary: ${cboxPath}`);
+		}
+		const version = silent(cbox, ["--version"]);
+		if (version) {
+			const displayVersion = version.split(/\r?\n/)[0];
+			ok(`version: ${displayVersion}`);
+			const minVersion = config?.requiredCrabbox?.minVersion;
+			if (minVersion) {
+				if (versionAtLeast(displayVersion, minVersion)) ok(`version ${displayVersion} >= ${minVersion}`);
+				else fail(`Crabbox version ${displayVersion} < ${minVersion}`, failures);
+			}
+		} else {
+			fail("could not read Crabbox version", failures);
+		}
+	}
+
+	console.log("\n── Model smoke configuration ──");
+	const model = process.env.PLATFORM_SMOKE_MODEL || config?.defaultModel || "zai/glm-5.1";
+	const authEnv = (process.env.PLATFORM_SMOKE_AUTH_ENV
+		? process.env.PLATFORM_SMOKE_AUTH_ENV.split(",")
+		: (config?.defaultAuthEnv ?? ["ZAI_API_KEY", "Z_AI_API_KEY"])
+	).map((name) => String(name).trim()).filter(Boolean);
+	ok(`model: ${model}`);
+	if ((config?.requiredSuites ?? []).includes("goal-runtime-smoke")) {
+		const presentAuth = authEnv.filter((name) => env(name).length > 0);
+		if (presentAuth.length > 0) ok(`auth env present: ${presentAuth.map((name) => `${name}=(present, redacted)`).join(", ")}`);
+		else fail(`no model auth env present; set one of ${authEnv.join(", ")} or PLATFORM_SMOKE_AUTH_ENV`, failures);
+	}
+
+	console.log("\n── Host tools ──");
+	for (const [name, command] of [["node", "node --version"], ["npm", "npm --version"], ["git", "git --version"], ["tar", "tar --version"]]) {
+		const output = shell(command);
+		if (!output) fail(`${name} not found`, failures);
+		else ok(`${name}: ${output.split(/\r?\n/)[0]}`);
+	}
+	const localNode = shell("node --version");
+	const localNodeMajor = Number(localNode?.replace(/^v/, "").split(".")[0] ?? 0);
+	if (localNodeMajor >= nodeMajor) ok(`host Node major ${localNodeMajor} >= ${nodeMajor}`);
+	else fail(`host Node major ${localNodeMajor || "unknown"} < ${nodeMajor}`, failures);
+
+	console.log("\n── Crabbox providers ──");
+	if (cboxPath) {
+		checkRequiredProviders(cbox, failures);
+		const ubuntuImage = env("PLATFORM_SMOKE_UBUNTU_IMAGE") || config?.ubuntuContainerImage || "cimg/node:24.16";
+		checkCrabboxProvider(cbox, ["--provider", "local-container", "--local-container-image", ubuntuImage], "ubuntu local-container", failures);
+		const macUser = env("PLATFORM_SMOKE_MAC_USER") || env("USER");
+		const macHost = env("PLATFORM_SMOKE_MAC_HOST") || "localhost";
+		const macRoot = env("PLATFORM_SMOKE_MAC_WORK_ROOT") || `/Users/${macUser}/crabbox/${packageName}`;
+		checkCrabboxProvider(cbox, ["--provider", "ssh", "--target", "macos", "--static-host", macHost, "--static-user", macUser, "--static-port", "22", "--static-work-root", macRoot], "macOS ssh", failures);
+	}
+
+	console.log("\n── Docker / Ubuntu ──");
+	const dockerVersion = shell("docker info --format '{{.ServerVersion}}'");
+	if (dockerVersion) ok(`Docker ${dockerVersion}`);
+	else fail("Docker is not available or not running", failures);
+
+	console.log("\n── macOS SSH ──");
+	const sshUser = env("PLATFORM_SMOKE_MAC_USER") || env("USER");
+	const sshHost = env("PLATFORM_SMOKE_MAC_HOST") || "localhost";
+	const sshProbe = shell(`ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no ${sshUser}@${sshHost} 'node --version && npm --version && git --version'`);
+	if (sshProbe) ok(`SSH ${sshUser}@${sshHost}: ${sshProbe.split(/\r?\n/).join(" | ")}`);
+	else fail(`SSH probe failed for ${sshUser}@${sshHost}`, failures);
+
+	if ((config?.requiredTargets ?? []).includes("windows-native")) {
+		console.log("\n── Windows native / Parallels ──");
+		if (!hasCommand("prlctl")) {
+			fail("prlctl not found", failures);
+		} else {
+			ok("prlctl found");
+			const vmName = env("PLATFORM_SMOKE_WINDOWS_VM") || "pi-extension-windows-template";
+			const snapshot = env("PLATFORM_SMOKE_WINDOWS_SNAPSHOT") || "crabbox-ready";
+			const user = env("PLATFORM_SMOKE_WINDOWS_USER") || env("USER");
+			const workRoot = env("PLATFORM_SMOKE_WINDOWS_WORK_ROOT") || `C:\\crabbox\\${packageName}`;
+			const list = shell("prlctl list -a --no-header 2>/dev/null");
+			if (!list) {
+				fail("prlctl list returned no VMs", failures);
+			} else if (!list.includes(vmName)) {
+				fail(`Windows VM ${vmName} not found`, failures);
+			} else {
+				ok(`Windows VM ${vmName} found`);
+				const status = shell(`prlctl status "${vmName.replace(/"/g, "\\\"")}" 2>/dev/null`);
+				if (/\bstopped\b/i.test(status ?? "")) ok(`Windows source VM ${vmName} is stopped`);
+				else fail(`Windows source VM ${vmName} must be stopped for forkable snapshot use; current status: ${status ?? "unknown"}`, failures);
+				const snapshotsJson = shell(`prlctl snapshot-list "${vmName.replace(/"/g, "\\\"")}" -j 2>/dev/null`);
+				let snapshotMatch = null;
+				try {
+					const snapshots = JSON.parse(snapshotsJson ?? "{}");
+					snapshotMatch = Object.entries(snapshots).find(([id, data]) => id === snapshot || data?.name === snapshot);
+				} catch {
+					// Fall through to the failure below.
+				}
+				if (snapshotMatch) {
+					ok(`snapshot ${snapshot} found`);
+					const snapshotState = snapshotMatch[1]?.state ?? "unknown";
+					if (snapshotState === "poweroff") ok(`snapshot ${snapshot} state is poweroff`);
+					else fail(`snapshot ${snapshot} must be poweroff; current snapshot state: ${snapshotState}`, failures);
+				} else {
+					fail(`snapshot ${snapshot} not found on ${vmName}`, failures);
+				}
+				checkCrabboxProvider(cbox, ["--provider", "parallels", "--target", "windows", "--windows-mode", "normal", "--parallels-source", vmName, "--parallels-source-snapshot", snapshot, "--parallels-user", user, "--parallels-work-root", workRoot], "windows parallels", failures);
+			}
+		}
+	} else {
+		console.log("\n── Windows native / Parallels ──");
+		warn("windows-native is not listed in requiredTargets for this configuration");
+	}
+
+	console.log("\n── Artifact root ──");
+	const artRoot = resolve(process.cwd(), artifactRoot);
+	try {
+		mkdirSync(artRoot, { recursive: true });
+		const probe = resolve(artRoot, ".doctor-write-test");
+		writeFileSync(probe, "ok");
+		unlinkSync(probe);
+		ok(`writable: ${artRoot}`);
+	} catch (error) {
+		fail(`artifact root not writable: ${error.message}`, failures);
+	}
+
+	console.log("\n── Repository hygiene ──");
+	const status = shell("git status --short");
+	if (status) warn(`${status.split(/\r?\n/).length} uncommitted change(s) recorded for smoke evidence`);
+	else ok("git status clean");
+	checkForbiddenProjectFiles(failures);
+
+	console.log(`\n=== Results: ${failures.count} failure(s) ===`);
+	if (failures.count > 0) {
+		console.log("Fix doctor failures before running smoke:platform:all.");
+		process.exitCode = 1;
+	} else {
+		console.log("Platform smoke setup is ready.");
+	}
+}

--- a/scripts/platform-smoke/goal-runtime-smoke.mjs
+++ b/scripts/platform-smoke/goal-runtime-smoke.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function parseArgs(argv) {
+	const args = { model: "zai/glm-5.1", packageName: "pi-codex-goal" };
+	for (let i = 2; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === "--help" || arg === "-h") {
+			console.log(`Usage: node scripts/platform-smoke/goal-runtime-smoke.mjs --model <model> --package-name <name>`);
+			process.exit(0);
+		}
+		if (arg === "--model" && argv[i + 1]) {
+			args.model = argv[++i];
+			continue;
+		}
+		if (arg === "--package-name" && argv[i + 1]) {
+			args.packageName = argv[++i];
+			continue;
+		}
+		throw new Error(`unknown argument: ${arg}`);
+	}
+	return args;
+}
+
+function commandName(name) {
+	return process.platform === "win32" ? `${name}.cmd` : name;
+}
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		cwd: options.cwd,
+		env: { ...process.env, ...options.env },
+		encoding: "utf8",
+		maxBuffer: 20 * 1024 * 1024,
+		shell: process.platform === "win32" && command.toLowerCase().endsWith(".cmd"),
+	});
+	return {
+		command: [command, ...args].join(" "),
+		cwd: options.cwd,
+		status: result.status ?? 1,
+		signal: result.signal,
+		stdout: result.stdout ?? "",
+		stderr: result.stderr ?? (result.error?.message ?? ""),
+	};
+}
+
+function section(name, text) {
+	console.log(`--- ${name} START ---`);
+	if (text) process.stdout.write(text.endsWith("\n") ? text : `${text}\n`);
+	console.log(`--- ${name} END ---`);
+}
+
+function b64(text) {
+	return Buffer.from(text ?? "", "utf8").toString("base64");
+}
+
+function walkFiles(root) {
+	const files = [];
+	function visit(dir) {
+		let entries = [];
+		try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+		for (const entry of entries) {
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) visit(path);
+			else if (entry.isFile()) files.push(path);
+		}
+	}
+	visit(root);
+	return files;
+}
+
+function findSessionJsonl(sessionDir) {
+	const candidates = walkFiles(sessionDir).filter((file) => file.endsWith(".jsonl"));
+	let best = "";
+	let bestScore = -1;
+	for (const file of candidates) {
+		let text = "";
+		try { text = readFileSync(file, "utf8"); } catch { continue; }
+		const score = (text.includes("pi-codex-goal") ? 10_000 : 0) + text.length;
+		if (score > bestScore) {
+			best = file;
+			bestScore = score;
+		}
+	}
+	return best;
+}
+
+function latestPackedTarball(packDir, packageName) {
+	const files = readdirSync(packDir)
+		.filter((file) => file.startsWith(`${packageName}-`) && file.endsWith(".tgz"))
+		.map((file) => join(packDir, file));
+	files.sort();
+	return files.at(-1) ?? "";
+}
+
+const args = parseArgs(process.argv);
+const sourceRoot = process.cwd();
+const runId = `goal-runtime-smoke-${new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14)}-${process.pid}`;
+const runRoot = resolve(sourceRoot, ".platform-smoke-runs", runId);
+const packDir = join(runRoot, "pack");
+const piProject = join(runRoot, "pi-project");
+const sessionDir = join(runRoot, "session");
+const agentDir = join(runRoot, "agent-config");
+const smokeFile = join(piProject, "goal-runtime-smoke.txt");
+mkdirSync(packDir, { recursive: true });
+mkdirSync(piProject, { recursive: true });
+mkdirSync(sessionDir, { recursive: true });
+mkdirSync(agentDir, { recursive: true });
+
+const npm = commandName("npm");
+const piCli = resolve(sourceRoot, "node_modules", ".bin", process.platform === "win32" ? "pi.cmd" : "pi");
+const piJs = resolve(sourceRoot, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+const piCommand = existsSync(piJs) ? process.execPath : (existsSync(piCli) ? piCli : "pi");
+const piPrefixArgs = existsSync(piJs) ? [piJs] : [];
+const piEnv = { PI_CODING_AGENT_DIR: agentDir, PI_OFFLINE: "1" };
+
+const commands = [];
+const pack = run(npm, ["pack", "--silent", "--pack-destination", packDir], { cwd: sourceRoot });
+commands.push({ name: "npm-pack", ...pack });
+const packedTarball = latestPackedTarball(packDir, args.packageName) || join(packDir, pack.stdout.trim().split(/\r?\n/).at(-1) ?? "");
+
+const npmInit = run(npm, ["init", "-y"], { cwd: piProject });
+commands.push({ name: "npm-init", ...npmInit });
+const npmInstall = run(npm, ["install", "--no-save", packedTarball], { cwd: piProject });
+commands.push({ name: "npm-install-packed", ...npmInstall });
+const installPath = `.${process.platform === "win32" ? "\\" : "/"}node_modules${process.platform === "win32" ? "\\" : "/"}${args.packageName}`;
+const piInstall = run(piCommand, [...piPrefixArgs, "install", "-l", installPath], { cwd: piProject, env: piEnv });
+commands.push({ name: "pi-install", ...piInstall });
+const piList = run(piCommand, [...piPrefixArgs, "list"], { cwd: piProject, env: piEnv });
+commands.push({ name: "pi-list", ...piList });
+
+const expectedContent = "PI_CODEX_GOAL_RUNTIME_OK";
+const prompt = `You are running a real cross-platform smoke test for the pi-codex-goal extension.
+Do not use slash commands. Use the available goal tools and filesystem tools.
+Required steps:
+1. Call create_goal with an objective that requires creating ${smokeFile} containing ${expectedContent}, verifying the file content from the filesystem, inspecting the current goal, and marking it complete only after verification.
+2. Create ${smokeFile} with exactly ${expectedContent}.
+3. Verify the file content by reading it from the filesystem.
+4. Call get_goal and confirm the goal is active before completion.
+5. Call update_goal with status complete only after the file content is verified.
+6. Call get_goal again and confirm the final status is complete.
+Final answer exactly: GOAL_RUNTIME_SMOKE_OK status=complete file=${expectedContent}`;
+
+const piRun = run(piCommand, [...piPrefixArgs, "--model", args.model, "--session-dir", sessionDir, "--no-context-files", "-p", prompt], { cwd: piProject, env: piEnv });
+commands.push({ name: "pi-run", ...piRun });
+
+let fileContent = "";
+try { fileContent = readFileSync(smokeFile, "utf8").trim(); } catch {}
+const sessionJsonlPath = findSessionJsonl(sessionDir);
+let sessionJsonl = "";
+try { sessionJsonl = readFileSync(sessionJsonlPath, "utf8"); } catch {}
+const finalMarkerObserved = piRun.stdout.includes(`GOAL_RUNTIME_SMOKE_OK status=complete file=${expectedContent}`);
+const customGoalObserved = sessionJsonl.includes("pi-codex-goal");
+const completeGoalObserved = sessionJsonl.includes('"status":"complete"') || sessionJsonl.includes('"status": "complete"');
+const fileVerified = fileContent === expectedContent;
+const ok = pack.status === 0
+	&& npmInit.status === 0
+	&& npmInstall.status === 0
+	&& piInstall.status === 0
+	&& piList.status === 0
+	&& piRun.status === 0
+	&& finalMarkerObserved
+	&& customGoalObserved
+	&& completeGoalObserved
+	&& fileVerified;
+
+const result = {
+	ok,
+	model: args.model,
+	packageName: args.packageName,
+	runRoot,
+	piProject,
+	sessionDir,
+	agentDir,
+	sessionJsonlPath,
+	smokeFile,
+	packedTarball,
+	checks: {
+		npmPack: pack.status === 0,
+		npmInit: npmInit.status === 0,
+		npmInstallPacked: npmInstall.status === 0,
+		piInstall: piInstall.status === 0,
+		piList: piList.status === 0 && piList.stdout.includes(args.packageName),
+		piRun: piRun.status === 0,
+		finalMarkerObserved,
+		customGoalObserved,
+		completeGoalObserved,
+		fileVerified,
+	},
+	commands: commands.map((command) => ({ name: command.name, command: command.command, cwd: command.cwd, status: command.status, signal: command.signal })),
+};
+
+console.log(`PLATFORM_GOAL_RUNTIME_MODEL=${args.model}`);
+console.log(`PLATFORM_GOAL_RUNTIME_RUN_ROOT=${runRoot}`);
+console.log(`PLATFORM_GOAL_RUNTIME_PACKED_TARBALL=${packedTarball}`);
+console.log(`PLATFORM_GOAL_RUNTIME_PI_EXIT=${piRun.status}`);
+console.log(`PLATFORM_GOAL_RUNTIME_OK=${ok ? 1 : 0}`);
+console.log("PLATFORM_GOAL_RUNTIME_JSON_START");
+console.log(JSON.stringify(result, null, 2));
+console.log("PLATFORM_GOAL_RUNTIME_JSON_END");
+section("NPM_PACK_STDOUT", pack.stdout);
+section("NPM_PACK_STDERR", pack.stderr);
+section("PACKED_NODE_INSTALL_STDOUT", npmInstall.stdout);
+section("PACKED_NODE_INSTALL_STDERR", npmInstall.stderr);
+section("PI_INSTALL_STDOUT", piInstall.stdout);
+section("PI_INSTALL_STDERR", piInstall.stderr);
+section("PI_LIST_STDOUT", piList.stdout);
+section("PI_LIST_STDERR", piList.stderr);
+section("PI_RUN_STDOUT", piRun.stdout);
+section("PI_RUN_STDERR", piRun.stderr);
+section("SESSION_JSONL_B64", b64(sessionJsonl));
+
+if (ok) {
+	console.log("GOAL_RUNTIME_SMOKE_OK");
+} else {
+	console.log("GOAL_RUNTIME_SMOKE_FAILED");
+	process.exit(1);
+}

--- a/scripts/platform-smoke/platform-build-windows.ps1
+++ b/scripts/platform-smoke/platform-build-windows.ps1
@@ -1,0 +1,111 @@
+param(
+  [Parameter(Mandatory=$true)][string]$PackageName,
+  [Parameter(Mandatory=$true)][int]$NodeValidationMajor
+)
+
+$ErrorActionPreference = "Continue"
+$SourceRoot = (Get-Location).Path
+$RunRoot = Join-Path ".platform-smoke-runs" ("platform-build-{0}-{1}" -f ((Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")), $PID)
+$PackDir = Join-Path $SourceRoot (Join-Path $RunRoot "pack")
+$TestWorkspace = Join-Path $SourceRoot (Join-Path $RunRoot "test-workspace")
+$PiProject = Join-Path $SourceRoot (Join-Path $RunRoot "pi-project")
+New-Item -ItemType Directory -Force -Path $PackDir, $TestWorkspace, $PiProject | Out-Null
+
+function Write-Section($Name, $Path) {
+  Write-Output "--- $Name START ---"
+  if (Test-Path $Path) { Get-Content -Raw $Path }
+  Write-Output "--- $Name END ---"
+}
+
+Write-Output "Starting platform-build in $SourceRoot at $((Get-Date).ToUniversalTime().ToString('o'))"
+Write-Output "PLATFORM_RUN_ROOT=$RunRoot"
+
+$NodeVersion = (& node --version 2>$null)
+$NodeMajor = 0
+if ($NodeVersion -match '^v?(\d+)\.') { $NodeMajor = [int]$Matches[1] }
+Write-Output "PLATFORM_NODE_VERSION=$NodeVersion"
+$NodeVersionExit = if ($NodeMajor -ge $NodeValidationMajor) { 0 } else { 1 }
+Write-Output "PLATFORM_NODE_VERSION_EXIT=$NodeVersionExit"
+
+& npm ci 2>&1
+$NpmCiExit = $LASTEXITCODE
+Write-Output "PLATFORM_NPM_CI_EXIT=$NpmCiExit"
+
+& npm run verify 2>&1
+$VerifyExit = $LASTEXITCODE
+Write-Output "PLATFORM_VERIFY_EXIT=$VerifyExit"
+
+$PackStderr = Join-Path $PackDir "npm-pack.stderr.txt"
+$PackOutput = (& npm pack --silent --pack-destination $PackDir 2>$PackStderr)
+$PackExit = $LASTEXITCODE
+$PackTarball = ($PackOutput | Select-Object -Last 1)
+$PackFile = if ($PackTarball) { Join-Path $PackDir $PackTarball } else { "" }
+if (Test-Path $PackStderr) { Get-Content -Raw $PackStderr }
+Write-Output "PLATFORM_NPM_PACK_EXIT=$PackExit"
+Write-Output "PLATFORM_PACKED_TARBALL=$PackFile"
+
+Copy-Item package.json, README.md -Destination $TestWorkspace -ErrorAction SilentlyContinue
+$FixtureCopyExit = if ($?) { 0 } else { 1 }
+Copy-Item src, prompts -Destination $TestWorkspace -Recurse -ErrorAction SilentlyContinue
+$FixtureTreeExit = if ($?) { 0 } else { 1 }
+$FixtureExit = if ($FixtureCopyExit -eq 0 -and $FixtureTreeExit -eq 0) { 0 } else { 1 }
+Write-Output "PLATFORM_FIXTURE_EXIT=$FixtureExit"
+
+$PiCli = Join-Path $SourceRoot "node_modules/.bin/pi.cmd"
+if (-not (Test-Path $PiCli)) { $PiCli = Join-Path $SourceRoot "node_modules/.bin/pi" }
+if (-not (Test-Path $PiCli)) { $PiCli = "pi" }
+Write-Output "PLATFORM_PI_CLI=$PiCli"
+
+$PackedNodeInstallStdout = Join-Path $PackDir "packed-node-install.stdout.txt"
+$PackedNodeInstallStderr = Join-Path $PackDir "packed-node-install.stderr.txt"
+if ($PackFile -and (Test-Path $PackFile)) {
+  Push-Location $PiProject
+  & npm init -y >$PackedNodeInstallStdout 2>$PackedNodeInstallStderr
+  if ($LASTEXITCODE -eq 0) {
+    & npm install --no-save $PackFile >>$PackedNodeInstallStdout 2>>$PackedNodeInstallStderr
+  }
+  $PackedNodeInstallExit = $LASTEXITCODE
+  Pop-Location
+} else {
+  "missing tarball" | Set-Content $PackedNodeInstallStderr
+  $PackedNodeInstallExit = 1
+}
+Write-Output "PLATFORM_PACKED_NODE_INSTALL_EXIT=$PackedNodeInstallExit"
+Write-Section "PACKED_NODE_INSTALL_STDOUT" $PackedNodeInstallStdout
+Write-Section "PACKED_NODE_INSTALL_STDERR" $PackedNodeInstallStderr
+
+$PiInstallStdout = Join-Path $PackDir "pi-install.stdout.txt"
+$PiInstallStderr = Join-Path $PackDir "pi-install.stderr.txt"
+if ($PackedNodeInstallExit -eq 0) {
+  Push-Location $PiProject
+  $env:PI_OFFLINE = "1"
+  & $PiCli install -l ".\node_modules\$PackageName" >$PiInstallStdout 2>$PiInstallStderr
+  $PiInstallExit = $LASTEXITCODE
+  Remove-Item Env:\PI_OFFLINE -ErrorAction SilentlyContinue
+  Pop-Location
+} else {
+  "packed npm install failed" | Set-Content $PiInstallStderr
+  $PiInstallExit = 1
+}
+Write-Output "PLATFORM_PI_INSTALL_EXIT=$PiInstallExit"
+Write-Section "PI_INSTALL_STDOUT" $PiInstallStdout
+Write-Section "PI_INSTALL_STDERR" $PiInstallStderr
+
+$PiListStdout = Join-Path $PackDir "pi-list.stdout.txt"
+$PiListStderr = Join-Path $PackDir "pi-list.stderr.txt"
+Push-Location $PiProject
+$env:PI_OFFLINE = "1"
+& $PiCli list >$PiListStdout 2>$PiListStderr
+$PiListExit = $LASTEXITCODE
+Remove-Item Env:\PI_OFFLINE -ErrorAction SilentlyContinue
+Pop-Location
+Write-Output "PLATFORM_PI_LIST_EXIT=$PiListExit"
+Write-Section "PI_LIST_STDOUT" $PiListStdout
+Write-Section "PI_LIST_STDERR" $PiListStderr
+
+if ($NodeVersionExit -ne 0 -or $NpmCiExit -ne 0 -or $VerifyExit -ne 0 -or $PackExit -ne 0 -or $FixtureExit -ne 0 -or $PackedNodeInstallExit -ne 0 -or $PiInstallExit -ne 0 -or $PiListExit -ne 0) {
+  Write-Output "PLATFORM_BUILD_FAILED"
+  exit 1
+}
+
+Write-Output "PLATFORM_BUILD_OK"

--- a/scripts/platform-smoke/targets.mjs
+++ b/scripts/platform-smoke/targets.mjs
@@ -1,0 +1,420 @@
+/** Target/suite runner for pi-codex-goal platform smoke. */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { collectSecretValues, createSuiteDir, redactSecrets, scanArtifactTextFiles, scanForSecrets, writeCommand, writeExitCode, writeManifest, writeSummary } from "./artifacts.mjs";
+import { cleanupStaleTargetState, runOnLease, stopLease, warmupLease } from "./crabbox-runner.mjs";
+
+export function platformFor(targetName) {
+	return targetName === "windows-native" ? "powershell" : "posix";
+}
+
+function makeRunId() {
+	return `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function shellQuote(value) {
+	return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function psSingleQuote(value) {
+	return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function smokeModel(config) {
+	return process.env.PLATFORM_SMOKE_MODEL || config.defaultModel || "zai/glm-5.1";
+}
+
+function authEnvAllowList(config) {
+	const raw = process.env.PLATFORM_SMOKE_AUTH_ENV;
+	const names = raw ? raw.split(",") : (config.defaultAuthEnv ?? ["ZAI_API_KEY", "Z_AI_API_KEY"]);
+	return names.map((name) => String(name).trim()).filter(Boolean);
+}
+
+function sectionBase64(text, name) {
+	const raw = section(text, name).trim();
+	if (!raw) return "";
+	try {
+		return Buffer.from(raw, "base64").toString("utf8");
+	} catch {
+		return "";
+	}
+}
+
+function writeRedacted(path, text, secretValues) {
+	writeFileSync(path, redactSecrets(text ?? "", secretValues));
+}
+
+function jsonBlock(text, start, end) {
+	const startIndex = text.indexOf(start);
+	if (startIndex === -1) return "";
+	const contentStart = startIndex + start.length;
+	const endIndex = text.indexOf(end, contentStart);
+	return (endIndex === -1 ? text.slice(contentStart) : text.slice(contentStart, endIndex)).trim();
+}
+
+function section(text, name) {
+	const start = `--- ${name} START ---`;
+	const end = `--- ${name} END ---`;
+	const startIndex = text.indexOf(start);
+	if (startIndex === -1) return "";
+	const contentStart = startIndex + start.length;
+	const endIndex = text.indexOf(end, contentStart);
+	return (endIndex === -1 ? text.slice(contentStart) : text.slice(contentStart, endIndex)).replace(/^\r?\n/, "").replace(/\r?\n$/, "");
+}
+
+function marker(text, name) {
+	return text.match(new RegExp(`^${name}=(.*)$`, "m"))?.[1]?.trim() ?? "";
+}
+
+function writeExtracts(suiteDir, stdout, secretValues = []) {
+	writeFileSync(resolve(suiteDir, "node-version.txt"), `${marker(stdout, "PLATFORM_NODE_VERSION")}\n`);
+	writeRedacted(resolve(suiteDir, "packed-tarball.txt"), `${marker(stdout, "PLATFORM_PACKED_TARBALL")}\n`, secretValues);
+	writeRedacted(resolve(suiteDir, "packed-node-install.stdout.txt"), section(stdout, "PACKED_NODE_INSTALL_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "packed-node-install.stderr.txt"), section(stdout, "PACKED_NODE_INSTALL_STDERR"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-install.stdout.txt"), section(stdout, "PI_INSTALL_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-install.stderr.txt"), section(stdout, "PI_INSTALL_STDERR"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-list.stdout.txt"), section(stdout, "PI_LIST_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-list.stderr.txt"), section(stdout, "PI_LIST_STDERR"), secretValues);
+}
+
+function assertionsFromChecks(checks) {
+	const evaluated = checks.map((check) => {
+		let ok = false;
+		let error = check.error;
+		try {
+			ok = check.fn() === true;
+		} catch (err) {
+			error = err.message;
+		}
+		return { id: check.id, ok, ...(ok ? {} : { error: error ?? `${check.id} failed` }) };
+	});
+	return { ok: evaluated.every((check) => check.ok), checks: evaluated, writtenAt: new Date().toISOString() };
+}
+
+function writeAssertions(suiteDir, checks) {
+	const assertions = assertionsFromChecks(checks);
+	writeFileSync(resolve(suiteDir, "assertions.json"), JSON.stringify(assertions, null, 2));
+	if (!assertions.ok) {
+		writeFileSync(resolve(suiteDir, "failures.md"), [
+			`# Platform smoke failures`,
+			"",
+			...assertions.checks.filter((check) => !check.ok).map((check) => `- ${check.id}: ${check.error ?? "failed"}`),
+			"",
+			"Inspect command.txt, crabbox.stdout.txt, and crabbox.stderr.txt in this suite directory.",
+			"",
+		].join("\n"));
+	}
+	return assertions;
+}
+
+function finalizeSuite(suiteDir, checks, summary, expectedFiles) {
+	const assertions = writeAssertions(suiteDir, checks);
+	writeSummary(suiteDir, { ...summary, ok: assertions.ok });
+	const expected = assertions.ok ? expectedFiles : [...expectedFiles, "failures.md"];
+	const manifest = writeManifest(suiteDir, expected);
+	if (manifest.missing.length === 0) return { assertions, manifest };
+	const finalAssertions = writeAssertions(suiteDir, [
+		...checks,
+		{ id: "artifact-manifest-complete", fn: () => false, error: `missing required artifact(s): ${manifest.missing.join(", ")}` },
+	]);
+	writeSummary(suiteDir, { ...summary, ok: false });
+	return { assertions: finalAssertions, manifest: writeManifest(suiteDir, [...expectedFiles, "failures.md"]) };
+}
+
+export function createLeaseCleanupResult(config, targetName, leaseId, stopResult, staleCleanupResult = null) {
+	const suiteName = "lease-cleanup";
+	const runId = makeRunId();
+	const suiteDir = createSuiteDir(config.artifactRoot, runId, targetName, suiteName);
+	const secretValues = collectSecretValues(authEnvAllowList(config));
+	writeFileSync(resolve(suiteDir, "target.json"), JSON.stringify({ targetName, platform: platformFor(targetName), runId, slug: `${config.packageName}-${targetName}` }, null, 2));
+	writeFileSync(resolve(suiteDir, "suite.json"), JSON.stringify({ suiteName, leaseId, modelCalls: 0 }, null, 2));
+	writeCommand(suiteDir, `crabbox stop ${targetName} --id ${leaseId}`);
+	writeExitCode(suiteDir, stopResult.code, stopResult.signal);
+	writeRedacted(resolve(suiteDir, "crabbox.stop.stdout.txt"), stopResult.stdout ?? "", secretValues);
+	writeRedacted(resolve(suiteDir, "crabbox.stop.stderr.txt"), stopResult.stderr ?? "", secretValues);
+	writeFileSync(resolve(suiteDir, "crabbox.stop.exit-code.txt"), `code=${stopResult.code}\nsignal=${stopResult.signal ?? "none"}\n`);
+	if (staleCleanupResult) {
+		writeRedacted(resolve(suiteDir, "crabbox.cleanup.stdout.txt"), staleCleanupResult.stdout ?? "", secretValues);
+		writeRedacted(resolve(suiteDir, "crabbox.cleanup.stderr.txt"), staleCleanupResult.stderr ?? "", secretValues);
+		writeFileSync(resolve(suiteDir, "crabbox.cleanup.exit-code.txt"), `code=${staleCleanupResult.code}\nsignal=${staleCleanupResult.signal ?? "none"}\n`);
+	}
+	const secretViolations = [
+		...scanForSecrets(`${stopResult.stdout ?? ""}\n${stopResult.stderr ?? ""}`, secretValues),
+		...scanArtifactTextFiles(suiteDir, secretValues).map((finding) => `${finding.file}: ${finding.violation}`),
+	];
+	const { assertions } = finalizeSuite(
+		suiteDir,
+		[
+			{ id: "lease-cleanup", fn: () => stopResult.code === 0, error: `Crabbox stop failed with exit ${stopResult.code}` },
+			{ id: "stale-cleanup", fn: () => !staleCleanupResult || staleCleanupResult.code === 0, error: `Crabbox cleanup failed with exit ${staleCleanupResult?.code}` },
+			{ id: "no-secret-artifacts", fn: () => secretViolations.length === 0, error: secretViolations.join(", ") },
+		],
+		{ target: targetName, suite: suiteName, exitCode: stopResult.code, signal: stopResult.signal, elapsedMs: 0 },
+		[
+			"summary.json", "artifact-manifest.json", "target.json", "suite.json", "command.txt", "exit-code.txt",
+			"crabbox.stop.stdout.txt", "crabbox.stop.stderr.txt", "crabbox.stop.exit-code.txt",
+			...(staleCleanupResult ? ["crabbox.cleanup.stdout.txt", "crabbox.cleanup.stderr.txt", "crabbox.cleanup.exit-code.txt"] : []),
+			"assertions.json",
+		],
+	);
+	return { ok: assertions.ok, suiteDir, assertions };
+}
+
+export function createLeaseCleanupFailureResult(config, targetName, leaseId, stopResult) {
+	return createLeaseCleanupResult(config, targetName, leaseId, stopResult);
+}
+
+export function buildGoalRuntimeSmokeCommand(config, targetName) {
+	const model = smokeModel(config);
+	const packageName = config.packageName ?? "pi-codex-goal";
+	if (platformFor(targetName) === "powershell") {
+		return `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "node .\\scripts\\platform-smoke\\goal-runtime-smoke.mjs --model ${model.replace(/"/g, "`\"")} --package-name ${packageName.replace(/"/g, "`\"")}"`;
+	}
+	return `node scripts/platform-smoke/goal-runtime-smoke.mjs --model ${shellQuote(model)} --package-name ${shellQuote(packageName)}`;
+}
+
+export function buildPlatformBuildCommand(targetName, packageName = "pi-codex-goal", nodeValidationMajor = 24) {
+	if (platformFor(targetName) === "powershell") {
+		return `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\platform-smoke\\platform-build-windows.ps1 -PackageName ${psSingleQuote(packageName)} -NodeValidationMajor ${nodeValidationMajor}`;
+	}
+
+	const lines = [];
+	lines.push(`echo "Starting platform-build in $(pwd) at $(date -u +%Y-%m-%dT%H:%M:%SZ)"`);
+	lines.push(`RUN_ROOT=".platform-smoke-runs/platform-build-$(date -u +%Y%m%dT%H%M%SZ)-$$"`);
+	lines.push(`SOURCE_ROOT="$(pwd)"`);
+	lines.push(`PACK_DIR="$SOURCE_ROOT/$RUN_ROOT/pack"`);
+	lines.push(`TEST_WORKSPACE="$SOURCE_ROOT/$RUN_ROOT/test-workspace"`);
+	lines.push(`PI_PROJECT="$SOURCE_ROOT/$RUN_ROOT/pi-project"`);
+	lines.push(`mkdir -p "$PACK_DIR" "$TEST_WORKSPACE" "$PI_PROJECT"`);
+	lines.push(`echo "PLATFORM_RUN_ROOT=$RUN_ROOT"`);
+	lines.push(`NODE_VERSION=$(node --version)`);
+	lines.push(`NODE_MAJOR="${"${NODE_VERSION#v}"}"`);
+	lines.push(`NODE_MAJOR="${"${NODE_MAJOR%%.*}"}"`);
+	lines.push(`echo "PLATFORM_NODE_VERSION=$NODE_VERSION"`);
+	lines.push(`if [ "$NODE_MAJOR" -ge ${nodeValidationMajor} ]; then NODE_VERSION_EXIT=0; else NODE_VERSION_EXIT=1; fi`);
+	lines.push(`echo "PLATFORM_NODE_VERSION_EXIT=$NODE_VERSION_EXIT"`);
+	lines.push(`npm ci 2>&1`);
+	lines.push(`NPM_CI_EXIT=$?`);
+	lines.push(`echo "PLATFORM_NPM_CI_EXIT=$NPM_CI_EXIT"`);
+	lines.push(`npm run verify 2>&1`);
+	lines.push(`VERIFY_EXIT=$?`);
+	lines.push(`echo "PLATFORM_VERIFY_EXIT=$VERIFY_EXIT"`);
+	lines.push(`PACK_TARBALL=$(npm pack --silent --pack-destination "$PACK_DIR" 2>"$PACK_DIR/npm-pack.stderr.txt")`);
+	lines.push(`PACK_EXIT=$?`);
+	lines.push(`cat "$PACK_DIR/npm-pack.stderr.txt"`);
+	lines.push(`PACK_FILE="$PACK_DIR/$PACK_TARBALL"`);
+	lines.push(`echo "PLATFORM_NPM_PACK_EXIT=$PACK_EXIT"`);
+	lines.push(`echo "PLATFORM_PACKED_TARBALL=$PACK_FILE"`);
+	lines.push(`cp package.json README.md "$TEST_WORKSPACE"/ 2>"$PACK_DIR/fixture.stderr.txt"`);
+	lines.push(`FIXTURE_COPY_EXIT=$?`);
+	lines.push(`cp -R src prompts "$TEST_WORKSPACE"/ 2>>"$PACK_DIR/fixture.stderr.txt"`);
+	lines.push(`FIXTURE_TREE_EXIT=$?`);
+	lines.push(`if [ "$FIXTURE_COPY_EXIT" -eq 0 ] && [ "$FIXTURE_TREE_EXIT" -eq 0 ]; then FIXTURE_EXIT=0; else FIXTURE_EXIT=1; fi`);
+	lines.push(`echo "PLATFORM_FIXTURE_EXIT=$FIXTURE_EXIT"`);
+	lines.push(`cat "$PACK_DIR/fixture.stderr.txt"`);
+	lines.push(`PI_CLI="$SOURCE_ROOT/node_modules/.bin/pi"`);
+	lines.push(`if [ ! -x "$PI_CLI" ]; then PI_CLI="$(command -v pi || true)"; fi`);
+	lines.push(`echo "PLATFORM_PI_CLI=$PI_CLI"`);
+	lines.push(`if [ -n "$PACK_TARBALL" ] && [ -f "$PACK_FILE" ]; then (cd "$PI_PROJECT" && npm init -y >"$PACK_DIR/packed-node-install.stdout.txt" 2>"$PACK_DIR/packed-node-install.stderr.txt" && npm install --no-save "$PACK_FILE" >>"$PACK_DIR/packed-node-install.stdout.txt" 2>>"$PACK_DIR/packed-node-install.stderr.txt"); PACKED_NODE_INSTALL_EXIT=$?; else echo "missing tarball" >"$PACK_DIR/packed-node-install.stderr.txt"; PACKED_NODE_INSTALL_EXIT=1; fi`);
+	lines.push(`echo "PLATFORM_PACKED_NODE_INSTALL_EXIT=$PACKED_NODE_INSTALL_EXIT"`);
+	lines.push(`echo "--- PACKED_NODE_INSTALL_STDOUT START ---"; cat "$PACK_DIR/packed-node-install.stdout.txt" 2>/dev/null || true; echo "--- PACKED_NODE_INSTALL_STDOUT END ---"`);
+	lines.push(`echo "--- PACKED_NODE_INSTALL_STDERR START ---"; cat "$PACK_DIR/packed-node-install.stderr.txt" 2>/dev/null || true; echo "--- PACKED_NODE_INSTALL_STDERR END ---"`);
+	lines.push(`if [ "$PACKED_NODE_INSTALL_EXIT" -eq 0 ] && [ -n "$PI_CLI" ]; then (cd "$PI_PROJECT" && PI_OFFLINE=1 "$PI_CLI" install -l ./node_modules/${packageName} >"$PACK_DIR/pi-install.stdout.txt" 2>"$PACK_DIR/pi-install.stderr.txt"); PI_INSTALL_EXIT=$?; else echo "missing pi cli or packed install" >"$PACK_DIR/pi-install.stderr.txt"; PI_INSTALL_EXIT=1; fi`);
+	lines.push(`echo "PLATFORM_PI_INSTALL_EXIT=$PI_INSTALL_EXIT"`);
+	lines.push(`echo "--- PI_INSTALL_STDOUT START ---"; cat "$PACK_DIR/pi-install.stdout.txt" 2>/dev/null || true; echo "--- PI_INSTALL_STDOUT END ---"`);
+	lines.push(`echo "--- PI_INSTALL_STDERR START ---"; cat "$PACK_DIR/pi-install.stderr.txt" 2>/dev/null || true; echo "--- PI_INSTALL_STDERR END ---"`);
+	lines.push(`if [ -n "$PI_CLI" ]; then (cd "$PI_PROJECT" && PI_OFFLINE=1 "$PI_CLI" list >"$PACK_DIR/pi-list.stdout.txt" 2>"$PACK_DIR/pi-list.stderr.txt"); PI_LIST_EXIT=$?; else echo "missing pi cli" >"$PACK_DIR/pi-list.stderr.txt"; PI_LIST_EXIT=1; fi`);
+	lines.push(`echo "PLATFORM_PI_LIST_EXIT=$PI_LIST_EXIT"`);
+	lines.push(`echo "--- PI_LIST_STDOUT START ---"; cat "$PACK_DIR/pi-list.stdout.txt" 2>/dev/null || true; echo "--- PI_LIST_STDOUT END ---"`);
+	lines.push(`echo "--- PI_LIST_STDERR START ---"; cat "$PACK_DIR/pi-list.stderr.txt" 2>/dev/null || true; echo "--- PI_LIST_STDERR END ---"`);
+	lines.push(`if [ "$NODE_VERSION_EXIT" -ne 0 ] || [ "$NPM_CI_EXIT" -ne 0 ] || [ "$VERIFY_EXIT" -ne 0 ] || [ "$PACK_EXIT" -ne 0 ] || [ "$FIXTURE_EXIT" -ne 0 ] || [ "$PACKED_NODE_INSTALL_EXIT" -ne 0 ] || [ "$PI_INSTALL_EXIT" -ne 0 ] || [ "$PI_LIST_EXIT" -ne 0 ]; then echo "PLATFORM_BUILD_FAILED"; exit 1; fi`);
+	lines.push(`echo "PLATFORM_BUILD_OK"`);
+	return lines.join("\n");
+}
+
+async function runGoalRuntimeSmokeSuite(config, targetName, suiteName, leaseSession) {
+	const runId = makeRunId();
+	const suiteDir = createSuiteDir(config.artifactRoot, runId, targetName, suiteName);
+	const startedAt = Date.now();
+	const platform = platformFor(targetName);
+	const slug = `${config.packageName}-${targetName}`;
+	const command = buildGoalRuntimeSmokeCommand(config, targetName);
+	writeFileSync(resolve(suiteDir, "target.json"), JSON.stringify({ targetName, platform, runId, slug }, null, 2));
+	writeFileSync(resolve(suiteDir, "suite.json"), JSON.stringify({ suiteName, modelCalls: 1, model: smokeModel(config) }, null, 2));
+	writeCommand(suiteDir, command);
+
+	let lease = leaseSession;
+	const ownsLease = !lease;
+	if (!lease) lease = await warmupLease(targetName, slug);
+	if (!lease.ok) {
+		writeExitCode(suiteDir, lease.code, lease.signal);
+		writeFileSync(resolve(suiteDir, "crabbox.stdout.txt"), lease.stdout ?? "");
+		writeFileSync(resolve(suiteDir, "crabbox.stderr.txt"), lease.stderr ?? "");
+		const { assertions } = finalizeSuite(suiteDir, [{ id: "crabbox-warmup", fn: () => false, error: "Crabbox warmup failed" }], { target: targetName, suite: suiteName, elapsedMs: Date.now() - startedAt }, ["summary.json", "artifact-manifest.json", "target.json", "suite.json", "command.txt", "exit-code.txt", "crabbox.stdout.txt", "crabbox.stderr.txt", "assertions.json"]);
+		return { ok: false, suiteDir, assertions };
+	}
+
+	const allowEnv = authEnvAllowList(config);
+	const secretValues = collectSecretValues(allowEnv);
+	const result = await runOnLease(targetName, lease.leaseId, command, {
+		timeout: 600_000,
+		sync: leaseSession?.sync,
+		allowEnv,
+	});
+	const elapsedMs = Date.now() - startedAt;
+	writeRedacted(resolve(suiteDir, "crabbox.stdout.txt"), result.stdout, secretValues);
+	writeRedacted(resolve(suiteDir, "crabbox.stderr.txt"), result.stderr, secretValues);
+	writeFileSync(resolve(suiteDir, "crabbox.timing.json"), JSON.stringify({ elapsedMs, code: result.code, signal: result.signal }, null, 2));
+	writeExitCode(suiteDir, result.code, result.signal);
+
+	let stopResult;
+	if (ownsLease) {
+		stopResult = await stopLease(targetName, lease.leaseId);
+		writeRedacted(resolve(suiteDir, "crabbox.stop.stdout.txt"), stopResult.stdout, secretValues);
+		writeRedacted(resolve(suiteDir, "crabbox.stop.stderr.txt"), stopResult.stderr, secretValues);
+		writeFileSync(resolve(suiteDir, "crabbox.stop.exit-code.txt"), `code=${stopResult.code}\nsignal=${stopResult.signal ?? "none"}\n`);
+	}
+
+	const resultJsonText = jsonBlock(result.stdout, "PLATFORM_GOAL_RUNTIME_JSON_START", "PLATFORM_GOAL_RUNTIME_JSON_END");
+	let runtimeResult = {};
+	try { runtimeResult = JSON.parse(resultJsonText); } catch {}
+	writeRedacted(resolve(suiteDir, "goal-runtime-result.json"), resultJsonText ? `${resultJsonText}\n` : "{}\n", secretValues);
+	writeFileSync(resolve(suiteDir, "packed-tarball.txt"), `${runtimeResult.packedTarball ?? ""}\n`);
+	writeRedacted(resolve(suiteDir, "npm-pack.stdout.txt"), section(result.stdout, "NPM_PACK_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "npm-pack.stderr.txt"), section(result.stdout, "NPM_PACK_STDERR"), secretValues);
+	writeRedacted(resolve(suiteDir, "packed-node-install.stdout.txt"), section(result.stdout, "PACKED_NODE_INSTALL_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "packed-node-install.stderr.txt"), section(result.stdout, "PACKED_NODE_INSTALL_STDERR"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-install.stdout.txt"), section(result.stdout, "PI_INSTALL_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-install.stderr.txt"), section(result.stdout, "PI_INSTALL_STDERR"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-list.stdout.txt"), section(result.stdout, "PI_LIST_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-list.stderr.txt"), section(result.stdout, "PI_LIST_STDERR"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-run.stdout.txt"), section(result.stdout, "PI_RUN_STDOUT"), secretValues);
+	writeRedacted(resolve(suiteDir, "pi-run.stderr.txt"), section(result.stdout, "PI_RUN_STDERR"), secretValues);
+	writeRedacted(resolve(suiteDir, "session.jsonl"), sectionBase64(result.stdout, "SESSION_JSONL_B64"), secretValues);
+
+	const secretViolations = [
+		...scanForSecrets(`${result.stdout}\n${result.stderr}`, secretValues),
+		...scanArtifactTextFiles(suiteDir, secretValues).map((finding) => `${finding.file}: ${finding.violation}`),
+	];
+	const checks = [
+		{ id: "command-exit-zero", fn: () => result.code === 0, error: `exit ${result.code}` },
+		{ id: "runtime-marker", fn: () => result.stdout.includes("PLATFORM_GOAL_RUNTIME_OK=1") && result.stdout.includes("GOAL_RUNTIME_SMOKE_OK") },
+		{ id: "runtime-result-ok", fn: () => runtimeResult.ok === true },
+		{ id: "model-configured", fn: () => runtimeResult.model === smokeModel(config) },
+		{ id: "pi-run-exit-zero", fn: () => runtimeResult.checks?.piRun === true },
+		{ id: "final-marker", fn: () => runtimeResult.checks?.finalMarkerObserved === true },
+		{ id: "file-verified", fn: () => runtimeResult.checks?.fileVerified === true },
+		{ id: "goal-custom-entry-observed", fn: () => runtimeResult.checks?.customGoalObserved === true },
+		{ id: "goal-complete-observed", fn: () => runtimeResult.checks?.completeGoalObserved === true },
+		{ id: "pi-list-local-package", fn: () => runtimeResult.checks?.piList === true },
+		{ id: "session-jsonl", fn: () => readFileSync(resolve(suiteDir, "session.jsonl"), "utf8").includes("pi-codex-goal") },
+		{ id: "no-secret-artifacts", fn: () => secretViolations.length === 0, error: secretViolations.join(", ") },
+	];
+	if (stopResult) checks.push({ id: "lease-cleanup", fn: () => stopResult.code === 0, error: `stop exit ${stopResult.code}` });
+	const expectedFiles = [
+		"summary.json", "artifact-manifest.json", "target.json", "suite.json", "command.txt", "exit-code.txt", "crabbox.stdout.txt", "crabbox.stderr.txt", "crabbox.timing.json",
+		"goal-runtime-result.json", "packed-tarball.txt", "npm-pack.stdout.txt", "npm-pack.stderr.txt", "packed-node-install.stdout.txt", "packed-node-install.stderr.txt",
+		"pi-install.stdout.txt", "pi-install.stderr.txt", "pi-list.stdout.txt", "pi-list.stderr.txt", "pi-run.stdout.txt", "pi-run.stderr.txt", "session.jsonl", "assertions.json",
+	];
+	if (stopResult) expectedFiles.push("crabbox.stop.stdout.txt", "crabbox.stop.stderr.txt", "crabbox.stop.exit-code.txt");
+	const { assertions } = finalizeSuite(suiteDir, checks, { target: targetName, suite: suiteName, elapsedMs, exitCode: result.code, signal: result.signal, model: smokeModel(config) }, expectedFiles);
+	return { ok: assertions.ok, suiteDir, assertions };
+}
+
+export async function runTargetSuite(config, targetName, suiteName, leaseSession) {
+	if (suiteName === "goal-runtime-smoke") return await runGoalRuntimeSmokeSuite(config, targetName, suiteName, leaseSession);
+	if (suiteName !== "platform-build") throw new Error(`unknown suite: ${suiteName}`);
+	const runId = makeRunId();
+	const suiteDir = createSuiteDir(config.artifactRoot, runId, targetName, suiteName);
+	const startedAt = Date.now();
+	const platform = platformFor(targetName);
+	const slug = `${config.packageName}-${targetName}`;
+	const command = buildPlatformBuildCommand(targetName, config.packageName, config.nodeValidationMajor);
+	mkdirSync(dirname(suiteDir), { recursive: true });
+	writeFileSync(resolve(suiteDir, "target.json"), JSON.stringify({ targetName, platform, runId, slug }, null, 2));
+	writeFileSync(resolve(suiteDir, "suite.json"), JSON.stringify({ suiteName, modelCalls: 0 }, null, 2));
+	writeCommand(suiteDir, command);
+
+	let lease = leaseSession;
+	const ownsLease = !lease;
+	if (!lease) lease = await warmupLease(targetName, slug);
+	if (!lease.ok) {
+		writeExitCode(suiteDir, lease.code, lease.signal);
+		writeFileSync(resolve(suiteDir, "crabbox.stdout.txt"), lease.stdout ?? "");
+		writeFileSync(resolve(suiteDir, "crabbox.stderr.txt"), lease.stderr ?? "");
+		const { assertions } = finalizeSuite(suiteDir, [{ id: "crabbox-warmup", fn: () => false, error: "Crabbox warmup failed" }], { target: targetName, suite: suiteName, elapsedMs: Date.now() - startedAt }, ["summary.json", "artifact-manifest.json", "target.json", "suite.json", "command.txt", "exit-code.txt", "crabbox.stdout.txt", "crabbox.stderr.txt", "assertions.json"]);
+		return { ok: false, suiteDir, assertions };
+	}
+
+	const secretValues = collectSecretValues(authEnvAllowList(config));
+	const result = await runOnLease(targetName, lease.leaseId, command, { timeout: 900_000, sync: leaseSession?.sync });
+	const elapsedMs = Date.now() - startedAt;
+	writeRedacted(resolve(suiteDir, "crabbox.stdout.txt"), result.stdout, secretValues);
+	writeRedacted(resolve(suiteDir, "crabbox.stderr.txt"), result.stderr, secretValues);
+	writeFileSync(resolve(suiteDir, "crabbox.timing.json"), JSON.stringify({ elapsedMs, code: result.code, signal: result.signal }, null, 2));
+	writeExitCode(suiteDir, result.code, result.signal);
+	writeExtracts(suiteDir, result.stdout, secretValues);
+	let stopResult;
+	if (ownsLease) {
+		stopResult = await stopLease(targetName, lease.leaseId);
+		writeRedacted(resolve(suiteDir, "crabbox.stop.stdout.txt"), stopResult.stdout, secretValues);
+		writeRedacted(resolve(suiteDir, "crabbox.stop.stderr.txt"), stopResult.stderr, secretValues);
+		writeFileSync(resolve(suiteDir, "crabbox.stop.exit-code.txt"), `code=${stopResult.code}\nsignal=${stopResult.signal ?? "none"}\n`);
+	}
+
+	const stdout = result.stdout;
+	const listOutput = section(stdout, "PI_LIST_STDOUT");
+	const nodeMajor = Number(marker(stdout, "PLATFORM_NODE_VERSION").replace(/^v/, "").split(".")[0] ?? 0);
+	const secretViolations = [
+		...scanForSecrets(`${result.stdout}\n${result.stderr}`, secretValues),
+		...scanArtifactTextFiles(suiteDir, secretValues).map((finding) => `${finding.file}: ${finding.violation}`),
+	];
+	const checks = [
+		{ id: "command-exit-zero", fn: () => result.code === 0, error: `exit ${result.code}` },
+		{ id: "platform-marker", fn: () => stdout.includes("PLATFORM_BUILD_OK") },
+		{ id: "node-version", fn: () => nodeMajor >= (config.nodeValidationMajor ?? 24), error: `Node major ${nodeMajor}` },
+		{ id: "npm-ci", fn: () => /PLATFORM_NPM_CI_EXIT=0/.test(stdout) },
+		{ id: "npm-run-verify", fn: () => /PLATFORM_VERIFY_EXIT=0/.test(stdout) },
+		{ id: "npm-pack", fn: () => /PLATFORM_NPM_PACK_EXIT=0/.test(stdout) && marker(stdout, "PLATFORM_PACKED_TARBALL").length > 0 },
+		{ id: "packed-node-install", fn: () => /PLATFORM_PACKED_NODE_INSTALL_EXIT=0/.test(stdout) },
+		{ id: "pi-install-local-package", fn: () => /PLATFORM_PI_INSTALL_EXIT=0/.test(stdout) },
+		{ id: "pi-list-local-package", fn: () => /PLATFORM_PI_LIST_EXIT=0/.test(stdout) && listOutput.includes(config.packageName) },
+		{ id: "no-source-extension-shortcut", fn: () => !/\bpi\s+(?:-e|--extension)\s+\./.test(stdout) },
+		{ id: "no-secret-artifacts", fn: () => secretViolations.length === 0, error: secretViolations.join(", ") },
+	];
+	if (stopResult) checks.push({ id: "lease-cleanup", fn: () => stopResult.code === 0, error: `stop exit ${stopResult.code}` });
+	const expectedFiles = [
+		"summary.json", "artifact-manifest.json", "target.json", "suite.json", "command.txt", "exit-code.txt", "crabbox.stdout.txt", "crabbox.stderr.txt", "crabbox.timing.json",
+		"node-version.txt", "packed-tarball.txt", "packed-node-install.stdout.txt", "packed-node-install.stderr.txt", "pi-install.stdout.txt", "pi-install.stderr.txt", "pi-list.stdout.txt", "pi-list.stderr.txt", "assertions.json",
+	];
+	if (stopResult) expectedFiles.push("crabbox.stop.stdout.txt", "crabbox.stop.stderr.txt", "crabbox.stop.exit-code.txt");
+	const { assertions } = finalizeSuite(suiteDir, checks, { target: targetName, suite: suiteName, elapsedMs, exitCode: result.code, signal: result.signal }, expectedFiles);
+	return { ok: assertions.ok, suiteDir, assertions };
+}
+
+export async function runTargetSuites(config, targetName, suiteNames) {
+	const slug = `${config.packageName}-${targetName}`;
+	const lease = await warmupLease(targetName, slug);
+	if (!lease.ok) return { ok: false, results: [{ ok: false, error: lease.stderr || lease.stdout || "warmup failed" }] };
+	const results = [];
+	let stopResult;
+	let staleCleanupResult;
+	try {
+		let sync = true;
+		for (const suiteName of suiteNames) {
+			const result = await runTargetSuite(config, targetName, suiteName, { ...lease, sync });
+			results.push(result);
+			sync = false;
+			if (!result.ok) break;
+		}
+	} finally {
+		stopResult = await stopLease(targetName, lease.leaseId);
+		staleCleanupResult = await cleanupStaleTargetState(targetName);
+	}
+	if (stopResult) {
+		results.push(createLeaseCleanupResult(config, targetName, lease.leaseId, stopResult, staleCleanupResult));
+	}
+	return { ok: results.every((result) => result.ok), results };
+}

--- a/test/platform-smoke.test.ts
+++ b/test/platform-smoke.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+function run(command: string, args: string[]) {
+  return spawnSync(command, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    shell: process.platform === "win32" && command === "npm",
+  });
+}
+
+test("platform smoke scripts have working syntax and help", () => {
+  for (const path of [
+    "scripts/platform-smoke.mjs",
+    "scripts/platform-smoke/artifacts.mjs",
+    "scripts/platform-smoke/crabbox-runner.mjs",
+    "scripts/platform-smoke/doctor.mjs",
+    "scripts/platform-smoke/goal-runtime-smoke.mjs",
+    "scripts/platform-smoke/targets.mjs",
+  ]) {
+    assert.equal(run(process.execPath, ["--check", path]).status, 0, path);
+  }
+
+  assert.ok(existsSync("scripts/platform-smoke/platform-build-windows.ps1"));
+  const powershellScript = readFileSync("scripts/platform-smoke/platform-build-windows.ps1", "utf8");
+  assert.match(powershellScript, /param\(/);
+  assert.match(powershellScript, /npm run verify/);
+  assert.match(powershellScript, /pi-list\.stdout\.txt/);
+
+  const help = run(process.execPath, ["scripts/platform-smoke.mjs", "--help"]);
+  assert.equal(help.status, 0);
+  assert.match(help.stdout, /windows-native/);
+  assert.match(help.stdout, /PLATFORM_SMOKE_CRABBOX/);
+  assert.match(help.stdout, /platform-build/);
+  assert.match(help.stdout, /goal-runtime-smoke/);
+  assert.match(help.stdout, /zai\/glm-5\.1/);
+});
+
+test("platform smoke config and package scripts require macOS, Ubuntu, and native Windows", () => {
+  const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+    files?: string[];
+    scripts?: Record<string, string>;
+  };
+  assert.ok(packageJson.files?.includes("scripts"));
+  assert.ok(packageJson.files?.includes("platform-smoke.config.mjs"));
+  assert.match(packageJson.scripts?.["check:platform-smoke"] ?? "", /node --check scripts\/platform-smoke\.mjs/);
+  assert.match(packageJson.scripts?.["check:platform-smoke"] ?? "", /test\/platform-smoke\.test\.ts/);
+  assert.match(packageJson.scripts?.["verify"] ?? "", /check:platform-smoke/);
+  assert.equal(packageJson.scripts?.["smoke:platform:doctor"], "node scripts/platform-smoke.mjs doctor");
+  assert.match(packageJson.scripts?.["smoke:platform:all"] ?? "", /smoke:platform:doctor/);
+  assert.match(packageJson.scripts?.["smoke:platform:all"] ?? "", /macos,ubuntu,windows-native/);
+  assert.match(packageJson.scripts?.["smoke:platform:windows-native"] ?? "", /windows-native/);
+
+  const code = String.raw`
+import config from "./platform-smoke.config.mjs";
+const result = {
+  targets: config.requiredTargets,
+  suites: config.requiredSuites,
+  packageName: config.packageName,
+};
+console.log(JSON.stringify(result));
+if (result.packageName !== "pi-codex-goal") process.exit(1);
+if (result.suites.join(",") !== "platform-build,goal-runtime-smoke") process.exit(1);
+if (result.targets.join(",") !== "macos,ubuntu,windows-native") process.exit(1);
+`;
+  const result = run(process.execPath, ["--input-type=module", "-e", code]);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("platform-build command rendering uses POSIX and PowerShell without source-extension shortcuts", () => {
+  const code = String.raw`
+import { buildGoalRuntimeSmokeCommand, buildPlatformBuildCommand, platformFor } from "./scripts/platform-smoke/targets.mjs";
+const posix = buildPlatformBuildCommand("ubuntu", "pi-codex-goal", 24);
+const macos = buildPlatformBuildCommand("macos", "pi-codex-goal", 24);
+const powershell = buildPlatformBuildCommand("windows-native", "pi-codex-goal", 24);
+const goalRuntime = buildGoalRuntimeSmokeCommand({ packageName: "pi-codex-goal", defaultModel: "zai/glm-5.1" }, "ubuntu");
+const result = {
+  macosPlatform: platformFor("macos"),
+  ubuntuPlatform: platformFor("ubuntu"),
+  windowsPlatform: platformFor("windows-native"),
+  posixHasVerify: posix.includes("npm run verify"),
+  posixHasPackedInstall: posix.includes("install -l ./node_modules/pi-codex-goal"),
+  posixNoExtensionShortcut: !/\\bpi\\s+(?:-e|--extension)\\s+\\./.test(posix),
+  macosHasVerify: macos.includes("npm run verify"),
+  powershellUsesScript: powershell.includes("platform-build-windows.ps1"),
+  powershellHasPackage: powershell.includes("pi-codex-goal"),
+  powershellNoExtensionShortcut: !/\\bpi\\s+(?:-e|--extension)\\s+\\./.test(powershell),
+  goalRuntimeHasDefaultModel: goalRuntime.includes("zai/glm-5.1"),
+  goalRuntimeHasPackage: goalRuntime.includes("pi-codex-goal"),
+};
+console.log(JSON.stringify(result));
+if (!Object.values(result).every(Boolean)) process.exit(1);
+`;
+  const result = run(process.execPath, ["--input-type=module", "-e", code]);
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+});
+
+test("artifact manifests and lease cleanup failures are enforced", () => {
+  const code = String.raw`
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectSecretValues, redactSecrets, scanForSecrets, writeManifest } from "./scripts/platform-smoke/artifacts.mjs";
+import { createLeaseCleanupFailureResult, createLeaseCleanupResult } from "./scripts/platform-smoke/targets.mjs";
+
+const root = mkdtempSync(join(tmpdir(), "pi-codex-goal-platform-smoke-test-"));
+try {
+  const suiteDir = join(root, "suite");
+  mkdirSync(suiteDir, { recursive: true });
+  writeFileSync(join(suiteDir, "present.txt"), "ok");
+  const manifest = writeManifest(suiteDir, ["artifact-manifest.json", "present.txt", "missing.txt"]);
+  const cleanup = createLeaseCleanupFailureResult({ artifactRoot: root, packageName: "pi-codex-goal" }, "ubuntu", "cbx_failed", {
+    stdout: "",
+    stderr: "stop failed",
+    code: 1,
+    signal: null,
+  });
+  const cleanupSuccess = createLeaseCleanupResult({ artifactRoot: root, packageName: "pi-codex-goal" }, "ubuntu", "cbx_ok", {
+    stdout: "stopped",
+    stderr: "",
+    code: 0,
+    signal: null,
+  }, {
+    stdout: "cleaned stale clones",
+    stderr: "",
+    code: 0,
+    signal: null,
+  });
+  const assertions = JSON.parse(readFileSync(join(cleanup.suiteDir, "assertions.json"), "utf8"));
+  const successManifest = JSON.parse(readFileSync(join(cleanupSuccess.suiteDir, "artifact-manifest.json"), "utf8"));
+  const env = { ZAI_API_KEY: "zai-secret-value-1234567890" };
+  const secrets = collectSecretValues(["ZAI_API_KEY"], env);
+  const redacted = redactSecrets("token=" + env.ZAI_API_KEY, secrets);
+  const result = {
+    manifestIncludesSelf: manifest.present.includes("artifact-manifest.json"),
+    missingRecorded: manifest.missing.includes("missing.txt"),
+    cleanupOk: cleanup.ok,
+    cleanupSuccessOk: cleanupSuccess.ok,
+    cleanupSuccessRecorded: successManifest.present.includes("crabbox.stop.stdout.txt") && successManifest.present.includes("crabbox.cleanup.stdout.txt"),
+    assertionsOk: assertions.ok,
+    leaseCleanupFailed: assertions.checks.some((check) => check.id === "lease-cleanup" && check.ok === false),
+    secretDetected: scanForSecrets("token=" + env.ZAI_API_KEY, secrets).includes("raw forwarded secret value"),
+    secretRedacted: !redacted.includes(env.ZAI_API_KEY) && redacted.includes("[REDACTED_SECRET]"),
+  };
+  console.log(JSON.stringify(result));
+  if (!result.manifestIncludesSelf || !result.missingRecorded || result.cleanupOk || !result.cleanupSuccessOk || !result.cleanupSuccessRecorded || result.assertionsOk || !result.leaseCleanupFailed || !result.secretDetected || !result.secretRedacted) process.exit(1);
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+`;
+  const result = run(process.execPath, ["--input-type=module", "-e", code]);
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+});
+
+test("npm pack includes platform smoke docs and scripts", () => {
+  const result = run("npm", ["pack", "--dry-run", "--json"]);
+  assert.equal(result.status, 0, result.stderr);
+  const packs = JSON.parse(result.stdout) as Array<{ files: Array<{ path: string }> }>;
+  const paths = new Set(packs[0]?.files.map((file) => file.path) ?? []);
+  for (const path of [
+    "docs/platform-smoke.md",
+    "platform-smoke.config.mjs",
+    "scripts/platform-smoke.mjs",
+    "scripts/platform-smoke/artifacts.mjs",
+    "scripts/platform-smoke/crabbox-runner.mjs",
+    "scripts/platform-smoke/doctor.mjs",
+    "scripts/platform-smoke/goal-runtime-smoke.mjs",
+    "scripts/platform-smoke/targets.mjs",
+    "scripts/platform-smoke/platform-build-windows.ps1",
+  ]) {
+    assert.ok(paths.has(path), `expected npm pack to include ${path}`);
+  }
+  for (const forbidden of [".artifacts/", ".crabbox/", ".debug/", ".env", ".env."]) {
+    assert.equal([...paths].some((path) => path === forbidden || path.startsWith(forbidden)), false);
+  }
+  assert.equal([...paths].some((path) => path.endsWith(".tgz")), false);
+});


### PR DESCRIPTION
## Summary
- Add a Crabbox-backed platform smoke harness for macOS, Ubuntu Linux, and native Windows.
- Add packed-install proof and real model-backed goal runtime smoke through the packed package.
- Add `check:platform-smoke`, wire it into `npm run verify`, and make `smoke:platform:all` run doctor first.
- Strengthen doctor checks for Crabbox providers, Parallels template/snapshot readiness, hygiene, package contents, and auth presence.
- Record lease cleanup artifacts, run stale cleanup, and fail cleanup/secret-scan issues.

## Validation
- `npm run check:platform-smoke` ✅
- `npm test` ✅
- `npm pack --dry-run --json` ✅
- `git diff --check` ✅
- `npm run verify` ✅
- `npm run smoke:platform:doctor` ✅
- `npm run smoke:platform:all` ✅

## Smoke evidence
Latest inspected artifacts all had `ok=true` assertions:
- macOS platform-build: `.artifacts/platform-smoke/run-1780341605507-dt0pwk/macos/platform-build/assertions.json`
- macOS goal-runtime-smoke: `.artifacts/platform-smoke/run-1780341621081-4n7rco/macos/goal-runtime-smoke/assertions.json`
- macOS lease-cleanup: `.artifacts/platform-smoke/run-1780341639988-hnl7yl/macos/lease-cleanup/assertions.json`
- Ubuntu platform-build: `.artifacts/platform-smoke/run-1780341615959-wibh51/ubuntu/platform-build/assertions.json`
- Ubuntu goal-runtime-smoke: `.artifacts/platform-smoke/run-1780341631479-v51e9x/ubuntu/goal-runtime-smoke/assertions.json`
- Ubuntu lease-cleanup: `.artifacts/platform-smoke/run-1780341656577-h6944y/ubuntu/lease-cleanup/assertions.json`
- Windows platform-build: `.artifacts/platform-smoke/run-1780341648706-4dvyxt/windows-native/platform-build/assertions.json`
- Windows goal-runtime-smoke: `.artifacts/platform-smoke/run-1780341741455-on0gj2/windows-native/goal-runtime-smoke/assertions.json`
- Windows lease-cleanup: `.artifacts/platform-smoke/run-1780341784281-ail9x7/windows-native/lease-cleanup/assertions.json`

## Parallels/template notes
- `pi-extension-windows-template` was stopped before final doctor/smoke.
- `crabbox-ready` was verified present and poweroff.
- No stale `pi-codex-goal` Windows clone remained after cleanup.
