### PR TITLE
Hold goal continuation near context limit

### DIFF
--- a/src/continuation-scheduler.ts
+++ b/src/continuation-scheduler.ts
@@ -24,6 +24,7 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
   let continuationScheduledDelayMs: number | null = null;
   let continuationTimer: ReturnType<typeof setTimeout> | null = null;
   let passthroughContinuationInput: { text: string; turnIndex: number | null } | null = null;
+  let highContextNoticeFor: string | null = null;
 
   const clearContinuationTimer = (): void => {
     if (continuationTimer) {
@@ -96,6 +97,28 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
     return Boolean(goal?.status === "active" && isRecoveryPendingAttention(deps.getRecoveryState().attention));
   };
 
+  const shouldHoldForHighContext = (goalId: string, ctx: ExtensionContext): boolean => {
+    const usage = ctx.getContextUsage();
+    if (!usage || usage.tokens === null || usage.contextWindow <= 0) {
+      return false;
+    }
+
+    const percent = usage.percent ?? (usage.tokens / usage.contextWindow) * 100;
+    if (percent < 85) {
+      highContextNoticeFor = null;
+      return false;
+    }
+
+    if (highContextNoticeFor !== goalId && ctx.hasUI) {
+      ctx.ui.notify(
+        `Goal continuation paused because context is high (${percent.toFixed(1)}%). Run /compact, then /goal resume if you want to continue the goal.`,
+        "warning",
+      );
+      highContextNoticeFor = goalId;
+    }
+    return true;
+  };
+
   const sendContinuation = (goalToContinue: ThreadGoal): void => {
     continuationQueuedFor = goalToContinue.goalId;
     deps.pi.sendMessage(
@@ -152,6 +175,9 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
     }
 
     const goalId = goal.goalId;
+    if (shouldHoldForHighContext(goalId, ctx)) {
+      return;
+    }
     if (!ctx.isIdle() || ctx.hasPendingMessages()) {
       scheduleContinuationCheck(goalId, ctx, CONTINUATION_RETRY_MS);
       return;
@@ -162,12 +188,18 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
     if (!currentGoal || currentGoal.status !== "active" || currentGoal.goalId !== goalId) {
       return;
     }
+    if (shouldHoldForHighContext(goalId, ctx)) {
+      return;
+    }
     sendContinuation(currentGoal);
   };
 
   const maybeContinueAfterCurrentEvent = (ctx: ExtensionContext): void => {
     const goal = deps.getGoal();
     if (!canPlanContinuationFor(goal)) {
+      return;
+    }
+    if (shouldHoldForHighContext(goal.goalId, ctx)) {
       return;
     }
     scheduleContinuationCheck(goal.goalId, ctx, 0);

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -154,6 +154,72 @@ test("completed turns count input plus output and continue active goals", async 
   });
 });
 
