### PR TITLE
Release 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.22 - 2026-06-02
+
+- Tighten test-only TypeScript casts around goal state and recovery runtime harnesses.
+- Make the recovery runtime generic over its context so tests can use the minimal status context they exercise.
+- Add a type-hygiene regression check for banned TypeScript escape hatches such as double assertions, `as any`, `as never`, `any` annotations, and suppression comments.
+
 ## 0.1.21 - 2026-06-01
 
 - Add a Crabbox-backed release gate for macOS, Ubuntu Linux, and native Windows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-codex-goal",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "0.78.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Codex-style goal tracking and continuation for pi.",
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",

--- a/src/recovery-runtime.ts
+++ b/src/recovery-runtime.ts
@@ -1,5 +1,3 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-
 import {
   onRecoverySessionCompact,
   onRecoverySuccessfulTurn,
@@ -13,17 +11,17 @@ import {
 import type { AssistantErrorMessage } from "./recovery.js";
 import type { ThreadGoal } from "./types.js";
 
-interface RecoveryRuntimeDeps {
+interface RecoveryRuntimeDeps<TContext> {
   getGoal: () => ThreadGoal | null;
   getRecoveryState: () => GoalRecoveryMachineState;
   clearContinuationState: () => void;
-  pauseGoalForRecovery: (ctx: ExtensionContext, recoveryReason: string) => void;
-  refreshUi: (ctx: ExtensionContext) => void;
-  maybeContinue: (ctx: ExtensionContext) => void;
+  pauseGoalForRecovery: (ctx: TContext, recoveryReason: string) => void;
+  refreshUi: (ctx: TContext) => void;
+  maybeContinue: (ctx: TContext) => void;
 }
 
-export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
-  const pauseForRecoveryAttention = (ctx: ExtensionContext, reason: string): void => {
+export function createGoalRecoveryRuntime<TContext>(deps: RecoveryRuntimeDeps<TContext>) {
+  const pauseForRecoveryAttention = (ctx: TContext, reason: string): void => {
     const goal = deps.getGoal();
     if (!goal || goal.status !== "active") {
       return;
@@ -32,7 +30,7 @@ export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
     deps.pauseGoalForRecovery(ctx, reason);
   };
 
-  const applyRecoveryAction = (action: RecoveryAction, ctx: ExtensionContext): void => {
+  const applyRecoveryAction = (action: RecoveryAction, ctx: TContext): void => {
     switch (action.type) {
       case "noop":
         return;
@@ -52,7 +50,7 @@ export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
     }
   };
 
-  const handlePersistentAssistantError = (message: AssistantErrorMessage, ctx: ExtensionContext): void => {
+  const handlePersistentAssistantError = (message: AssistantErrorMessage, ctx: TContext): void => {
     const goal = deps.getGoal();
     if (!goal || goal.status !== "active") {
       return;
@@ -61,7 +59,7 @@ export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
     applyRecoveryAction(planRecoveryForAssistantError(deps.getRecoveryState(), message), ctx);
   };
 
-  const handleSilentContextOverflow = (ctx: ExtensionContext): void => {
+  const handleSilentContextOverflow = (ctx: TContext): void => {
     const goal = deps.getGoal();
     if (!goal || goal.status !== "active") {
       return;
@@ -72,7 +70,7 @@ export function createGoalRecoveryRuntime(deps: RecoveryRuntimeDeps) {
 
   const finishSuccessfulAssistantTurn = (
     message: AssistantErrorMessage,
-    ctx: ExtensionContext,
+    ctx: TContext,
     options?: { continueGoal?: boolean },
   ): void => {
     if (onRecoverySuccessfulTurn(deps.getRecoveryState(), message)) {

--- a/test/goal-state-controller.test.ts
+++ b/test/goal-state-controller.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { createGoalPersistence } from "../src/goal-persistence.js";
 import { createGoalStateController } from "../src/goal-state-controller.js";
@@ -9,6 +9,7 @@ import {
   createGoalRecoveryMachine,
   recoveryPhaseNeedsUserStartTurn,
 } from "../src/recovery-machine.js";
+import type { StatusContext } from "../src/goal-runtime-status.js";
 import type { ThreadGoal } from "../src/types.js";
 
 const activeGoal: ThreadGoal = {
@@ -28,7 +29,7 @@ function createStateControllerTestHarness(goal: ThreadGoal | null = activeGoal) 
     appendEntry(_type: string, data: unknown) {
       entries.push(data);
     },
-  } as unknown as Pick<ExtensionAPI, "appendEntry">;
+  } satisfies Pick<ExtensionAPI, "appendEntry">;
 
   const persistence = createGoalPersistence({ pi });
   if (goal) {
@@ -38,7 +39,7 @@ function createStateControllerTestHarness(goal: ThreadGoal | null = activeGoal) 
   let refreshCount = 0;
   const ctx = {
     ui: { setStatus() {} },
-  } as unknown as ExtensionContext;
+  } satisfies StatusContext;
 
   const stateController = createGoalStateController({
     pi,

--- a/test/recovery-runtime.test.ts
+++ b/test/recovery-runtime.test.ts
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-
 import {
   createGoalRecoveryMachine,
   setRecoveryPausedAttention,
 } from "../src/recovery-machine.js";
+import type { StatusContext } from "../src/goal-runtime-status.js";
 import { createGoalRecoveryRuntime } from "../src/recovery-runtime.js";
 import { CONTEXT_OVERFLOW_SIGNATURE } from "../src/recovery.js";
 import type { ThreadGoal } from "../src/types.js";
@@ -28,9 +27,9 @@ function createRecoveryTestRuntime(goal: ThreadGoal | null = activeGoal) {
 
   const ctx = {
     ui: { setStatus() {} },
-  } as unknown as ExtensionContext;
+  } satisfies StatusContext;
 
-  const runtime = createGoalRecoveryRuntime({
+  const runtime = createGoalRecoveryRuntime<StatusContext>({
     getGoal: () => goal,
     getRecoveryState: () => recoveryState,
     clearContinuationState: () => {},
@@ -76,7 +75,7 @@ test("persistent provider errors plan pending attention without scheduling hidde
 
 test("persistent overflow errors do not invoke extension compaction hooks", () => {
   const harness = createRecoveryTestRuntime();
-  const ctx = harness.ctx as ExtensionContext & { compact?: () => void };
+  const ctx: StatusContext & { compact?: () => void } = harness.ctx;
   let compactCalls = 0;
   ctx.compact = () => {
     compactCalls += 1;
@@ -149,7 +148,7 @@ test("recovery pause delegates reason without clearing continuation in recovery 
   let refreshCount = 0;
   const recoveryState = createGoalRecoveryMachine();
 
-  const runtime = createGoalRecoveryRuntime({
+  const runtime = createGoalRecoveryRuntime<StatusContext>({
     getGoal: () => activeGoal,
     getRecoveryState: () => recoveryState,
     clearContinuationState: () => {
@@ -164,7 +163,7 @@ test("recovery pause delegates reason without clearing continuation in recovery 
     maybeContinue: () => {},
   });
 
-  const ctx = { ui: { setStatus() {} } } as unknown as ExtensionContext;
+  const ctx = { ui: { setStatus() {} } } satisfies StatusContext;
 
   runtime.handlePersistentAssistantError(
     { role: "assistant", stopReason: "error", errorMessage: "context_length_exceeded" },

--- a/test/support/runtime-harness.ts
+++ b/test/support/runtime-harness.ts
@@ -116,7 +116,15 @@ export function createRuntimeHarness(options: {
     },
     registerShortcut() {},
     registerTool(tool) {
-      tools.set(tool.name, (params) => tool.execute("tool-call", params as never, undefined, undefined, ctx));
+      tools.set(tool.name, (params) =>
+        tool.execute(
+          "tool-call",
+          params as Parameters<typeof tool.execute>[1],
+          undefined,
+          undefined,
+          ctx,
+        ),
+      );
     },
     sendMessage(message, options) {
       sentMessages.push({ message, options });

--- a/test/type-hygiene.test.ts
+++ b/test/type-hygiene.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+function tsFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const path = join(root, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...tsFiles(path));
+      continue;
+    }
+    if (path.endsWith(".ts")) files.push(path);
+  }
+  return files;
+}
+
+const bannedEscapeHatchPatterns = [
+  { label: "double assertion through unknown", pattern: new RegExp("as\\s+unknown\\s+as") },
+  { label: "any assertion", pattern: new RegExp("as\\s+any\\b") },
+  { label: "never assertion", pattern: new RegExp("as\\s+never\\b") },
+  { label: "explicit any annotation", pattern: new RegExp(":\\s*any\\b") },
+  { label: "ts ignore directive", pattern: new RegExp("@ts-" + "ignore") },
+  { label: "unchecked ts expect error directive", pattern: new RegExp("@ts-" + "expect-error") },
+  { label: "lint suppression", pattern: new RegExp("eslint-" + "disable") },
+];
+
+test("source and tests avoid banned TypeScript escape hatches", () => {
+  const violations: string[] = [];
+  for (const file of [...tsFiles("src"), ...tsFiles("test")]) {
+    const text = readFileSync(file, "utf8");
+    for (const { label, pattern } of bannedEscapeHatchPatterns) {
+      if (pattern.test(text)) violations.push(`${file}: ${label}`);
+    }
+  }
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary
- tighten test-only TypeScript casts around goal state and recovery runtime harnesses
- make the recovery runtime context generic so tests can use the minimal status context they actually exercise
- add a type-hygiene regression test for banned TypeScript escape hatches
- bump package version to 0.1.22 and add CHANGELOG release notes

## Verification
- npm run verify
- npm publish --dry-run
- git diff --check