### PR TITLE
docs: clarify that omitting token_budget creates an unbounded goal

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -15,7 +15,7 @@ const CreateGoalParams = Type.Object({
   }),
   token_budget: Type.Optional(
     Type.Integer({
-      description: "Optional positive integer token budget.",
+      description: "Optional positive integer token budget. Omit or set to null for unbounded (no limit).",
       minimum: 1,
     }),
   ),


### PR DESCRIPTION
## Problem

The current description for the  parameter is:
> Optional positive integer token budget.

This doesn't make it clear what happens when the parameter is omitted. Users (and models) may incorrectly assume they must always provide a numeric budget.

## Solution

Updated the description to explicitly state the behavior when omitted:
> Optional positive integer token budget. Omit or set to null for unbounded (no limit).

## Changes

- : Updated  parameter description in 

## Context

When  is omitted (or /), the goal is created with , which means no token limit. The system already handles this correctly (showing 'none' for budget and 'unbounded' for remaining tokens), but the tool description didn't communicate this option to users/models.