### PR TITLE
Release 0.2.0 for Pi 0.84.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ pi install -l npm:pi-codex-goal
 pi install -l https://github.com/fitchmultz/pi-codex-goal@vX.Y.Z
 ```
 
-Those write duplicate package entries under `.pi/` for the current project, causing `get_goal`, `create_goal`, and `update_goal` tool-registration conflicts with the global local-checkout install. For install-path release verification, use an isolated temp project/config directory or remove the project-local entries immediately after the check. With Pi 0.79+ project trust, pass `--approve` for isolated project-local package install/list/non-interactive smoke commands when those commands must load `.pi/settings.json`. If conflicts appear, inspect `pi list --approve` and `.pi/settings.json`, then remove any project-local `pi-codex-goal` npm/GitHub installs so only the global local-checkout package remains active.
+Those write duplicate package entries under `.pi/` for the current project, causing `get_goal`, `create_goal`, and `update_goal` tool-registration conflicts with the global local-checkout install. For install-path release verification, use an isolated temp project/config directory or remove the project-local entries immediately after the check. On Pi 0.84.0 or later, pass `--approve` for isolated project-local package install/list/non-interactive smoke commands when those commands must load `.pi/settings.json`. If conflicts appear, inspect `pi list --approve` and `.pi/settings.json`, then remove any project-local `pi-codex-goal` npm/GitHub installs so only the global local-checkout package remains active.
 
 ## Verify before finishing
 
@@ -50,4 +50,4 @@ The required gate runs the full suite plus a real model-backed goal-tool smoke o
 | Recovery | `recovery*.ts` |
 | Domain | `state.ts`, `types.ts`, `goal-persistence.ts` |
 
-Current structural audit and remediation record: `docs/CODEBASE_AUDIT.md`.
+Historical 0.1.33 structural audit and remediation record: `docs/CODEBASE_AUDIT.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.2.0 - 2026-08-06
+
+- Raise the minimum supported Pi version to 0.84.0 and pin the development/type-validation baseline to the exact 0.84.0 release.
+- Align the SDK runtime smoke with Pi 0.84.0's public `Agent.streamFunction` API and use current pi-ai root exports instead of the compatibility subpath.
+- Align the extension test harness with Pi 0.84.0's `registerMarkdownTransformer()` and read-only `scopedModels` context contracts, and serialize the mutating goal tools because they share one session state machine.
+- Audit the full repository against every Pi 0.84.0 breaking change; the extension does not use JSON/RPC streaming, model-auth forwarding, dynamic providers, pi-agent-core harness sessions, custom harness filesystems, or remote sessions, so those migrations require no runtime compatibility code.
+- Require Pi 0.84.0 or later in install and compatibility documentation while retaining optional wildcard Pi peers as required by Pi package loading.
+- Refresh the development lockfile, including the patched `protobufjs` 7.6.5 transitive dependency.
+
+### Validation
+
+- Ran `npm run verify` and a clean public-registry `npm ci && npm run verify` under Pi 0.84.0: `tsc --noEmit`, 6 platform-smoke checks, and 333 regular tests passed in each run.
+- Ran `npm audit --omit=optional` with no vulnerabilities and `npm publish --dry-run --ignore-scripts --registry=https://registry.npmjs.org`; both passed.
+- Packed the release and installed it project-locally with an isolated Pi 0.84.0 executable/config, verified extension and prompt discovery over RPC, and completed a tmux model-backed `/goal` flow that created and read an exact file, called `get_goal`, called `update_goal`, and rendered the final fullscreen `Goal achieved` status.
+- The Crabbox macOS/Ubuntu/native-Windows matrix could not start on this shared host: its doctor stopped before every product suite because Crabbox, model-auth environment, localhost SSH, and Parallels `prlctl` were unavailable. No Crabbox product test ran or failed; the matrix remains required and unchanged for capable environments.
+
 ## 0.1.39 - 2026-07-28
 
 - Pause active goals when a hidden continuation run only calls `get_goal` / namespaced `*__get_goal` and makes no actionable progress, so blocked status-inspection loops stop and surface `/goal resume` attention instead of spinning forever (#47).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Goal state is stored in pi session custom entries, so it follows session history
 
 ## Install
 
+Requires Pi 0.84.0 or later.
+
 Install from npm:
 
 ```sh
@@ -45,7 +47,7 @@ pi install .
 
 On this maintainer machine, the active install is a global/user package that already points at this checkout; do not also leave a project-local install under this repository's `.pi/` settings. Duplicate local and global installs both try to register `get_goal`, `create_goal`, and `update_goal`, which causes tool-registration conflicts. For install-path release checks, use an isolated temp project/config directory or remove the project-local entry immediately after the check.
 
-Compatibility note: this package is tested against the current pi release during each package update. The current source tree targets Pi 0.80.10 on Node 24 for the next package release. The latest published npm artifact remains the reproducible source of truth for its own published version's metadata. Pi-bundled runtime packages remain optional wildcard peers, so npm peer ranges do not hard-block users from trying newer pi releases; runtime behavior is only verified against the tested baseline until a follow-up package release confirms it.
+Compatibility note: this package supports Pi 0.84.0 or later on Node 24. The latest published npm artifact remains the reproducible source of truth for its own published version's metadata. Pi-bundled runtime packages remain optional wildcard peers as required by Pi package loading; the support floor is declared here and validated by the source tree's exact Pi 0.84.0 development dependencies.
 
 Release note: npm installs and pinned GitHub tags are the reproducible release artifacts. Installing from the repository default branch can include unreleased changes that will ship in a future package release, even when `package.json` still identifies the latest published version.
 
@@ -81,10 +83,10 @@ npm run smoke:platform:all
 
 `smoke:platform:all` runs the doctor before any target suite.
 
-That local gate runs `npm run verify`, packs the package, installs the packed package into a clean pi project, checks `pi list`, and runs a real model-backed goal-tool smoke on macOS, Ubuntu Linux, and native Windows. Pi 0.79+ project trust is handled explicitly with `--approve` inside the isolated smoke projects so project-local package settings and the packed extension load in non-interactive runs. The runtime smoke defaults to `zai/glm-5.2`; override it with `PLATFORM_SMOKE_MODEL` and configure forwarded auth env vars with `PLATFORM_SMOKE_AUTH_ENV`. Setup and artifact details: [docs/platform-smoke.md](docs/platform-smoke.md).
+That local gate runs `npm run verify`, packs the package, installs the packed package into a clean pi project, checks `pi list`, and runs a real model-backed goal-tool smoke on macOS, Ubuntu Linux, and native Windows. Pi 0.84.0-or-later project trust is handled explicitly with `--approve` inside the isolated smoke projects so project-local package settings and the packed extension load in non-interactive runs. The runtime smoke defaults to `zai/glm-5.2`; override it with `PLATFORM_SMOKE_MODEL` and configure forwarded auth env vars with `PLATFORM_SMOKE_AUTH_ENV`. Setup and artifact details: [docs/platform-smoke.md](docs/platform-smoke.md).
 
 Project agent notes and module map: [AGENTS.md](AGENTS.md).
-Current structural audit and remediation record: [docs/CODEBASE_AUDIT.md](docs/CODEBASE_AUDIT.md).
+Historical 0.1.33 structural audit and remediation record: [docs/CODEBASE_AUDIT.md](docs/CODEBASE_AUDIT.md).
 
 ## Interactive smoke tests
 

--- a/docs/platform-smoke.md
+++ b/docs/platform-smoke.md
@@ -76,14 +76,14 @@ Each required target runs `platform-build` and `goal-runtime-smoke`.
 4. Run `npm pack`.
 5. Create a clean target-local pi project.
 6. Install the packed tarball into that project with `npm install --no-save`.
-7. Run `pi install -l ./node_modules/pi-codex-goal --approve` from the clean project so Pi 0.79+ can read and write project-local package settings for this isolated command.
+7. Run `pi install -l ./node_modules/pi-codex-goal --approve` from the clean project so supported Pi 0.84.0-or-later hosts can read and write project-local package settings for this isolated command.
 8. Run `pi list --approve` and assert `pi-codex-goal` is registered from the packed install.
 9. Assert the smoke never used the source shortcut `pi -e .` or `pi --extension .`.
 
 ### `goal-runtime-smoke`
 
 1. Re-pack and install the package into a clean target-local pi project.
-2. Run real `pi --approve --model <model> -p <prompt>` against that packed install so non-interactive Pi 0.79+ loads the isolated project-local package settings.
+2. Run real `pi --approve --model <model> -p <prompt>` against that packed install so non-interactive Pi 0.84.0-or-later hosts load the isolated project-local package settings.
 3. Prompt the model to call the actual goal tools, create a marker file, verify it with the built-in `read` tool, call `update_goal`, and confirm completion.
 4. Capture pi stdout/stderr and session JSONL.
 5. Assert the final marker, verified file, `pi-codex-goal` custom entries, built-in `read` tool evidence, and complete goal status.
@@ -142,7 +142,7 @@ The suites record failures as artifacts before reporting failure so the host can
 - Keep `platform-build` behavior in the shared Node orchestrator; native Windows may use only a thin PowerShell wrapper to launch it.
 - Run the repository's existing validation command on every required target.
 - Test the packed package, not `pi -e .`.
-- Pass `--approve` for isolated project-local package smoke commands and non-interactive runtime smokes; Pi 0.79+ otherwise skips project-local settings and packages when no saved trust decision exists.
+- Pass `--approve` for isolated project-local package smoke commands and non-interactive runtime smokes; Pi 0.84.0-or-later hosts otherwise skip project-local settings and packages when no saved trust decision exists.
 - Include a real model-backed pi run so release claims are not based on unit tests alone.
 - Assert built-in `read` evidence in the model-backed runtime smoke so post-tool goal completion stays covered.
 - Keep project-specific defaults in `platform-smoke.config.mjs`; use environment variables only for local overrides.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.39",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-codex-goal",
-      "version": "0.1.39",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.80.10",
-        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@earendil-works/pi-ai": "0.84.0",
+        "@earendil-works/pi-coding-agent": "0.84.0",
         "@types/node": "^25.9.1",
         "tsx": "^4.22.3",
-        "typebox": "1.1.39",
+        "typebox": "1.3.7",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -517,14 +517,15 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
-      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
+      "integrity": "sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.0",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
@@ -533,7 +534,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -542,29 +543,25 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
-      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.0.tgz",
+      "integrity": "sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.10",
-        "@earendil-works/pi-ai": "^0.80.10",
-        "@earendil-works/pi-tui": "^0.80.10",
+        "@earendil-works/pi-agent-core": "^0.84.0",
+        "@earendil-works/pi-ai": "^0.84.0",
+        "@earendil-works/pi-client": "^0.84.0",
+        "@earendil-works/pi-protocol": "^0.84.0",
+        "@earendil-works/pi-tui": "^0.84.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
         "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
         "ignore": "7.0.5",
@@ -572,8 +569,8 @@
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
-        "typebox": "1.1.38",
-        "undici": "8.5.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -1049,14 +1046,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.84.0",
+        "@earendil-works/pi-telemetry": "^0.84.0",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -1064,13 +1063,14 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.0",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
@@ -1079,7 +1079,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -1088,9 +1088,42 @@
         "node": ">=22.19.0"
       }
     },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.0.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.0.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.10",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1205,9 +1238,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1225,9 +1255,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,9 +1272,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1265,9 +1289,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1285,9 +1306,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1656,16 +1674,16 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
@@ -1929,6 +1947,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
       "version": "10.7.3",
@@ -2274,9 +2302,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -2399,16 +2427,16 @@
       "license": "0BSD"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2520,6 +2548,16 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
+      "integrity": "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3735,9 +3773,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -3836,9 +3874,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.1.39",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.39.tgz",
-      "integrity": "sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.1.39",
+  "version": "0.2.0",
   "description": "Codex-style goal tracking and continuation for pi.",
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",
@@ -71,11 +71,11 @@
     }
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.80.10",
-    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
     "@types/node": "^25.9.1",
     "tsx": "^4.22.3",
-    "typebox": "1.1.39",
+    "typebox": "1.3.7",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/src/recovery-adapters.ts
+++ b/src/recovery-adapters.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage, StopReason } from "@earendil-works/pi-ai/compat";
+import type { AssistantMessage, StopReason } from "@earendil-works/pi-ai";
 
 export interface OverflowCheckAssistantMessage {
   stopReason?: string;

--- a/src/recovery.ts
+++ b/src/recovery.ts
@@ -1,4 +1,4 @@
-import { isContextOverflow } from "@earendil-works/pi-ai/compat";
+import { isContextOverflow } from "@earendil-works/pi-ai";
 
 import { assistantMessageForOverflowCheck } from "./recovery-adapters.js";
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,4 +1,4 @@
-import { StringEnum } from "@earendil-works/pi-ai/compat";
+import { StringEnum } from "@earendil-works/pi-ai";
 import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
@@ -76,6 +76,7 @@ export function registerGoalTools(pi: ExtensionAPI, host: ToolHost): void {
       "Create one goal with an objective and optional positive token budget. Fails when a non-complete goal already exists unless replace_existing is true; replaces a completed goal.",
     promptGuidelines: TOOL_PROMPT_GUIDELINES,
     parameters: CreateGoalParams,
+    executionMode: "sequential",
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const current = host.getGoal();
       const shouldReplaceExisting = params.replace_existing === true && current !== null && current.status !== "complete";
@@ -98,6 +99,7 @@ export function registerGoalTools(pi: ExtensionAPI, host: ToolHost): void {
     promptSnippet: "Mark the current goal complete only after an evidence-backed completion audit proves no required work remains.",
     promptGuidelines: TOOL_PROMPT_GUIDELINES,
     parameters: UpdateGoalParams,
+    executionMode: "sequential",
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
       const result = host.completeGoal("tool", ctx);
       if (!result.ok || !result.goal) {

--- a/test/sdk-runtime-smoke.test.ts
+++ b/test/sdk-runtime-smoke.test.ts
@@ -110,7 +110,7 @@ test("SDK runtime uses Pi settings for the sole persisted threshold compaction",
 
   let nextContextTokens = 247_783;
   let streamCalls = 0;
-  session.agent.streamFn = (activeModel) => {
+  session.agent.streamFunction = (activeModel) => {
     streamCalls += 1;
     return assistantResponse(
       activeModel,
@@ -172,6 +172,10 @@ test("SDK runtime emits a continuation after willRetry compaction when no retry 
 
   try {
     const runner = session.extensionRunner;
+    assert.equal(runner.getToolDefinition("get_goal")?.executionMode, undefined);
+    for (const toolName of ["create_goal", "update_goal"]) {
+      assert.equal(runner.getToolDefinition(toolName)?.executionMode, "sequential");
+    }
     const createGoal = runner.getToolDefinition("create_goal");
     assert.ok(createGoal);
     const result = await createGoal.execute(

--- a/test/support/runtime-harness.ts
+++ b/test/support/runtime-harness.ts
@@ -162,6 +162,9 @@ export function createRuntimeHarness(options: {
     registerMessageRenderer() {
       unsupportedHarnessMethod("pi.registerMessageRenderer");
     },
+    registerMarkdownTransformer() {
+      unsupportedHarnessMethod("pi.registerMarkdownTransformer");
+    },
     registerProvider() {
       unsupportedHarnessMethod("pi.registerProvider");
     },
@@ -295,6 +298,7 @@ export function createRuntimeHarness(options: {
     isProjectTrusted: () => true,
     mode: "tui",
     model: undefined,
+    scopedModels: [],
     modelRegistry: {} as ExtensionCommandContext["modelRegistry"],
     navigateTree: async () => ({ cancelled: false }),
     newSession: async () => ({ cancelled: false }),


### PR DESCRIPTION
## Summary

- release `pi-codex-goal` 0.2.0 with Pi 0.84.0 as the minimum supported host
- pin Pi development/type dependencies to exact 0.84.0 while retaining optional wildcard host peers
- migrate the SDK smoke and extension harness to current Pi APIs, move off the pi-ai compatibility subpath, and serialize mutating goal tools
- document the support floor, complete the 12-item Pi 0.84 breaking-change audit, and refresh the public-registry lockfile

This is a breaking support-floor change, so the release moves from 0.1.39 to 0.2.0. No runtime compatibility shims remain or were added.

## Validation

- `npm run verify`: typecheck, 6 platform-smoke checks, and all 333 tests passed
- clean public-registry `npm ci && npm run verify`: passed with the same counts
- `npm audit --omit=optional`: no vulnerabilities
- `npm publish --dry-run --ignore-scripts --registry=https://registry.npmjs.org`: passed; no npm publish will be performed for this release
- packed 0.2.0 tarball installed project-locally under an isolated Pi 0.84.0 executable/config; `pi list` and RPC discovery found `/goal` and `/create-goal`
- exact-head tmux dogfood passed in Pi 0.84.0 fullscreen TUI: `/goal` created and read `PI_GOAL_084_FINAL_OK`, called `get_goal`, completed through `update_goal`, and rendered `Goal achieved (14s)`; tmux session and temporary credential/file copies were removed

## Environment-blocked matrix

`npm run smoke:platform:all` stopped in its doctor before any product suite ran because this shared host does not provide:

- Crabbox on `PATH`
- the configured model-auth environment
- localhost SSH
- Parallels `prlctl`

No Crabbox macOS, Ubuntu, or native-Windows product test ran or failed. The required matrix and its scripts remain unchanged. CI and independent reviewer results must be green before merge.

## Release plan

After the reviewed PR head is merged, tag the resulting `main` commit as `v0.2.0` and create the GitHub release. Do not publish to npm.
