### PR TITLE
fix: resume active goals after settled compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Resume an active goal from `agent_settled` when a post-compaction fallback remains pending, so a successful compaction or an empty host retry cannot strand the goal without a queued continuation (#53).
+
 ## 0.2.0 - 2026-08-06
 
 - Raise the minimum supported Pi version to 0.84.0 and pin the development/type-validation baseline to the exact 0.84.0 release.

--- a/src/continuation-scheduler.ts
+++ b/src/continuation-scheduler.ts
@@ -31,6 +31,7 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
   let continuationScheduledDelayMs: number | null = null;
   let continuationTimer: ReturnType<typeof setTimeout> | null = null;
   let postCompactContinuationTimer: ReturnType<typeof setTimeout> | null = null;
+  let postCompactContinuationFallback: (() => void) | null = null;
   let passthroughContinuationInput: { text: string; turnIndex: number | null } | null = null;
 
   const clearContinuationTimer = (): void => {
@@ -43,11 +44,11 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
   };
 
   const clearPostCompactContinuationFallback = (): void => {
-    if (!postCompactContinuationTimer) {
-      return;
+    if (postCompactContinuationTimer) {
+      clearTimeout(postCompactContinuationTimer);
+      postCompactContinuationTimer = null;
     }
-    clearTimeout(postCompactContinuationTimer);
-    postCompactContinuationTimer = null;
+    postCompactContinuationFallback = null;
   };
 
   const clearContinuationState = (): void => {
@@ -211,31 +212,59 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
     }
 
     const goalId = goal.goalId;
-    const runFallback = (): void => {
+    const runFallback = (ignoreRunIdentity: boolean): void => {
       postCompactContinuationTimer = null;
       const currentGoal = deps.getGoal();
-      if (!currentGoal || currentGoal.status !== "active" || currentGoal.goalId !== goalId) {
+      if (
+        !canSchedulePostCompactFallbackFor(currentGoal, options.prepareContinuation) ||
+        currentGoal.goalId !== goalId
+      ) {
+        clearPostCompactContinuationFallback();
         return;
       }
-      if (deps.getCurrentTurnIndex() !== options.turnIndex) {
-        return;
-      }
-      if (deps.getAgentRunSequence() !== options.agentRunSequence) {
+      if (
+        !ignoreRunIdentity &&
+        (deps.getCurrentTurnIndex() !== options.turnIndex ||
+          deps.getAgentRunSequence() !== options.agentRunSequence)
+      ) {
+        // A host retry now owns continuation. Keep the fallback dormant until
+        // agent_settled proves that retry left no runnable work behind.
         return;
       }
       if (!ctx.isIdle() || ctx.hasPendingMessages()) {
-        postCompactContinuationTimer = setTimeout(runFallback, CONTINUATION_RETRY_MS);
+        postCompactContinuationTimer = setTimeout(
+          () => runFallback(false),
+          CONTINUATION_RETRY_MS,
+        );
         postCompactContinuationTimer.unref?.();
         return;
       }
       if (options.prepareContinuation && !options.prepareContinuation()) {
+        clearPostCompactContinuationFallback();
         return;
       }
+      clearPostCompactContinuationFallback();
       maybeContinue(ctx);
     };
 
-    postCompactContinuationTimer = setTimeout(runFallback, CONTINUATION_RETRY_MS);
+    postCompactContinuationFallback = () => {
+      if (postCompactContinuationTimer) {
+        clearTimeout(postCompactContinuationTimer);
+        postCompactContinuationTimer = null;
+      }
+      // agent_settled guarantees that no host retry remains runnable, so a
+      // lifecycle identity change no longer justifies abandoning the fallback.
+      runFallback(true);
+    };
+    postCompactContinuationTimer = setTimeout(
+      () => runFallback(false),
+      CONTINUATION_RETRY_MS,
+    );
     postCompactContinuationTimer.unref?.();
+  };
+
+  const settlePostCompactContinuationFallback = (): void => {
+    postCompactContinuationFallback?.();
   };
 
   return {
@@ -251,5 +280,6 @@ export function createContinuationScheduler(deps: ContinuationSchedulerDeps) {
     maybeContinueAfterCurrentEvent,
     maybeContinueAfterPostCompactFallback,
     notePassthroughContinuationInput,
+    settlePostCompactContinuationFallback,
   };
 }

--- a/src/goal-runtime-agent-handlers.ts
+++ b/src/goal-runtime-agent-handlers.ts
@@ -1,4 +1,9 @@
-import type { AgentEndEvent, AgentStartEvent, ExtensionHandler } from "@earendil-works/pi-coding-agent";
+import type {
+  AgentEndEvent,
+  AgentSettledEvent,
+  AgentStartEvent,
+  ExtensionHandler,
+} from "@earendil-works/pi-coding-agent";
 
 import { assistantTurnTokens, isAbortedAssistantMessage } from "./goal-accounting.js";
 import { isErrorAssistantMessage, type AssistantErrorMessage } from "./recovery.js";
@@ -20,6 +25,10 @@ export function createAgentEventHandlers(deps: GoalRuntimeAgentHandlerContext) {
       runtimeState.agentRunFromContinuation = false;
       runtimeState.agentRunToolNames = [];
     }) satisfies ExtensionHandler<AgentStartEvent>,
+
+    onAgentSettled: (() => {
+      continuation.settlePostCompactContinuationFallback();
+    }) satisfies ExtensionHandler<AgentSettledEvent>,
 
     onAgentEnd: (async (event, ctx) => {
       continuation.clearPassthroughContinuationInput();

--- a/src/goal-runtime-event-handler-types.ts
+++ b/src/goal-runtime-event-handler-types.ts
@@ -1,5 +1,6 @@
 import type {
   AgentEndEvent,
+  AgentSettledEvent,
   AgentStartEvent,
   BeforeAgentStartEvent,
   ContextEvent,
@@ -35,6 +36,7 @@ export interface GoalRuntimeEventHandlers {
   onSessionTree: ExtensionHandler<SessionTreeEvent>;
   onBeforeAgentStart: ExtensionHandler<BeforeAgentStartEvent, undefined>;
   onAgentStart: ExtensionHandler<AgentStartEvent>;
+  onAgentSettled: ExtensionHandler<AgentSettledEvent>;
   onMessageStart: ExtensionHandler<MessageStartEvent>;
   onTurnStart: ExtensionHandler<TurnStartEvent>;
   onToolExecutionEnd: ExtensionHandler<ToolExecutionEndEvent>;
@@ -74,6 +76,7 @@ export interface GoalRuntimeContinuationPort {
     },
   ) => void;
   notePassthroughContinuationInput: (input: string) => void;
+  settlePostCompactContinuationFallback: () => void;
 }
 
 export interface GoalAccountingPort {
@@ -152,7 +155,9 @@ export interface GoalRuntimeAgentHandlerContext extends StaleQueuedWorkEffectCon
   >;
   continuation: Pick<
     GoalRuntimeContinuationPort,
-    "clearPassthroughContinuationInput" | "maybeContinue"
+    | "clearPassthroughContinuationInput"
+    | "maybeContinue"
+    | "settlePostCompactContinuationFallback"
   >;
   goalAccounting: Pick<GoalAccountingPort, "accountProgress">;
   recoveryRuntime: Pick<

--- a/src/goal-runtime-events.ts
+++ b/src/goal-runtime-events.ts
@@ -12,6 +12,7 @@ export function registerGoalRuntimeEvents(
   pi.on("session_tree", (event, ctx) => controller.onSessionTree(event, ctx));
   pi.on("before_agent_start", (event, ctx) => controller.onBeforeAgentStart(event, ctx));
   pi.on("agent_start", (event, ctx) => controller.onAgentStart(event, ctx));
+  pi.on("agent_settled", (event, ctx) => controller.onAgentSettled(event, ctx));
   pi.on("message_start", (event, ctx) => controller.onMessageStart(event, ctx));
   pi.on("turn_start", (event, ctx) => controller.onTurnStart(event, ctx));
   pi.on("tool_execution_end", (event, ctx) => controller.onToolExecutionEnd(event, ctx));

--- a/test/compaction-continuation.test.ts
+++ b/test/compaction-continuation.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { mock, test } from "node:test";
 
 import {
+  assistantMessage,
   createRuntimeHarness,
+  emitSilentContextOverflow,
   flushContinuationScheduler,
   sessionCompactEvent,
   type RuntimeHarness,
@@ -96,6 +98,111 @@ test("willRetry session compaction fallback is cancelled when host retry starts"
 
     flushContinuationScheduler();
     assert.equal(harness.sentMessages.length, 0);
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("settled host retry without continuation resumes the active goal", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness();
+    await startQueuedContinuation(harness);
+
+    await harness.emit("session_compact", sessionCompactEvent({ willRetry: true }));
+    await harness.emit("agent_start", { type: "agent_start" });
+    flushContinuationScheduler();
+    assert.equal(harness.sentMessages.length, 0);
+
+    await harness.emit("agent_settled", { type: "agent_settled" });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "continuation",
+      goalId: goal?.goalId,
+    });
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("successful overflow compaction resumes the active goal when the host settles", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness({ contextWindow: 128_000 });
+    await harness.runCommand("ship it");
+    harness.sentMessages.length = 0;
+
+    await emitSilentContextOverflow(
+      harness,
+      0,
+      assistantMessage("stop", { input: 130_000, output: 0, cacheRead: 0 }),
+    );
+    await harness.emit(
+      "session_compact",
+      sessionCompactEvent({ reason: "overflow", willRetry: false }),
+    );
+
+    assert.equal(harness.sentMessages.length, 0);
+    await harness.emit("agent_settled", { type: "agent_settled" });
+
+    const goal = harness.snapshot().goal;
+    assert.equal(goal?.status, "active");
+    assert.equal(harness.sentMessages.length, 1);
+    assert.deepEqual(harness.sentMessages[0]?.message.details, {
+      kind: "continuation",
+      goalId: goal?.goalId,
+    });
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("agent_settled does not duplicate a post-compaction timer continuation", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness({ contextWindow: 128_000 });
+    await harness.runCommand("ship it");
+    harness.sentMessages.length = 0;
+
+    await emitSilentContextOverflow(
+      harness,
+      0,
+      assistantMessage("stop", { input: 130_000, output: 0, cacheRead: 0 }),
+    );
+    await harness.emit(
+      "session_compact",
+      sessionCompactEvent({ reason: "overflow", willRetry: false }),
+    );
+
+    flushContinuationScheduler();
+    assert.equal(harness.sentMessages.length, 1);
+
+    await harness.emit("agent_settled", { type: "agent_settled" });
+    assert.equal(harness.sentMessages.length, 1);
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("agent_settled does not duplicate continuation from a completed host retry", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const harness = createRuntimeHarness();
+    await startQueuedContinuation(harness);
+
+    await harness.emit("session_compact", sessionCompactEvent({ willRetry: true }));
+    await harness.emit("agent_start", { type: "agent_start" });
+    await harness.emit("agent_end", {
+      type: "agent_end",
+      messages: [assistantMessage("stop", { input: 1, output: 1 })],
+    });
+
+    assert.equal(harness.sentMessages.length, 1);
+    await harness.emit("agent_settled", { type: "agent_settled" });
+    assert.equal(harness.sentMessages.length, 1);
   } finally {
     mock.timers.reset();
   }


### PR DESCRIPTION
## Summary

- retain a dormant post-compaction fallback when a host retry changes the turn or agent-run identity
- flush that narrowly scoped fallback from `agent_settled`, when Pi guarantees that no retry, compaction, or queued continuation remains runnable
- preserve normal per-run `agent_end` continuation behavior and suppress duplicate continuations
- add regression coverage for successful overflow compaction, empty host retries, timer-first continuation, and completed host retries

Closes #53.

## Why

This was observed with Pi 0.84.3 and pi-codex-goal 0.2.0. A successful automatic compaction left the goal active but idle for 780.659 seconds. No continuation was persisted until `/goal resume` was run manually.

The existing timer fallback intentionally stopped when a host retry changed lifecycle identity. That is correct while the retry is runnable, but it also discarded the only remaining recovery path when the retry later settled without queueing goal work.

The fix keeps that fallback dormant across the identity change. `agent_settled` is used only to resolve an already-pending post-compaction fallback; it does not replace the existing `agent_end` continuation path.

## Validation

- `npm run verify`
  - TypeScript typecheck passed
  - 6 platform-smoke checks passed
  - 337 tests passed
- focused compaction/continuation and recovery suites passed
- independent read-only review found no issues
- `git diff --check` passed