+test("high context usage holds automatic goal continuation", async () => {
+  const harness = createRuntimeHarness({
+    contextUsage: { tokens: 170_000, contextWindow: 200_000, percent: 85 },
+  });
+  await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const queuedMessage = queuedCustomMessage(queued);
+  harness.sentMessages.length = 0;
+
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: queuedMessage,
+  });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 0,
+    message: assistantMessage("stop", {
+      input: 30,
+      output: 12,
+      cacheRead: 160_000,
+      cacheWrite: 0,
+      totalTokens: 170_000,
+    }),
+    toolResults: [],
+  });
+
+  const goal = harness.snapshot().goal;
+  assert.equal(goal?.status, "active");
+  assert.equal(harness.sentMessages.length, 0);
+  assert.match(harness.notifications.at(-1)?.message ?? "", /Run \/compact, then \/goal resume/);
+});
+
+test("goal continuation resumes once context usage drops", async () => {
+  const harness = createRuntimeHarness({
+    contextUsage: { tokens: 170_000, contextWindow: 200_000, percent: 85 },
+  });
+  await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const queuedMessage = queuedCustomMessage(queued);
+  harness.sentMessages.length = 0;
+
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: queuedMessage,
+  });
+  harness.setContextUsage({ tokens: 80_000, contextWindow: 200_000, percent: 40 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 0,
+    message: assistantMessage("stop", { input: 30, output: 12 }),
+    toolResults: [],
+  });
+
+  const goal = harness.snapshot().goal;
+  assert.equal(goal?.status, "active");
+  assert.equal(harness.sentMessages.length, 1);
+  assert.deepEqual(harness.sentMessages[0]?.message.details, {
+    kind: "continuation",
+    goalId: goal?.goalId,
+  });
+});
+
 test("tool-use turn ends do not queue continuation before tool execution finishes", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");

--- a/test/support/runtime-harness.ts
+++ b/test/support/runtime-harness.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { mock } from "node:test";
 
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type {
+  ContextUsage,
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 
 import goalExtension, { __testHooks } from "../../src/index.js";
 import { isContextOverflowError } from "../../src/recovery.js";
@@ -36,12 +41,14 @@ export function createRuntimeHarness(options: {
   pendingMessages?: boolean;
   compactBehavior?: "success" | "error" | "unavailable";
   compactCompletion?: "immediate" | "manual";
+  contextUsage?: ContextUsage;
   contextWindow?: number;
 } = {}) {
   const entries: ReturnType<ExtensionCommandContext["sessionManager"]["getBranch"]> = [];
   const handlers = new Map<string, EventHandler[]>();
   const sentMessages: SentMessage[] = [];
   const sentUserMessages: SentUserMessage[] = [];
+  const notifications: Array<{ message: string; level?: string }> = [];
   const tools = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>();
   const compactCalls: Array<{
     customInstructions?: string;
@@ -59,6 +66,7 @@ export function createRuntimeHarness(options: {
     pendingMessages: options.pendingMessages ?? false,
     compactBehavior: options.compactBehavior ?? "success",
     compactCompletion: options.compactCompletion ?? "immediate",
+    contextUsage: options.contextUsage,
     hostOverflowRecoveryAttempted: false,
   };
   let commandHandler: ((args: string, ctx: ExtensionCommandContext) => void | Promise<void>) | null = null;
@@ -179,7 +187,9 @@ export function createRuntimeHarness(options: {
     getTheme: () => undefined,
     getToolsExpanded: () => false,
     input: async () => undefined,
-    notify() {},
+    notify(message, level) {
+      notifications.push(level === undefined ? { message } : { message, level });
+    },
     onTerminalInput: () => () => {},
     pasteToEditor() {},
     select: async () => undefined,
@@ -207,7 +217,7 @@ export function createRuntimeHarness(options: {
     },
     cwd: "/tmp",
     fork: async () => ({ cancelled: false }),
-    getContextUsage: () => undefined,
+    getContextUsage: () => runtime.contextUsage,
     getSystemPrompt: () => "",
     hasUI: true,
     compact(options) {
@@ -306,6 +316,7 @@ export function createRuntimeHarness(options: {
     runTool,
     reloadExtension,
     reloadSession,
+    notifications,
     sentMessages,
     sentUserMessages,
     setIdle(idle: boolean) {
@@ -313,6 +324,9 @@ export function createRuntimeHarness(options: {
     },
     setPendingMessages(pendingMessages: boolean) {
       runtime.pendingMessages = pendingMessages;
+    },
+    setContextUsage(contextUsage: ContextUsage | undefined) {
+      runtime.contextUsage = contextUsage;
     },
     setContextWindow(contextWindow: number) {
       ctx.model = {


### PR DESCRIPTION
## Summary
- hold automatic goal continuation when `ctx.getContextUsage()` reports the session is at or above 85% of the model context window
- show a UI warning telling the user to run `/compact`, then `/goal resume` if they want to continue the goal
- add regression coverage for high-context hold and continuation resuming after context usage drops

## Why
In a long resumed session, an active `/goal` can immediately enqueue a hidden `pi_goal_continuation` follow-up. If the session is already near/over the active model's context window, that follow-up can start before the user gets a chance to run manual `/compact`, making compaction appear unresponsive and keeping the session over limit.

This keeps `/goal` behavior unchanged for normal context usage, while avoiding auto-continuation races in high-context sessions.

## Verification
- `node node_modules/typescript/bin/tsc --noEmit`
- `node --import tsx --test test/continuation.test.ts`