### PR TITLE
fix: pause get_goal-only continuation loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Pause active goals when a hidden continuation run only calls `get_goal` / namespaced `*__get_goal` and makes no actionable progress, so blocked status-inspection loops stop and surface `/goal resume` attention instead of spinning forever (#47).
+
 ## 0.1.38 - 2026-07-19
 
 - Make Pi the sole compaction owner: remove the extension's hardcoded 50k `turn_end` trigger so Pi's effective compaction settings determine threshold behavior and host/extension races cannot produce `Already compacted` or interrupt an active goal.

--- a/src/goal-runtime-agent-handlers.ts
+++ b/src/goal-runtime-agent-handlers.ts
@@ -17,6 +17,7 @@ export function createAgentEventHandlers(deps: GoalRuntimeAgentHandlerContext) {
   return {
     onAgentStart: (async () => {
       runtimeState.agentRunSequence += 1;
+      runtimeState.agentRunFromContinuation = false;
       runtimeState.agentRunToolNames = [];
     }) satisfies ExtensionHandler<AgentStartEvent>,
 
@@ -51,7 +52,6 @@ export function createAgentEventHandlers(deps: GoalRuntimeAgentHandlerContext) {
       if (lastAssistant && recordAssistantContextOverflow(lastAssistant, ctx, deps)) {
         return;
       }
-      resetErrorRecovery();
       if (
         shouldPauseStatusInspectionOnlyContinuation(
           runtimeState.agentRunFromContinuation,
@@ -61,6 +61,7 @@ export function createAgentEventHandlers(deps: GoalRuntimeAgentHandlerContext) {
         stateController.pauseForRecovery(ctx, STATUS_INSPECTION_ONLY_CONTINUATION_REASON);
         return;
       }
+      resetErrorRecovery();
       continuation.maybeContinue(ctx);
     }) satisfies ExtensionHandler<AgentEndEvent>,
   };

--- a/src/goal-runtime-agent-handlers.ts
+++ b/src/goal-runtime-agent-handlers.ts
@@ -6,6 +6,8 @@ import {
   handleAgentErrorMessage,
   recordAssistantContextOverflow,
   runStaleQueuedWorkPlan,
+  shouldPauseStatusInspectionOnlyContinuation,
+  STATUS_INSPECTION_ONLY_CONTINUATION_REASON,
 } from "./goal-runtime-event-utils.js";
 import type { GoalRuntimeAgentHandlerContext } from "./goal-runtime-event-handler-types.js";
 
@@ -15,6 +17,7 @@ export function createAgentEventHandlers(deps: GoalRuntimeAgentHandlerContext) {
   return {
     onAgentStart: (async () => {
       runtimeState.agentRunSequence += 1;
+      runtimeState.agentRunToolNames = [];
     }) satisfies ExtensionHandler<AgentStartEvent>,
 
     onAgentEnd: (async (event, ctx) => {
@@ -49,6 +52,15 @@ export function createAgentEventHandlers(deps: GoalRuntimeAgentHandlerContext) {
         return;
       }
       resetErrorRecovery();
+      if (
+        shouldPauseStatusInspectionOnlyContinuation(
+          runtimeState.agentRunFromContinuation,
+          runtimeState.agentRunToolNames,
+        )
+      ) {
+        stateController.pauseForRecovery(ctx, STATUS_INSPECTION_ONLY_CONTINUATION_REASON);
+        return;
+      }
       continuation.maybeContinue(ctx);
     }) satisfies ExtensionHandler<AgentEndEvent>,
   };

--- a/src/goal-runtime-controller.ts
+++ b/src/goal-runtime-controller.ts
@@ -120,10 +120,7 @@ export function createGoalRuntimeController(pi: ExtensionAPI): GoalRuntimeContro
     getRecoveryState: () => runtimeState.recoveryState,
     clearContinuationState: continuation.clearContinuationState,
     pauseGoalForRecovery(ctx, recoveryReason) {
-      stateController.applyGoalTransition(
-        { kind: "recovery_pause", recoveryReason },
-        ctx,
-      );
+      stateController.pauseForRecovery(ctx, recoveryReason);
     },
     refreshUi: status.refreshUi,
     maybeContinue: continuation.maybeContinue,

--- a/src/goal-runtime-event-handler-types.ts
+++ b/src/goal-runtime-event-handler-types.ts
@@ -105,7 +105,10 @@ export interface StaleQueuedWorkEffectContext {
 }
 
 export interface GoalRuntimeInputContextHandlerContext extends StaleQueuedWorkEffectContext {
-  runtimeState: Pick<GoalRuntimeState, "currentTurnIndex" | "staleQueuedWorkGuard">;
+  runtimeState: Pick<
+    GoalRuntimeState,
+    "agentRunFromContinuation" | "currentTurnIndex" | "staleQueuedWorkGuard"
+  >;
   stateController: Pick<
     GoalStateController,
     "getGoal" | "isCurrentActiveGoalId" | "persistHostOverflowUserReset"
@@ -116,13 +119,20 @@ export interface GoalRuntimeInputContextHandlerContext extends StaleQueuedWorkEf
 }
 
 export interface GoalRuntimeTurnHandlerContext extends StaleQueuedWorkEffectContext {
-  runtimeState: Pick<GoalRuntimeState, "currentTurnIndex" | "staleQueuedWorkGuard">;
+  runtimeState: Pick<
+    GoalRuntimeState,
+    | "agentRunFromContinuation"
+    | "agentRunToolNames"
+    | "currentTurnIndex"
+    | "staleQueuedWorkGuard"
+  >;
   stateController: Pick<
     GoalStateController,
     | "beginOverflowRecovery"
     | "flushGoalPersistence"
     | "maybeFlushRuntimePersistence"
     | "pauseForAbort"
+    | "pauseForRecovery"
   >;
   continuation: Pick<GoalRuntimeContinuationPort, "bindPassthroughContinuationInputToTurn">;
   goalAccounting: GoalAccountingPort;
@@ -130,8 +140,17 @@ export interface GoalRuntimeTurnHandlerContext extends StaleQueuedWorkEffectCont
 }
 
 export interface GoalRuntimeAgentHandlerContext extends StaleQueuedWorkEffectContext {
-  runtimeState: Pick<GoalRuntimeState, "agentRunSequence" | "staleQueuedWorkGuard">;
-  stateController: Pick<GoalStateController, "beginOverflowRecovery" | "flushGoalPersistence" | "pauseForAbort">;
+  runtimeState: Pick<
+    GoalRuntimeState,
+    | "agentRunFromContinuation"
+    | "agentRunSequence"
+    | "agentRunToolNames"
+    | "staleQueuedWorkGuard"
+  >;
+  stateController: Pick<
+    GoalStateController,
+    "beginOverflowRecovery" | "flushGoalPersistence" | "pauseForAbort" | "pauseForRecovery"
+  >;
   continuation: Pick<
     GoalRuntimeContinuationPort,
     "clearPassthroughContinuationInput" | "maybeContinue"

--- a/src/goal-runtime-event-handler-types.ts
+++ b/src/goal-runtime-event-handler-types.ts
@@ -132,7 +132,6 @@ export interface GoalRuntimeTurnHandlerContext extends StaleQueuedWorkEffectCont
     | "flushGoalPersistence"
     | "maybeFlushRuntimePersistence"
     | "pauseForAbort"
-    | "pauseForRecovery"
   >;
   continuation: Pick<GoalRuntimeContinuationPort, "bindPassthroughContinuationInputToTurn">;
   goalAccounting: GoalAccountingPort;

--- a/src/goal-runtime-event-utils.ts
+++ b/src/goal-runtime-event-utils.ts
@@ -63,6 +63,25 @@ export function getContextWindow(ctx: ExtensionContext): number {
   return ctx.model?.contextWindow ?? 0;
 }
 
+/** Hidden continuations that only call get_goal / *.__get_goal are blocked, not progressed. */
+export const STATUS_INSPECTION_ONLY_CONTINUATION_REASON =
+  "continuation only re-inspected goal status with no actionable progress";
+
+export function isGoalStatusInspectionToolName(name: string): boolean {
+  return name === "get_goal" || name.endsWith("__get_goal");
+}
+
+export function isStatusInspectionOnlyToolRun(toolNames: readonly string[]): boolean {
+  return toolNames.length > 0 && toolNames.every(isGoalStatusInspectionToolName);
+}
+
+export function shouldPauseStatusInspectionOnlyContinuation(
+  fromContinuation: boolean,
+  toolNames: readonly string[],
+): boolean {
+  return fromContinuation && isStatusInspectionOnlyToolRun(toolNames);
+}
+
 export function recordAssistantContextOverflow(
   message: AssistantErrorMessage,
   ctx: ExtensionContext,

--- a/src/goal-runtime-input-context-handlers.ts
+++ b/src/goal-runtime-input-context-handlers.ts
@@ -8,7 +8,10 @@ import type {
 
 import { continuationGoalIdFromPrompt } from "./prompts.js";
 import { applyQueuedGoalProviderContextRewrites, extensionQueuedGoalWorkMessageId } from "./queued-goal-work.js";
-import { isCommandResumeQueuedGoalMessage } from "./queued-goal-messages.js";
+import {
+  isActiveGoalQueuedDetails,
+  isCommandResumeQueuedGoalMessage,
+} from "./queued-goal-messages.js";
 import { applyStaleQueuedWorkEffects } from "./goal-runtime-event-utils.js";
 import type {
   ContextEventResult,
@@ -84,18 +87,15 @@ export function createInputContextEventHandlers(
       if (continuationGoalId !== null) {
         continuation.clearContinuationStateFor(continuationGoalId);
         if (!stateController.isCurrentActiveGoalId(continuationGoalId)) {
-          runtimeState.agentRunFromContinuation = false;
           status.refreshUi(ctx);
           return undefined;
         }
-        runtimeState.agentRunFromContinuation = true;
         applyStaleQueuedWorkEffects(
           runtimeState.staleQueuedWorkGuard.planBeforeAgentStartClearAbort().effects,
           ctx,
           deps,
         );
       } else {
-        runtimeState.agentRunFromContinuation = false;
         applyStaleQueuedWorkEffects(
           runtimeState.staleQueuedWorkGuard.planBeforeAgentStartClearAbort().effects,
           ctx,
@@ -123,6 +123,11 @@ export function createInputContextEventHandlers(
       continuation.clearContinuationStateFor(queuedGoalId);
       if (stateController.isCurrentActiveGoalId(queuedGoalId)) {
         runtimeState.staleQueuedWorkGuard.noteRunnableWorkStarted();
+        const details =
+          "details" in event.message ? (event.message as { details?: unknown }).details : undefined;
+        if (isActiveGoalQueuedDetails(details) && details.kind === "continuation") {
+          runtimeState.agentRunFromContinuation = true;
+        }
         if (isCommandResumeQueuedGoalMessage(event.message)) {
           resetErrorRecovery();
         }

--- a/src/goal-runtime-input-context-handlers.ts
+++ b/src/goal-runtime-input-context-handlers.ts
@@ -84,15 +84,18 @@ export function createInputContextEventHandlers(
       if (continuationGoalId !== null) {
         continuation.clearContinuationStateFor(continuationGoalId);
         if (!stateController.isCurrentActiveGoalId(continuationGoalId)) {
+          runtimeState.agentRunFromContinuation = false;
           status.refreshUi(ctx);
           return undefined;
         }
+        runtimeState.agentRunFromContinuation = true;
         applyStaleQueuedWorkEffects(
           runtimeState.staleQueuedWorkGuard.planBeforeAgentStartClearAbort().effects,
           ctx,
           deps,
         );
       } else {
+        runtimeState.agentRunFromContinuation = false;
         applyStaleQueuedWorkEffects(
           runtimeState.staleQueuedWorkGuard.planBeforeAgentStartClearAbort().effects,
           ctx,

--- a/src/goal-runtime-state.ts
+++ b/src/goal-runtime-state.ts
@@ -10,6 +10,8 @@ export interface GoalRuntimeState {
   recoveryState: GoalRecoveryMachineState;
   agentRunSequence: number;
   currentTurnIndex: number | null;
+  agentRunFromContinuation: boolean;
+  agentRunToolNames: string[];
   staleQueuedWorkGuard: StaleQueuedWorkGuard;
 }
 
@@ -19,6 +21,8 @@ export function createGoalRuntimeState(): GoalRuntimeState {
     recoveryState: createGoalRecoveryMachine(),
     agentRunSequence: 0,
     currentTurnIndex: null,
+    agentRunFromContinuation: false,
+    agentRunToolNames: [],
     staleQueuedWorkGuard: createStaleQueuedWorkGuard(),
   };
 }

--- a/src/goal-runtime-turn-handlers.ts
+++ b/src/goal-runtime-turn-handlers.ts
@@ -2,7 +2,12 @@ import type { ExtensionHandler, TurnEndEvent, TurnStartEvent } from "@earendil-w
 
 import { assistantTurnTokens, isAbortedAssistantMessage, isToolUseAssistantMessage } from "./goal-accounting.js";
 import { isAssistantContextOverflow, isErrorAssistantMessage } from "./recovery.js";
-import { getContextWindow, runStaleQueuedWorkPlan } from "./goal-runtime-event-utils.js";
+import {
+  getContextWindow,
+  runStaleQueuedWorkPlan,
+  shouldPauseStatusInspectionOnlyContinuation,
+  STATUS_INSPECTION_ONLY_CONTINUATION_REASON,
+} from "./goal-runtime-event-utils.js";
 import type {
   GoalRuntimeTurnHandlerContext,
   ToolExecutionEndEvent,
@@ -20,11 +25,12 @@ export function createTurnEventHandlers(deps: GoalRuntimeTurnHandlerContext) {
       status.refreshUi(ctx);
     }) satisfies ExtensionHandler<TurnStartEvent>,
 
-    onToolExecutionEnd: (async (_event, ctx) => {
+    onToolExecutionEnd: (async (event, ctx) => {
       if (runStaleQueuedWorkPlan(runtimeState.staleQueuedWorkGuard.planToolExecutionEnd(), ctx, deps)) {
         return;
       }
 
+      runtimeState.agentRunToolNames.push(event.toolName);
       goalAccounting.accountProgress(ctx, true, 0, true);
       stateController.maybeFlushRuntimePersistence("runtime");
     }) satisfies ExtensionHandler<ToolExecutionEndEvent>,
@@ -52,6 +58,15 @@ export function createTurnEventHandlers(deps: GoalRuntimeTurnHandlerContext) {
       }
       if (isAssistantContextOverflow(event.message, getContextWindow(ctx))) {
         stateController.beginOverflowRecovery(ctx);
+        return;
+      }
+      const pauseStatusInspection = shouldPauseStatusInspectionOnlyContinuation(
+        runtimeState.agentRunFromContinuation,
+        runtimeState.agentRunToolNames,
+      );
+      if (pauseStatusInspection && !isToolUseAssistantMessage(event.message)) {
+        recoveryRuntime.finishSuccessfulAssistantTurn(event.message, ctx, { continueGoal: false });
+        stateController.pauseForRecovery(ctx, STATUS_INSPECTION_ONLY_CONTINUATION_REASON);
         return;
       }
       recoveryRuntime.finishSuccessfulAssistantTurn(event.message, ctx, {

--- a/src/goal-runtime-turn-handlers.ts
+++ b/src/goal-runtime-turn-handlers.ts
@@ -6,7 +6,6 @@ import {
   getContextWindow,
   runStaleQueuedWorkPlan,
   shouldPauseStatusInspectionOnlyContinuation,
-  STATUS_INSPECTION_ONLY_CONTINUATION_REASON,
 } from "./goal-runtime-event-utils.js";
 import type {
   GoalRuntimeTurnHandlerContext,
@@ -60,17 +59,12 @@ export function createTurnEventHandlers(deps: GoalRuntimeTurnHandlerContext) {
         stateController.beginOverflowRecovery(ctx);
         return;
       }
-      const pauseStatusInspection = shouldPauseStatusInspectionOnlyContinuation(
+      const suppressContinuation = shouldPauseStatusInspectionOnlyContinuation(
         runtimeState.agentRunFromContinuation,
         runtimeState.agentRunToolNames,
       );
-      if (pauseStatusInspection && !isToolUseAssistantMessage(event.message)) {
-        recoveryRuntime.finishSuccessfulAssistantTurn(event.message, ctx, { continueGoal: false });
-        stateController.pauseForRecovery(ctx, STATUS_INSPECTION_ONLY_CONTINUATION_REASON);
-        return;
-      }
       recoveryRuntime.finishSuccessfulAssistantTurn(event.message, ctx, {
-        continueGoal: !isToolUseAssistantMessage(event.message),
+        continueGoal: !isToolUseAssistantMessage(event.message) && !suppressContinuation,
       });
     }) satisfies ExtensionHandler<TurnEndEvent>,
   };

--- a/src/goal-state-controller.ts
+++ b/src/goal-state-controller.ts
@@ -45,6 +45,7 @@ export interface GoalStateController {
   isCurrentActiveGoalId: (goalId: string) => boolean;
   maybeFlushRuntimePersistence: GoalPersistence["maybeFlushRuntimePersistence"];
   pauseForAbort: (ctx: ExtensionContext) => void;
+  pauseForRecovery: (ctx: ExtensionContext, recoveryReason: string) => void;
   persistHostOverflowUserReset: (needsReset: boolean) => void;
   reloadFromSession: (ctx: ExtensionContext) => void;
   resumePausedGoal: (ctx: StatusContext) => void;
@@ -154,6 +155,15 @@ export function createGoalStateController(deps: GoalStateControllerDeps) {
     applyGoalTransition({ kind: "abort_pause" }, ctx);
   };
 
+  const pauseForRecovery = (ctx: ExtensionContext, recoveryReason: string): void => {
+    const goal = getGoal();
+    if (!goal || goal.status !== "active") {
+      return;
+    }
+
+    applyGoalTransition({ kind: "recovery_pause", recoveryReason }, ctx);
+  };
+
   const resumePausedGoal = (ctx: StatusContext): void => {
     const goal = getGoal();
     if (!goal || goal.status !== "paused") {
@@ -185,6 +195,7 @@ export function createGoalStateController(deps: GoalStateControllerDeps) {
     isCurrentActiveGoalId,
     maybeFlushRuntimePersistence: deps.persistence.maybeFlushRuntimePersistence,
     pauseForAbort,
+    pauseForRecovery,
     persistHostOverflowUserReset,
     reloadFromSession,
     resumePausedGoal,

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -10,6 +10,7 @@ import {
   emitPersistentAssistantError,
   fireProviderLimitAutoResume,
   flushContinuationScheduler,
+  goalUserContextMessage,
   queuedCustomMessage,
   sessionCompactEvent,
   sessionShutdownEvent,
@@ -838,150 +839,140 @@ test("assistant error turns do not immediately queue continuation", async () => 
   assert.equal(harness.sentMessages.length, 0);
 });
 
-test("continuation run that only calls get_goal pauses without queuing another continuation", async () => {
-  const harness = createRuntimeHarness();
-  await harness.runCommand("ship it");
-  const queued = harness.sentMessages[0];
-  assert.ok(queued);
-  const content = String(queued.message.content);
-  harness.sentMessages.length = 0;
-  harness.footerStatuses.length = 0;
-
-  await harness.emit("before_agent_start", {
-    type: "before_agent_start",
-    prompt: content,
-    systemPrompt: "",
-    systemPromptOptions: {},
-  });
+async function finishQueuedCustomRun(
+  harness: ReturnType<typeof createRuntimeHarness>,
+  queued: NonNullable<(typeof harness.sentMessages)[number]>,
+  toolNames: readonly string[],
+): Promise<void> {
   await harness.emit("agent_start", { type: "agent_start" });
-  await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: queuedCustomMessage(queued),
+  });
+
+  let turnIndex = 0;
+  if (toolNames.length > 0) {
+    await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex,
+      message: assistantMessage("toolUse", { input: 8, output: 2 }),
+      toolResults: [],
+    });
+    for (const [index, toolName] of toolNames.entries()) {
+      await harness.emit("tool_execution_end", {
+        type: "tool_execution_end",
+        toolCallId: `tool-call-${index}`,
+        toolName,
+        args: {},
+        result: {},
+        isError: false,
+      });
+    }
+    turnIndex += 1;
+  }
+
+  const stopMessage = assistantMessage("stop", { input: 10, output: 3 });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
   await harness.emit("turn_end", {
     type: "turn_end",
-    turnIndex: 0,
-    message: assistantMessage("toolUse", { input: 10, output: 2 }),
-    toolResults: [],
-  });
-  await harness.emit("tool_execution_end", {
-    type: "tool_execution_end",
-    toolCallId: "tool-call",
-    toolName: "get_goal",
-    args: {},
-    result: {},
-    isError: false,
-  });
-  await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
-  await harness.emit("turn_end", {
-    type: "turn_end",
-    turnIndex: 1,
-    message: assistantMessage("stop", { input: 12, output: 4 }),
+    turnIndex,
+    message: stopMessage,
     toolResults: [],
   });
   await harness.emit("agent_end", {
     type: "agent_end",
-    messages: [assistantMessage("stop", { input: 12, output: 4 })],
+    messages: [stopMessage],
   });
+}
+
+async function queueHiddenContinuation(
+  harness: ReturnType<typeof createRuntimeHarness>,
+): Promise<NonNullable<(typeof harness.sentMessages)[number]>> {
+  await harness.runCommand("ship it");
+  const commandStart = harness.sentMessages[0];
+  assert.ok(commandStart);
+  harness.sentMessages.length = 0;
+
+  // command_start is not a hidden continuation; finishing it should queue one.
+  await finishQueuedCustomRun(harness, commandStart, ["bash"]);
+  const continuation = harness.sentMessages[0];
+  assert.ok(continuation);
+  assert.deepEqual(continuation.message.details, {
+    kind: "continuation",
+    goalId: harness.snapshot().goal?.goalId,
+  });
+  harness.sentMessages.length = 0;
+  return continuation;
+}
+
+for (const toolName of ["get_goal", "pi__get_goal"] as const) {
+  test(`hidden custom continuation that only calls ${toolName} pauses without queuing another continuation`, async () => {
+    const harness = createRuntimeHarness();
+    const continuation = await queueHiddenContinuation(harness);
+    harness.footerStatuses.length = 0;
+
+    await finishQueuedCustomRun(harness, continuation, [toolName]);
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.status, "paused");
+    assert.equal(harness.sentMessages.length, 0);
+    assert.match(harness.footerStatuses.at(-1) ?? "", /Goal needs attention/);
+    assert.match(harness.footerStatuses.at(-1) ?? "", /re-inspected goal status/);
+  });
+}
+
+test("hidden custom continuation with actionable tools still queues continuation", async () => {
+  const harness = createRuntimeHarness();
+  const continuation = await queueHiddenContinuation(harness);
+
+  await finishQueuedCustomRun(harness, continuation, ["get_goal", "bash"]);
 
   const goal = harness.snapshot().goal;
-  assert.equal(goal?.status, "paused");
-  assert.equal(harness.sentMessages.length, 0);
-  assert.match(harness.footerStatuses.at(-1) ?? "", /Goal needs attention/);
-  assert.match(harness.footerStatuses.at(-1) ?? "", /re-inspected goal status/);
+  assert.equal(goal?.status, "active");
+  assert.equal(harness.sentMessages.length, 1);
+  assert.deepEqual(harness.sentMessages[0]?.message.details, {
+    kind: "continuation",
+    goalId: goal?.goalId,
+  });
 });
 
-test("continuation run that only calls namespaced pi__get_goal pauses without queuing another continuation", async () => {
+test("user-driven get_goal-only run stays active and can continue", async () => {
   const harness = createRuntimeHarness();
   await harness.runCommand("ship it");
-  const queued = harness.sentMessages[0];
-  assert.ok(queued);
-  const content = String(queued.message.content);
   harness.sentMessages.length = 0;
 
-  await harness.emit("before_agent_start", {
-    type: "before_agent_start",
-    prompt: content,
-    systemPrompt: "",
-    systemPromptOptions: {},
-  });
   await harness.emit("agent_start", { type: "agent_start" });
+  await harness.emit("message_start", {
+    type: "message_start",
+    message: goalUserContextMessage("what is blocking the goal?"),
+  });
   await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
   await harness.emit("turn_end", {
     type: "turn_end",
     turnIndex: 0,
-    message: assistantMessage("toolUse", { input: 8, output: 1 }),
+    message: assistantMessage("toolUse", { input: 8, output: 2 }),
     toolResults: [],
   });
   await harness.emit("tool_execution_end", {
     type: "tool_execution_end",
     toolCallId: "tool-call",
-    toolName: "pi__get_goal",
-    args: {},
-    result: {},
-    isError: false,
-  });
-  await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
-  await harness.emit("turn_end", {
-    type: "turn_end",
-    turnIndex: 1,
-    message: assistantMessage("stop", { input: 9, output: 2 }),
-    toolResults: [],
-  });
-  await harness.emit("agent_end", {
-    type: "agent_end",
-    messages: [assistantMessage("stop", { input: 9, output: 2 })],
-  });
-
-  assert.equal(harness.snapshot().goal?.status, "paused");
-  assert.equal(harness.sentMessages.length, 0);
-});
-
-test("continuation run with actionable tools still queues continuation", async () => {
-  const harness = createRuntimeHarness();
-  await harness.runCommand("ship it");
-  const queued = harness.sentMessages[0];
-  assert.ok(queued);
-  const content = String(queued.message.content);
-  harness.sentMessages.length = 0;
-
-  await harness.emit("before_agent_start", {
-    type: "before_agent_start",
-    prompt: content,
-    systemPrompt: "",
-    systemPromptOptions: {},
-  });
-  await harness.emit("agent_start", { type: "agent_start" });
-  await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
-  await harness.emit("turn_end", {
-    type: "turn_end",
-    turnIndex: 0,
-    message: assistantMessage("toolUse", { input: 10, output: 2 }),
-    toolResults: [],
-  });
-  await harness.emit("tool_execution_end", {
-    type: "tool_execution_end",
-    toolCallId: "tool-call-1",
     toolName: "get_goal",
     args: {},
     result: {},
     isError: false,
   });
-  await harness.emit("tool_execution_end", {
-    type: "tool_execution_end",
-    toolCallId: "tool-call-2",
-    toolName: "bash",
-    args: {},
-    result: {},
-    isError: false,
-  });
+  const stopMessage = assistantMessage("stop", { input: 10, output: 3 });
   await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
   await harness.emit("turn_end", {
     type: "turn_end",
     turnIndex: 1,
-    message: assistantMessage("stop", { input: 20, output: 5 }),
+    message: stopMessage,
     toolResults: [],
   });
   await harness.emit("agent_end", {
     type: "agent_end",
-    messages: [assistantMessage("stop", { input: 20, output: 5 })],
+    messages: [stopMessage],
   });
 
   const goal = harness.snapshot().goal;

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -845,20 +845,27 @@ async function finishQueuedCustomRun(
   toolNames: readonly string[],
 ): Promise<void> {
   await harness.emit("agent_start", { type: "agent_start" });
+
+  const runMessages: object[] = [];
+  let turnIndex = 0;
+
+  // Pi emits turn_start before the initial custom message_start for triggerTurn custom prompts.
+  await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
   await harness.emit("message_start", {
     type: "message_start",
     message: queuedCustomMessage(queued),
   });
 
-  let turnIndex = 0;
   if (toolNames.length > 0) {
-    await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
-    await harness.emit("turn_end", {
-      type: "turn_end",
-      turnIndex,
-      message: assistantMessage("toolUse", { input: 8, output: 2 }),
-      toolResults: [],
-    });
+    const toolUseMessage = {
+      ...assistantMessage("toolUse", { input: 8, output: 2 }),
+      content: toolNames.map((name, index) => ({
+        type: "toolCall" as const,
+        id: `tool-call-${index}`,
+        name,
+        arguments: {},
+      })),
+    };
     for (const [index, toolName] of toolNames.entries()) {
       await harness.emit("tool_execution_end", {
         type: "tool_execution_end",
@@ -869,11 +876,19 @@ async function finishQueuedCustomRun(
         isError: false,
       });
     }
+    await harness.emit("turn_end", {
+      type: "turn_end",
+      turnIndex,
+      message: toolUseMessage,
+      toolResults: [],
+    });
+    runMessages.push(toolUseMessage);
     turnIndex += 1;
+    await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
   }
 
   const stopMessage = assistantMessage("stop", { input: 10, output: 3 });
-  await harness.emit("turn_start", { type: "turn_start", turnIndex, timestamp: turnIndex + 1 });
+  runMessages.push(stopMessage);
   await harness.emit("turn_end", {
     type: "turn_end",
     turnIndex,
@@ -882,7 +897,7 @@ async function finishQueuedCustomRun(
   });
   await harness.emit("agent_end", {
     type: "agent_end",
-    messages: [stopMessage],
+    messages: runMessages,
   });
 }
 

--- a/test/continuation.test.ts
+++ b/test/continuation.test.ts
@@ -837,3 +837,158 @@ test("assistant error turns do not immediately queue continuation", async () => 
   assert.equal(goal?.usage.tokensUsed, 42);
   assert.equal(harness.sentMessages.length, 0);
 });
+
+test("continuation run that only calls get_goal pauses without queuing another continuation", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const content = String(queued.message.content);
+  harness.sentMessages.length = 0;
+  harness.footerStatuses.length = 0;
+
+  await harness.emit("before_agent_start", {
+    type: "before_agent_start",
+    prompt: content,
+    systemPrompt: "",
+    systemPromptOptions: {},
+  });
+  await harness.emit("agent_start", { type: "agent_start" });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 0,
+    message: assistantMessage("toolUse", { input: 10, output: 2 }),
+    toolResults: [],
+  });
+  await harness.emit("tool_execution_end", {
+    type: "tool_execution_end",
+    toolCallId: "tool-call",
+    toolName: "get_goal",
+    args: {},
+    result: {},
+    isError: false,
+  });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 1,
+    message: assistantMessage("stop", { input: 12, output: 4 }),
+    toolResults: [],
+  });
+  await harness.emit("agent_end", {
+    type: "agent_end",
+    messages: [assistantMessage("stop", { input: 12, output: 4 })],
+  });
+
+  const goal = harness.snapshot().goal;
+  assert.equal(goal?.status, "paused");
+  assert.equal(harness.sentMessages.length, 0);
+  assert.match(harness.footerStatuses.at(-1) ?? "", /Goal needs attention/);
+  assert.match(harness.footerStatuses.at(-1) ?? "", /re-inspected goal status/);
+});
+
+test("continuation run that only calls namespaced pi__get_goal pauses without queuing another continuation", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const content = String(queued.message.content);
+  harness.sentMessages.length = 0;
+
+  await harness.emit("before_agent_start", {
+    type: "before_agent_start",
+    prompt: content,
+    systemPrompt: "",
+    systemPromptOptions: {},
+  });
+  await harness.emit("agent_start", { type: "agent_start" });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 0,
+    message: assistantMessage("toolUse", { input: 8, output: 1 }),
+    toolResults: [],
+  });
+  await harness.emit("tool_execution_end", {
+    type: "tool_execution_end",
+    toolCallId: "tool-call",
+    toolName: "pi__get_goal",
+    args: {},
+    result: {},
+    isError: false,
+  });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 1,
+    message: assistantMessage("stop", { input: 9, output: 2 }),
+    toolResults: [],
+  });
+  await harness.emit("agent_end", {
+    type: "agent_end",
+    messages: [assistantMessage("stop", { input: 9, output: 2 })],
+  });
+
+  assert.equal(harness.snapshot().goal?.status, "paused");
+  assert.equal(harness.sentMessages.length, 0);
+});
+
+test("continuation run with actionable tools still queues continuation", async () => {
+  const harness = createRuntimeHarness();
+  await harness.runCommand("ship it");
+  const queued = harness.sentMessages[0];
+  assert.ok(queued);
+  const content = String(queued.message.content);
+  harness.sentMessages.length = 0;
+
+  await harness.emit("before_agent_start", {
+    type: "before_agent_start",
+    prompt: content,
+    systemPrompt: "",
+    systemPromptOptions: {},
+  });
+  await harness.emit("agent_start", { type: "agent_start" });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 0, timestamp: 1 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 0,
+    message: assistantMessage("toolUse", { input: 10, output: 2 }),
+    toolResults: [],
+  });
+  await harness.emit("tool_execution_end", {
+    type: "tool_execution_end",
+    toolCallId: "tool-call-1",
+    toolName: "get_goal",
+    args: {},
+    result: {},
+    isError: false,
+  });
+  await harness.emit("tool_execution_end", {
+    type: "tool_execution_end",
+    toolCallId: "tool-call-2",
+    toolName: "bash",
+    args: {},
+    result: {},
+    isError: false,
+  });
+  await harness.emit("turn_start", { type: "turn_start", turnIndex: 1, timestamp: 2 });
+  await harness.emit("turn_end", {
+    type: "turn_end",
+    turnIndex: 1,
+    message: assistantMessage("stop", { input: 20, output: 5 }),
+    toolResults: [],
+  });
+  await harness.emit("agent_end", {
+    type: "agent_end",
+    messages: [assistantMessage("stop", { input: 20, output: 5 })],
+  });
+
+  const goal = harness.snapshot().goal;
+  assert.equal(goal?.status, "active");
+  assert.equal(harness.sentMessages.length, 1);
+  assert.deepEqual(harness.sentMessages[0]?.message.details, {
+    kind: "continuation",
+    goalId: goal?.goalId,
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #47: when a hidden continuation run only executes `get_goal` / namespaced `*__get_goal` (no actionable tools), pause the goal and surface `/goal resume` attention instead of queuing another continuation.
- Tracks per-agent-run tool names + whether the run came from a continuation prompt; normal tool progress and user-driven runs keep existing continuation behavior.
- Also closes #45 and #46: already fixed on main by `707c754` (Pi owns compaction; extension no longer calls proactive `ctx.compact()`).

## Test plan
- [x] `npm run verify` (tsc, platform-smoke checks, 332 tests)
- [x] Regression: get_goal-only continuation → paused, no continuation queued
- [x] Regression: `pi__get_goal`-only continuation → paused
- [x] Regression: get_goal + bash continuation → still continues