### PR TITLE
Pre-compile typescript to javascript before publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- Precompile the Pi extension to NodeNext ESM during `npm pack` and `npm publish`, and load `dist/index.js` instead of transpiling the TypeScript module graph during every Pi startup.
+- Precompile the published npm extension to NodeNext ESM during `npm pack` and `npm publish`, so Pi loads `dist/index.js` instead of transpiling the TypeScript module graph at startup.
 - Exclude runtime TypeScript sources from the npm artifact while retaining declarations, source maps, prompts, documentation, and release-smoke tooling.
+- Keep Git and local directory installs build-free using Pi's native directory index selection, with exactly one source extension even when local build output exists.
 
 ## 0.2.0 - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.1 - 2026-09-05
 
 - Precompile the published npm extension to NodeNext ESM during `npm pack` and `npm publish`, so Pi loads `dist/index.js` instead of transpiling the TypeScript module graph at startup.
 - Exclude runtime TypeScript sources from the npm artifact while retaining declarations, source maps, prompts, documentation, and release-smoke tooling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Precompile the Pi extension to NodeNext ESM during `npm pack` and `npm publish`, and load `dist/index.js` instead of transpiling the TypeScript module graph during every Pi startup.
+- Exclude runtime TypeScript sources from the npm artifact while retaining declarations, source maps, prompts, documentation, and release-smoke tooling.
+
 ## 0.2.0 - 2026-08-06
 
 - Raise the minimum supported Pi version to 0.84.0 and pin the development/type-validation baseline to the exact 0.84.0 release.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ On this maintainer machine, the active install is a global/user package that alr
 
 Compatibility note: this package supports Pi 0.84.0 or later on Node 24. The latest published npm artifact remains the reproducible source of truth for its own published version's metadata. Pi-bundled runtime packages remain optional wildcard peers as required by Pi package loading; the support floor is declared here and validated by the source tree's exact Pi 0.84.0 development dependencies.
 
-Release note: npm installs and pinned GitHub tags are the reproducible release artifacts. Published packages load the precompiled `dist/index.js` extension; `npm pack` and `npm publish` rebuild it from TypeScript before creating the artifact. Installing from the repository default branch can include unreleased changes that will ship in a future package release, even when `package.json` still identifies the latest published version.
+Release note: npm installs and pinned GitHub tags are the reproducible release artifacts. Installing from the repository default branch can include unreleased changes that will ship in a future package release, even when `package.json` still identifies the latest published version.
+
+Published packages load the precompiled `dist/index.js` extension; `npm pack` and `npm publish` rebuild it from TypeScript before creating the artifact. Git and local directory installs load `src/index.ts` without a build or production TypeScript dependency. Pi selects the single index entry in `extensions/`: `index.ts` in a checkout (even after a build), or `index.js` in the npm artifact, which omits the source entry.
 
 ## Best way to create goals
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ On this maintainer machine, the active install is a global/user package that alr
 
 Compatibility note: this package supports Pi 0.84.0 or later on Node 24. The latest published npm artifact remains the reproducible source of truth for its own published version's metadata. Pi-bundled runtime packages remain optional wildcard peers as required by Pi package loading; the support floor is declared here and validated by the source tree's exact Pi 0.84.0 development dependencies.
 
-Release note: npm installs and pinned GitHub tags are the reproducible release artifacts. Installing from the repository default branch can include unreleased changes that will ship in a future package release, even when `package.json` still identifies the latest published version.
+Release note: npm installs and pinned GitHub tags are the reproducible release artifacts. Published packages load the precompiled `dist/index.js` extension; `npm pack` and `npm publish` rebuild it from TypeScript before creating the artifact. Installing from the repository default branch can include unreleased changes that will ship in a future package release, even when `package.json` still identifies the latest published version.
 
 ## Best way to create goals
 

