### PR TITLE
Fix active goal stalls after willRetry compaction

### DIFF
--- a/src/goal-runtime-event-handler-types.ts
+++ b/src/goal-runtime-event-handler-types.ts
@@ -94,7 +94,7 @@ export interface StaleQueuedWorkEffectContext {
 }
 
 export interface GoalRuntimeInputContextHandlerContext extends StaleQueuedWorkEffectContext {
-  runtimeState: Pick<GoalRuntimeState, "currentTurnIndex" | "staleQueuedWorkGuard">;
+  runtimeState: Pick<GoalRuntimeState, "agentRunSequence" | "currentTurnIndex" | "staleQueuedWorkGuard">;
   stateController: Pick<
     GoalStateController,
     "getGoal" | "isCurrentActiveGoalId" | "persistHostOverflowUserReset"
@@ -131,7 +131,10 @@ export interface GoalRuntimeAgentHandlerContext extends StaleQueuedWorkEffectCon
 }
 
 export interface GoalRuntimeSessionHandlerContext extends StaleQueuedWorkEffectContext {
-  runtimeState: Pick<GoalRuntimeState, "currentTurnIndex" | "recoveryState" | "staleQueuedWorkGuard">;
+  runtimeState: Pick<
+    GoalRuntimeState,
+    "agentRunSequence" | "currentTurnIndex" | "recoveryState" | "staleQueuedWorkGuard"
+  >;
   stateController: Pick<
     GoalStateController,
     "applyGoalTransition" | "flushGoalPersistence" | "getGoal" | "reloadFromSession"

--- a/src/goal-runtime-input-context-handlers.ts
+++ b/src/goal-runtime-input-context-handlers.ts
@@ -80,6 +80,7 @@ export function createInputContextEventHandlers(
     }) satisfies ExtensionHandler<ContextEvent, ContextEventResult | undefined>,
 
     onBeforeAgentStart: (async (event, ctx) => {
+      runtimeState.agentRunSequence += 1;
       const continuationGoalId = continuation.continuationGoalIdFromRuntimePrompt(event.prompt);
       if (continuationGoalId !== null) {
         continuation.clearContinuationStateFor(continuationGoalId);

--- a/src/goal-runtime-session-handlers.ts
+++ b/src/goal-runtime-session-handlers.ts
@@ -31,49 +31,71 @@ export function createSessionEventHandlers(deps: GoalRuntimeSessionHandlerContex
     resumeGoalWithContinuation,
   } = deps;
 
-  let hostOverflowPostCompactFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+  let postCompactContinuationFallbackTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const clearHostOverflowPostCompactFallback = (): void => {
-    if (!hostOverflowPostCompactFallbackTimer) {
+  const clearPostCompactContinuationFallback = (): void => {
+    if (!postCompactContinuationFallbackTimer) {
       return;
     }
-    clearTimeout(hostOverflowPostCompactFallbackTimer);
-    hostOverflowPostCompactFallbackTimer = null;
+    clearTimeout(postCompactContinuationFallbackTimer);
+    postCompactContinuationFallbackTimer = null;
   };
 
-  const scheduleHostOverflowPostCompactFallback = (ctx: ExtensionContext): void => {
-    clearHostOverflowPostCompactFallback();
-    if (!recoveryPhaseBlocksContinuation(runtimeState.recoveryState.phase)) {
+  const schedulePostCompactContinuationFallback = (
+    ctx: ExtensionContext,
+    options: { clearHostOverflowRecovery: boolean },
+  ): void => {
+    clearPostCompactContinuationFallback();
+    const scheduledGoal = stateController.getGoal();
+    if (!scheduledGoal || scheduledGoal.status !== "active") {
+      return;
+    }
+    if (
+      options.clearHostOverflowRecovery &&
+      !recoveryPhaseBlocksContinuation(runtimeState.recoveryState.phase)
+    ) {
       return;
     }
 
+    const scheduledGoalId = scheduledGoal.goalId;
     const scheduledTurnIndex = runtimeState.currentTurnIndex;
-    hostOverflowPostCompactFallbackTimer = setTimeout(() => {
-      hostOverflowPostCompactFallbackTimer = null;
+    const scheduledAgentRunSequence = runtimeState.agentRunSequence;
+    postCompactContinuationFallbackTimer = setTimeout(() => {
+      postCompactContinuationFallbackTimer = null;
       const goal = stateController.getGoal();
-      if (!goal || goal.status !== "active") {
+      if (!goal || goal.status !== "active" || goal.goalId !== scheduledGoalId) {
         return;
       }
       if (runtimeState.currentTurnIndex !== scheduledTurnIndex) {
         return;
       }
-      if (!recoveryPhaseBlocksContinuation(runtimeState.recoveryState.phase)) {
+      if (runtimeState.agentRunSequence !== scheduledAgentRunSequence) {
         return;
       }
       if (!ctx.isIdle() || ctx.hasPendingMessages()) {
         return;
       }
 
-      clearActiveHostOverflowRecovery(runtimeState.recoveryState);
-      status.refreshUi(ctx);
+      const recoveryBlocksContinuation = recoveryPhaseBlocksContinuation(
+        runtimeState.recoveryState.phase,
+      );
+      if (options.clearHostOverflowRecovery) {
+        if (!recoveryBlocksContinuation) {
+          return;
+        }
+        clearActiveHostOverflowRecovery(runtimeState.recoveryState);
+        status.refreshUi(ctx);
+      } else if (recoveryBlocksContinuation) {
+        return;
+      }
       continuation.maybeContinue(ctx);
     }, CONTINUATION_RETRY_MS);
-    hostOverflowPostCompactFallbackTimer.unref?.();
+    postCompactContinuationFallbackTimer.unref?.();
   };
 
   return {
     onSessionStart: (async (event, ctx) => {
-      clearHostOverflowPostCompactFallback();
+      clearPostCompactContinuationFallback();
       deps.providerLimitAutoResume.clear();
       stateController.reloadFromSession(ctx);
       goalAccounting.beginAccounting();
@@ -94,7 +116,7 @@ export function createSessionEventHandlers(deps: GoalRuntimeSessionHandlerContex
     }) satisfies ExtensionHandler<SessionStartEvent>,
 
     onSessionTree: (async (_event, ctx) => {
-      clearHostOverflowPostCompactFallback();
+      clearPostCompactContinuationFallback();
       deps.providerLimitAutoResume.clear();
       stateController.reloadFromSession(ctx);
       goalAccounting.beginAccounting();
@@ -128,18 +150,21 @@ export function createSessionEventHandlers(deps: GoalRuntimeSessionHandlerContex
       recoveryRuntime.onSessionCompact();
       status.refreshUi(ctx);
       if (event.willRetry) {
-        clearHostOverflowPostCompactFallback();
+        // A host retry is expected, but keep a guarded fallback in case no retry turn arrives.
+        schedulePostCompactContinuationFallback(ctx, {
+          clearHostOverflowRecovery: wasRecoveringFromHostOverflow,
+        });
         return;
       }
       if (!recoveryPhaseBlocksContinuation(runtimeState.recoveryState.phase)) {
         continuation.maybeContinueAfterCurrentEvent(ctx);
       } else if (wasRecoveringFromHostOverflow) {
-        scheduleHostOverflowPostCompactFallback(ctx);
+        schedulePostCompactContinuationFallback(ctx, { clearHostOverflowRecovery: true });
       }
     }) satisfies ExtensionHandler<SessionCompactEvent>,
 
     onSessionShutdown: (async (_event, ctx) => {
-      clearHostOverflowPostCompactFallback();
+      clearPostCompactContinuationFallback();
       deps.providerLimitAutoResume.clear();
       continuation.clearPassthroughContinuationInput();
       applyStaleQueuedWorkEffects(runtimeState.staleQueuedWorkGuard.planSessionShutdown().effects, ctx, deps);

--- a/src/goal-runtime-state.ts
+++ b/src/goal-runtime-state.ts
@@ -8,6 +8,7 @@ import {
 export interface GoalRuntimeState {
   accounting: AccountingState;
   recoveryState: GoalRecoveryMachineState;
+  agentRunSequence: number;
   currentTurnIndex: number | null;
   staleQueuedWorkGuard: StaleQueuedWorkGuard;
 }
@@ -16,6 +17,7 @@ export function createGoalRuntimeState(): GoalRuntimeState {
   return {
     accounting: createAccountingState(),
     recoveryState: createGoalRecoveryMachine(),
+    agentRunSequence: 0,
     currentTurnIndex: null,
     staleQueuedWorkGuard: createStaleQueuedWorkGuard(),
   };

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -476,6 +476,77 @@ test("session compaction queues continuation for active goals after the compacti
   }
 });
 
+test("willRetry session compaction falls back after grace when host retry never starts", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const queued = harness.sentMessages[0];
+    assert.ok(queued);
+    const content = String(queued.message.content);
+    harness.sentMessages.length = 0;
+
+    await harness.emit("before_agent_start", {
+      type: "before_agent_start",
+      prompt: content,
+      systemPrompt: "",
+      systemPromptOptions: {},
+    });
+    await harness.emit("session_compact", sessionCompactEvent({ willRetry: true }));
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 0);
+
+    flushContinuationScheduler();
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "continuation",
+      goalId: goal?.goalId,
+    });
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("willRetry session compaction fallback does not continue a replaced active goal", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    const queued = harness.sentMessages[0];
+    assert.ok(queued);
+    const content = String(queued.message.content);
+    harness.sentMessages.length = 0;
+
+    await harness.emit("before_agent_start", {
+      type: "before_agent_start",
+      prompt: content,
+      systemPrompt: "",
+      systemPromptOptions: {},
+    });
+    const oldGoalId = harness.snapshot().goal?.goalId;
+    assert.ok(oldGoalId);
+
+    await harness.emit("session_compact", sessionCompactEvent({ willRetry: true }));
+    await harness.runCommand("replacement");
+
+    const replacementGoal = harness.snapshot().goal;
+    assert.equal(replacementGoal?.status, "active");
+    assert.notEqual(replacementGoal?.goalId, oldGoalId);
+    assert.equal(harness.sentMessages.length, 1);
+
+    flushContinuationScheduler();
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "command_start",
+      goalId: replacementGoal?.goalId,
+    });
+  } finally {
+    mock.timers.reset();
+  }
+});
+
 test("session compaction accelerates an existing idle retry after length stops", async () => {
   mock.timers.enable({ apis: ["setTimeout"] });
   try {

--- a/test/recovery-overflow.test.ts
+++ b/test/recovery-overflow.test.ts
@@ -17,6 +17,15 @@ import {
 } from "./support/runtime-harness.js";
 import { givenOverflowPausedGoal } from "./support/scenarios.js";
 
+function hostRetryStartEvent(prompt = "host retry"): object {
+  return {
+    type: "before_agent_start",
+    prompt,
+    systemPrompt: "",
+    systemPromptOptions: {},
+  };
+}
+
 test("turn_end provider errors defer recovery to agent_end without hidden continuation or extension compaction", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");
@@ -75,10 +84,41 @@ test("host overflow session compaction does not queue extension continuation bef
     assert.equal(harness.sentMessages.length, 0);
 
     await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 0);
+
+    await harness.emit("before_agent_start", hostRetryStartEvent());
     flushContinuationScheduler();
 
     assert.equal(harness.snapshot().goal?.status, "active");
     assert.equal(harness.sentMessages.length, 0);
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("host overflow session compaction falls back when promised host retry never starts", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    harness.sentMessages.length = 0;
+
+    await emitPersistentAssistantError(harness, 0, "context_length_exceeded");
+    await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 0);
+
+    flushContinuationScheduler();
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "continuation",
+      goalId: goal?.goalId,
+    });
   } finally {
     mock.timers.reset();
   }
@@ -104,15 +144,18 @@ test("host overflow retry success resumes goal continuation after clearing recov
   await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
   assert.equal(harness.sentMessages.length, 0);
 
-  await harness.emit("before_agent_start", {
-    type: "before_agent_start",
-    prompt: "host retry",
-    systemPrompt: "",
-    systemPromptOptions: {},
+  await harness.emit("before_agent_start", hostRetryStartEvent());
+  const retryMessage = assistantMessage("stop", { input: 1, output: 1 });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 1,
+    message: retryMessage,
+    toolResults: [],
   });
   await harness.emit("agent_end", {
     type: "agent_end",
-    messages: [assistantMessage("stop", { input: 1, output: 1 })],
+    messages: [retryMessage],
   });
 
   assert.equal(harness.snapshot().goal?.status, "active");
@@ -140,6 +183,7 @@ test("first overflow error stays active while host performs compact-and-retry", 
 
   await emitPersistentAssistantError(harness, 0, "context_length_exceeded");
   await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+  await harness.emit("before_agent_start", hostRetryStartEvent());
 
   assert.equal(harness.snapshot().goal?.status, "active");
   assert.equal(harness.sentMessages.length, 0);
@@ -157,6 +201,9 @@ test("context overflow recovery preserves compaction attempts across host sessio
       `prompt is too long: ${(attempt + 1) * 100_000} tokens > 200000 maximum`,
     );
     await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+    if (harness.snapshot().goal?.status === "active") {
+      await harness.emit("before_agent_start", hostRetryStartEvent());
+    }
   }
 
   assert.equal(harness.compactCalls.length, 0);
@@ -179,6 +226,7 @@ test("overflow after compaction and intervening transient error pauses with reco
   assert.doesNotMatch(harness.footerStatuses.at(-1) ?? "", /\/goal resume/);
 
   await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+  await harness.emit("before_agent_start", hostRetryStartEvent());
   assert.equal(harness.snapshot().goal?.status, "active");
 
   await emitPersistentAssistantError(harness, 1, "websocket closed");
@@ -355,6 +403,7 @@ test("successful toolUse turns reset context overflow recovery counters", async 
   await emitPersistentAssistantError(harness, 0, "context_length_exceeded");
   assert.equal(harness.compactCalls.length, 0);
   await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+  await harness.emit("before_agent_start", hostRetryStartEvent());
 
   await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
   await harness.emit("turn_end", {

--- a/test/recovery-session.test.ts
+++ b/test/recovery-session.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import { mock, test } from "node:test";
 
 import { pendingRecoveryShutdownReason } from "../src/goal-runtime-session-handlers.js";
 import { createRecoveryPausedAttention, createRecoveryPendingAttention } from "../src/recovery.js";
@@ -225,22 +225,27 @@ test("session_tree to a different active goal clears stale overflow recovery and
 });
 
 test("delayed session_compact keeps goal active without premature pause or extension follow-up", async () => {
-  const harness = createRuntimeHarness();
-  await harness.runCommand("ship it");
-  harness.sentMessages.length = 0;
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness();
+    await harness.runCommand("ship it");
+    harness.sentMessages.length = 0;
 
-  await emitPersistentAssistantError(harness, 0, "context_length_exceeded");
+    await emitPersistentAssistantError(harness, 0, "context_length_exceeded");
 
-  assert.equal(harness.snapshot().goal?.status, "active");
-  assert.equal(harness.sentMessages.length, 0);
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 0);
 
-  await harness.emit("session_before_compact", sessionBeforeCompactEvent());
+    await harness.emit("session_before_compact", sessionBeforeCompactEvent());
 
-  assert.equal(harness.snapshot().goal?.status, "active");
-  assert.equal(harness.sentMessages.length, 0);
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 0);
 
-  await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+    await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
 
-  assert.equal(harness.snapshot().goal?.status, "active");
-  assert.equal(harness.sentMessages.length, 0);
+    assert.equal(harness.snapshot().goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 0);
+  } finally {
+    mock.timers.reset();
+  }
 });

--- a/test/support/scenarios.ts
+++ b/test/support/scenarios.ts
@@ -46,6 +46,14 @@ export async function givenOverflowPausedGoal(
   for (let attempt = 0; attempt < 2; attempt += 1) {
     await emitPersistentAssistantError(harness, attempt, "context_length_exceeded");
     await harness.emit("session_compact", sessionCompactEvent({ reason: "overflow", willRetry: true }));
+    if (harness.snapshot().goal?.status === "active") {
+      await harness.emit("before_agent_start", {
+        type: "before_agent_start",
+        prompt: "host retry",
+        systemPrompt: "",
+        systemPromptOptions: {},
+      });
+    }
   }
 
   const goal = harness.snapshot().goal;


### PR DESCRIPTION
Fixes a bug where an active goal could get stranded after `session_compact` reported `willRetry: true`. The handler treated `willRetry` as a permanent handoff to the host runtime, so if no retry turn actually started, the goal stayed active with no pending messages and no scheduled continuation.

**Fix**
`willRetry` now schedules a guarded delayed fallback. The fallback only continues if the same goal is still active, no new agent run or turn started, the session is idle, and recovery state permits continuation. Actual retries cancel the fallback via a new `agentRunSequence` incremented on `before_agent_start`. Host-overflow recovery still clears its blocking phase before fallback continuation.