--- a/extensions/index.js
+++ b/extensions/index.js
@@ -1,0 +1,1 @@
+export { default } from "../dist/index.js";

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "../src/index.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-codex-goal",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "0.84.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-codex-goal",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Codex-style goal tracking and continuation for pi.",
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",
   "license": "MIT",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "files": [
-    "src",
+    "dist",
     "docs",
     "scripts",
     "AGENTS.md",
@@ -36,13 +36,15 @@
   "homepage": "https://github.com/fitchmultz/pi-codex-goal#readme",
   "pi": {
     "extensions": [
-      "./src/index.ts"
+      "./dist/index.js"
     ],
     "prompts": [
       "./prompts"
     ]
   },
   "scripts": {
+    "build": "node --input-type=module --eval \"import { rmSync } from 'node:fs'; rmSync('dist', { recursive: true, force: true });\" && tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
     "test": "node --import tsx --test test/*.test.ts",
     "typecheck": "tsc --noEmit",
     "check:platform-smoke": "node scripts/platform-smoke/check.mjs",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/index.js",
   "files": [
     "dist",
+    "extensions/index.js",
     "docs",
     "scripts",
     "AGENTS.md",
@@ -36,7 +37,7 @@
   "homepage": "https://github.com/fitchmultz/pi-codex-goal#readme",
   "pi": {
     "extensions": [
-      "./dist/index.js"
+      "./extensions"
     ],
     "prompts": [
       "./prompts"

--- a/test/package-loading.test.ts
+++ b/test/package-loading.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test, type TestContext } from "node:test";
+
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+function tempRoot(t: TestContext): string {
+  const root = mkdtempSync(join(tmpdir(), "pi-goal-package-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function run(command: string, args: string[], cwd: string): string {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    shell: process.platform === "win32" && command === "npm",
+  });
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+  return result.stdout;
+}
+
+function copySource(root: string): string {
+  const packageRoot = join(root, "package");
+  mkdirSync(packageRoot);
+  // No build output or adjacent dependencies: these must come from Pi itself.
+  for (const path of ["package.json", "package-lock.json", "src", "extensions", "prompts"]) {
+    if (existsSync(path)) cpSync(path, join(packageRoot, path), { recursive: true });
+  }
+  return packageRoot;
+}
+
+async function checkPackage(root: string, packageRoot: string, extension: ".ts" | ".js"): Promise<void> {
+  const cwd = join(root, "project");
+  const agentDir = join(root, "agent");
+  mkdirSync(cwd);
+  const settingsManager = SettingsManager.inMemory();
+  const loader = new DefaultResourceLoader({
+    cwd,
+    agentDir,
+    settingsManager,
+    noContextFiles: true,
+    noExtensions: true,
+    noSkills: true,
+    noThemes: true,
+    additionalExtensionPaths: [packageRoot],
+  });
+  await loader.reload();
+  const loaded = loader.getExtensions();
+  assert.deepEqual(loaded.errors, []);
+  assert.equal(loaded.extensions.length, 1, "package must discover exactly one extension");
+  assert.ok(loaded.extensions[0]?.resolvedPath.endsWith(extension));
+  assert.deepEqual(loader.getPrompts().prompts.map((prompt) => prompt.name), ["create-goal"]);
+  assert.ok(loaded.extensions[0]?.commands.has("goal"));
+
+  const modelRuntime = await ModelRuntime.create({
+    allowModelNetwork: false,
+    credentials: new InMemoryCredentialStore(),
+    modelsPath: null,
+    modelsStorePath: join(agentDir, "models-store.json"),
+  });
+  const { session } = await createAgentSession({
+    cwd,
+    agentDir,
+    modelRuntime,
+    noTools: "builtin",
+    resourceLoader: loader,
+    sessionManager: SessionManager.inMemory(cwd),
+    settingsManager,
+  });
+  const runner = session.extensionRunner;
+  try {
+    assert.deepEqual(session.getActiveToolNames().sort(), ["create_goal", "get_goal", "update_goal"]);
+    const call = async (name: string, params: Record<string, unknown>) => {
+      const tool = runner.getToolDefinition(name);
+      assert.ok(tool);
+      return tool.execute(name, params, undefined, undefined, runner.createContext());
+    };
+    const created = await call("create_goal", { objective: "Verify the installed package" });
+    assert.partialDeepStrictEqual(created.details, { goal: { objective: "Verify the installed package" } });
+    assert.partialDeepStrictEqual((await call("get_goal", {})).details, { goal: { status: "active" } });
+    assert.partialDeepStrictEqual((await call("update_goal", { status: "complete" })).details, { goal: { status: "complete" } });
+    assert.partialDeepStrictEqual((await call("get_goal", {})).details, { goal: { status: "complete" } });
+  } finally {
+    await runner.emit({ type: "session_shutdown", reason: "quit" });
+    session.dispose();
+  }
+}
+
+test("clean local source discovers and executes one goal extension without a build", async (t) => {
+  const root = tempRoot(t);
+  await checkPackage(root, copySource(root), ".ts");
+});
+
+test("Pi Git production install discovers and executes one goal extension without tsc", async (t) => {
+  const root = tempRoot(t);
+  const packageRoot = copySource(root);
+  // Pi clones first, then runs npm install --omit=dev (not npm install <git-url>).
+  run("npm", ["install", "--omit=dev", "--offline", "--no-audit", "--no-fund", "--cache", join(root, "npm-cache")], packageRoot);
+  assert.equal(existsSync(join(packageRoot, "node_modules", "typescript")), false);
+  assert.equal(existsSync(join(packageRoot, "dist")), false);
+  await checkPackage(root, packageRoot, ".ts");
+});
+
+test("local source stays authoritative when build output is present", async (t) => {
+  const root = tempRoot(t);
+  const packageRoot = copySource(root);
+  mkdirSync(join(packageRoot, "dist"));
+  writeFileSync(join(packageRoot, "dist", "index.js"), 'throw new Error("stale build must not load");\n');
+  await checkPackage(root, packageRoot, ".ts");
+});
+
+test("npm artifact discovers and executes one compiled goal extension without source or local peers", async (t) => {
+  const root = tempRoot(t);
+  const packs = JSON.parse(run("npm", ["pack", "--json", "--pack-destination", root], process.cwd())) as Array<{ filename: string }>;
+  assert.ok(packs[0]);
+  run("tar", ["-xzf", join(root, packs[0].filename), "-C", root], process.cwd());
+  const packageRoot = join(root, "package");
+  assert.equal(existsSync(join(packageRoot, "src")), false);
+  assert.equal(existsSync(join(packageRoot, "node_modules")), false);
+  await checkPackage(root, packageRoot, ".js");
+});

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -22,7 +22,7 @@ function frontmatter(prompt: string): Record<string, string> {
   );
 }
 
-test("package exposes compiled runtime and create-goal prompt entrypoints", () => {
+test("package exposes source and compiled runtime plus create-goal prompt entrypoints", () => {
   const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
     main?: string;
     files?: string[];
@@ -31,8 +31,9 @@ test("package exposes compiled runtime and create-goal prompt entrypoints", () =
   };
 
   assert.equal(packageJson.main, "dist/index.js");
-  assert.deepEqual(packageJson.pi?.extensions, ["./dist/index.js"]);
+  assert.deepEqual(packageJson.pi?.extensions, ["./extensions"]);
   assert.ok(packageJson.files?.includes("dist"));
+  assert.ok(packageJson.files?.includes("extensions/index.js"));
   assert.equal(packageJson.files?.includes("src"), false);
   assert.equal(packageJson.scripts?.prepack, "npm run build");
   assert.ok(packageJson.files?.includes("prompts"));

--- a/test/package-manifest.test.ts
+++ b/test/package-manifest.test.ts
@@ -22,12 +22,19 @@ function frontmatter(prompt: string): Record<string, string> {
   );
 }
 
-test("package exposes the create-goal prompt template", () => {
+test("package exposes compiled runtime and create-goal prompt entrypoints", () => {
   const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+    main?: string;
     files?: string[];
-    pi?: { prompts?: string[] };
+    pi?: { extensions?: string[]; prompts?: string[] };
+    scripts?: { prepack?: string };
   };
 
+  assert.equal(packageJson.main, "dist/index.js");
+  assert.deepEqual(packageJson.pi?.extensions, ["./dist/index.js"]);
+  assert.ok(packageJson.files?.includes("dist"));
+  assert.equal(packageJson.files?.includes("src"), false);
+  assert.equal(packageJson.scripts?.prepack, "npm run build");
   assert.ok(packageJson.files?.includes("prompts"));
   assert.ok(packageJson.pi?.prompts?.includes("./prompts"));
 });

--- a/test/platform-smoke.check.ts
+++ b/test/platform-smoke.check.ts
@@ -296,6 +296,8 @@ test("npm pack includes platform smoke docs and scripts", () => {
   const packs = JSON.parse(result.stdout) as Array<{ files: Array<{ path: string }> }>;
   const paths = new Set(packs[0]?.files.map((file) => file.path) ?? []);
   for (const path of [
+    "dist/index.js",
+    "dist/index.d.ts",
     "docs/platform-smoke.md",
     ".crabboxignore",
     "platform-smoke.config.mjs",
@@ -303,7 +305,7 @@ test("npm pack includes platform smoke docs and scripts", () => {
   ]) {
     assert.ok(paths.has(path), `expected npm pack to include ${path}`);
   }
-  for (const forbidden of [".artifacts/", ".crabbox/", ".debug/", ".env", ".env."]) {
+  for (const forbidden of [".artifacts/", ".crabbox/", ".debug/", ".env", ".env.", "src/"]) {
     assert.equal([...paths].some((path) => path === forbidden || path.startsWith(forbidden)), false);
   }
   assert.equal([...paths].some((path) => path.endsWith(".tgz")), false);

--- a/test/platform-smoke.check.ts
+++ b/test/platform-smoke.check.ts
@@ -297,6 +297,7 @@ test("npm pack includes platform smoke docs and scripts", () => {
   const paths = new Set(packs[0]?.files.map((file) => file.path) ?? []);
   for (const path of [
     "dist/index.js",
+    "extensions/index.js",
     "dist/index.d.ts",
     "docs/platform-smoke.md",
     ".crabboxignore",
@@ -305,7 +306,7 @@ test("npm pack includes platform smoke docs and scripts", () => {
   ]) {
     assert.ok(paths.has(path), `expected npm pack to include ${path}`);
   }
-  for (const forbidden of [".artifacts/", ".crabbox/", ".debug/", ".env", ".env.", "src/"]) {
+  for (const forbidden of [".artifacts/", ".crabbox/", ".debug/", ".env", ".env.", "src/", "extensions/index.ts"]) {
     assert.equal([...paths].some((path) => path === forbidden || path.startsWith(forbidden)), false);
   }
   assert.equal([...paths].some((path) => path.endsWith(".tgz")), false);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "noEmit": false
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "test"
+  ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,13 +6,9 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "inlineSources": true,
-    "noEmit": false
+    "inlineSources": true
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "exclude": [
-    "test"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     ]
   },
   "include": [
+    "extensions/**/*.ts",
     "src/**/*.ts",
     "test/**/*.ts"
   ]


### PR DESCRIPTION
I noticed this extension taking up a bunch of time in my `pi` startup. It turns out Pi was compiling the typescript on every startup. Do that once at publish rather than on each invocation. I saw this decrease the extension startup from ~3.5 seconds to ~2 seconds.

I tried also bundling the generated JS with esbuild, but it only saved about 50ms, so I didn't think the complexity was worth it.

Note that the code and commit messages are LLM-generated, as well as the rest of this PR description.

---

Pi previously loaded the TypeScript source graph from npm, forcing startup transpilation on every process. Build clean NodeNext ESM artifacts during prepack and point package discovery at dist/index.js while keeping host runtime packages as optional peers.

Manifest and tarball checks prevent releases from reverting to a TypeScript runtime entrypoint or shipping src. Verified with the 333-test suite and an isolated packed-package Pi RPC load.